### PR TITLE
fix: resolve merge syntax errors breaking main build

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/CreateProductEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/CreateProductEndpoint.cs
@@ -91,14 +91,16 @@ public sealed class CreateProductEndpoint(IProductService productService)
 
     public override async Task HandleAsync(CreateProductApiRequest req, CancellationToken ct)
     {
-        var appRequest = new CreateProductRequest(
-            req.BasePrice,
-            req.ImageUrl,
-            req.Translations
-                .Select(t => new TranslationRequest(t.LanguageCode, t.Name, t.Description))
-                .ToList().AsReadOnly(),
-            req.Allergens?.AsReadOnly(),
-            req.DietaryTags?.AsReadOnly());
+        try
+        {
+            var appRequest = new CreateProductRequest(
+                req.BasePrice,
+                req.ImageUrl,
+                req.Translations
+                    .Select(t => new TranslationRequest(t.LanguageCode, t.Name, t.Description))
+                    .ToList().AsReadOnly(),
+                req.Allergens?.AsReadOnly(),
+                req.DietaryTags?.AsReadOnly());
 
             var response = await productService.CreateProductAsync(appRequest, ct);
 

--- a/src/backend/TheMillionthFoodOrderApp.Application/MenuCategories/MenuCategoryService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/MenuCategories/MenuCategoryService.cs
@@ -229,13 +229,12 @@ public sealed class MenuCategoryService(
     private static ProductListItemResponse MapProductToListItem(Product product, string primaryLanguage) =>
         new(
             product.Id,
+            product.ProductType.ToString(),
             TranslationResolver.ResolveName(
                 product.Translations,
                 t => t.LanguageCode,
                 t => t.Name,
                 primaryLanguage),
-            product.ProductType.ToString(),
-            product.Translations.FirstOrDefault()?.Name ?? "(unnamed)",
             new MoneyResponse(product.BasePrice.Amount, product.BasePrice.Currency),
             product.ImageUrl,
             product.MenuCategoryId,

--- a/src/backend/TheMillionthFoodOrderApp.Application/Products/ProductService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Products/ProductService.cs
@@ -224,13 +224,12 @@ public sealed class ProductService(
     private static ProductListItemResponse MapToListItem(Product product, string primaryLanguage) =>
         new(
             product.Id,
+            product.ProductType.ToString(),
             TranslationResolver.ResolveName(
                 product.Translations,
                 t => t.LanguageCode,
                 t => t.Name,
                 primaryLanguage),
-            product.ProductType.ToString(),
-            product.Translations.FirstOrDefault()?.Name ?? "(unnamed)",
             new MoneyResponse(product.BasePrice.Amount, product.BasePrice.Currency),
             product.ImageUrl,
             product.MenuCategoryId,

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Products/Product.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Products/Product.cs
@@ -198,6 +198,8 @@ public sealed class Product : AggregateRoot<Guid>, IAuditable, ISoftDeletable
             if (!Enum.IsDefined(tag))
                 throw new ArgumentException($"Invalid dietary tag value: {(int)tag}.", nameof(dietaryTags));
         }
+    }
+
     /// <summary>
     /// Factory method — creates a combo product bundling two or more existing simple products.
     /// </summary>

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/BrandDbContextModelSnapshot.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/BrandDbContextModelSnapshot.cs
@@ -251,7 +251,6 @@ namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
                 });
 
             modelBuilder.Entity("TheMillionthFoodOrderApp.Domain.OrderLifecycle.OrderLifecycleConfig", b =>
-            modelBuilder.Entity("TheMillionthFoodOrderApp.Domain.Products.ComboItem", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -300,10 +299,6 @@ namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
                         .HasColumnType("nvarchar(100)");
 
                     b.Property<Guid>("OrderLifecycleConfigId")
-                    b.Property<Guid>("ComboProductId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("ComponentProductId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<int>("SortOrder")
@@ -320,6 +315,30 @@ namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
                         .HasDatabaseName("IX_OrderStatuses_ConfigId_SortOrder");
 
                     b.ToTable("OrderStatuses", (string)null);
+                });
+
+            modelBuilder.Entity("TheMillionthFoodOrderApp.Domain.Products.ComboItem", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("ComboProductId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("ComponentProductId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<int>("SortOrder")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ComboProductId");
+
+                    b.HasIndex("ComponentProductId");
+
+                    b.ToTable("ComboItems", (string)null);
                 });
 
             modelBuilder.Entity("TheMillionthFoodOrderApp.Domain.OrderLifecycle.OrderStatusTransition", b =>
@@ -658,6 +677,10 @@ namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
                     b.HasOne("TheMillionthFoodOrderApp.Domain.OrderLifecycle.OrderStatus", null)
                         .WithMany()
                         .HasForeignKey("ToStatusId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("TheMillionthFoodOrderApp.Domain.Products.ComboItem", b =>
                 {
                     b.HasOne("TheMillionthFoodOrderApp.Domain.Products.Product", null)


### PR DESCRIPTION
## Summary
Main is broken with compilation errors from four merge collision artifacts across PRs #91, #92, #93, #94:

1. **`Product.cs`** — Missing closing `}` on `ValidateDietaryTags` method; body ran into `CreateCombo`
2. **`CreateProductEndpoint.cs`** — `try {` removed but `catch (InvalidOperationException)` left behind with wrong indentation
3. **`ProductService.cs` + `MenuCategoryService.cs`** — Duplicate name field in `MapToListItem` (both `TranslationResolver.ResolveName` and `FirstOrDefault()?.Name` kept), plus parameter order mismatch with DTO
4. **`BrandDbContextModelSnapshot.cs`** — Three entity declarations merged onto same lines (OrderLifecycleConfig/ComboItem collisions)

## Test Plan
- [x] Backend builds with 0 errors
- [x] 74 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)