### PR TITLE
feat: real-time order updates via SignalR (US-FP-068)

### DIFF
--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -95,7 +95,7 @@ Once brands + shops exist, these streams are **independent of each other**.
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
 | ⬜ | **US-FP-046** | Apply Belgian VAT rates | 022 |
-| ⬜ | **US-FP-068** | Real-time updates (SignalR/SSE) | — (infra, can start in L1) |
+| ✅ | **US-FP-068** | Real-time updates (SignalR/SSE) | — (infra, can start in L1) |
 | ⬜ | **US-FP-016** | Place an online order | 005, 006, 007, 014, 022, 046 |
 | ⬜ | **US-FP-058** | Complete payment flow (mocked) | 016 |
 | ⬜ | **US-FP-017** | Place an order as a guest | 016 |

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
@@ -1,4 +1,6 @@
 using FastEndpoints;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using TheMillionthFoodOrderApp.Domain.Orders;
 using Wolverine;
 
@@ -19,7 +21,7 @@ public sealed record SimulateOrderStatusChangeResponse(Guid OrderId, string Mess
 /// via Wolverine so the SignalR infrastructure can be tested end-to-end
 /// before the Order aggregate is implemented (US-FP-016).
 /// </summary>
-public sealed class SimulateOrderStatusChangeEndpoint(IMessageBus messageBus)
+public sealed class SimulateOrderStatusChangeEndpoint(IMessageBus messageBus, IWebHostEnvironment env)
     : Endpoint<SimulateOrderStatusChangeRequest, SimulateOrderStatusChangeResponse>
 {
     public override void Configure()
@@ -37,6 +39,12 @@ public sealed class SimulateOrderStatusChangeEndpoint(IMessageBus messageBus)
 
     public override async Task HandleAsync(SimulateOrderStatusChangeRequest req, CancellationToken ct)
     {
+        if (!env.IsDevelopment())
+        {
+            await HttpContext.Response.SendNotFoundAsync(ct);
+            return;
+        }
+
         var orderId = req.OrderId ?? Guid.CreateVersion7();
 
         var @event = new OrderStatusChangedEvent(

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
@@ -1,0 +1,57 @@
+using FastEndpoints;
+using TheMillionthFoodOrderApp.Domain.Orders;
+using Wolverine;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record SimulateOrderStatusChangeRequest(
+    [property: RouteParam] string BrandSlug,
+    Guid ShopId,
+    Guid? OrderId,
+    string PreviousStatus,
+    string NewStatus,
+    string? CustomerName);
+
+public sealed record SimulateOrderStatusChangeResponse(Guid OrderId, string Message);
+
+/// <summary>
+/// Development-only endpoint that publishes a simulated OrderStatusChangedEvent
+/// via Wolverine so the SignalR infrastructure can be tested end-to-end
+/// before the Order aggregate is implemented (US-FP-016).
+/// </summary>
+public sealed class SimulateOrderStatusChangeEndpoint(IMessageBus messageBus)
+    : Endpoint<SimulateOrderStatusChangeRequest, SimulateOrderStatusChangeResponse>
+{
+    public override void Configure()
+    {
+        Post("/api/brands/{brandSlug}/orders/simulate-status-change");
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<SimulateOrderStatusChangeRequest>>();
+        Tags("development");
+        Summary(s =>
+        {
+            s.Summary = "Simulate an order status change (dev only)";
+            s.Description = "Publishes a simulated OrderStatusChangedEvent to test the SignalR real-time notification pipeline.";
+        });
+    }
+
+    public override async Task HandleAsync(SimulateOrderStatusChangeRequest req, CancellationToken ct)
+    {
+        var orderId = req.OrderId ?? Guid.CreateVersion7();
+
+        var @event = new OrderStatusChangedEvent(
+            orderId,
+            req.ShopId,
+            req.BrandSlug,
+            req.PreviousStatus,
+            req.NewStatus,
+            req.CustomerName);
+
+        await messageBus.PublishAsync(@event);
+
+        await HttpContext.Response.SendAsync(
+            new SimulateOrderStatusChangeResponse(orderId, "Event published"),
+            statusCode: 200,
+            cancellation: ct);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
@@ -20,6 +20,10 @@ public sealed record SimulateOrderStatusChangeResponse(Guid OrderId, string Mess
 /// Development-only endpoint that publishes a simulated OrderStatusChangedEvent
 /// via Wolverine so the SignalR infrastructure can be tested end-to-end
 /// before the Order aggregate is implemented (US-FP-016).
+///
+/// Note: this endpoint remains in the production route table but returns 404
+/// outside Development. FastEndpoints does not support conditional registration,
+/// so the runtime guard is the simplest approach.
 /// </summary>
 public sealed class SimulateOrderStatusChangeEndpoint(IMessageBus messageBus, IWebHostEnvironment env)
     : Endpoint<SimulateOrderStatusChangeRequest, SimulateOrderStatusChangeResponse>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Program.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Program.cs
@@ -80,6 +80,7 @@ builder.Host.UseWolverine(opts =>
 builder.Services.AddHealthChecks()
     .AddCheck<BrandDatabaseHealthCheck>("brand-databases");
 
+builder.Services.AddSignalR();
 builder.Services.AddFastEndpoints();
 builder.Services.SwaggerDocument(o =>
 {
@@ -137,6 +138,9 @@ app.UseMiddleware<BrandContextMiddleware>();
 
 app.UseFastEndpoints();
 app.UseSwaggerGen();
+
+// SignalR hub for real-time order updates (US-FP-068)
+app.MapHub<TheMillionthFoodOrderApp.Infrastructure.Notifications.OrderHub>("/api/hubs/orders");
 
 app.Run();
 

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderNotificationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderNotificationService.cs
@@ -17,5 +17,20 @@ public interface IOrderNotificationService
         string previousStatus,
         string newStatus,
         string? customerName,
+        DateTimeOffset occurredOn,
         CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Canonical payload shape for order status change notifications sent via SignalR.
+/// Shared between the notification service, integration tests, and used as
+/// the contract for the TypeScript frontend type.
+/// </summary>
+public sealed record OrderStatusUpdatePayload(
+    Guid OrderId,
+    Guid ShopId,
+    string BrandSlug,
+    string PreviousStatus,
+    string NewStatus,
+    string? CustomerName,
+    DateTimeOffset Timestamp);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderNotificationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderNotificationService.cs
@@ -1,0 +1,21 @@
+namespace TheMillionthFoodOrderApp.Application.Orders;
+
+/// <summary>
+/// Abstraction for sending real-time order notifications to connected clients.
+/// Implementations live in the Infrastructure layer (SignalR).
+/// </summary>
+public interface IOrderNotificationService
+{
+    /// <summary>
+    /// Notifies all clients monitoring the specified shop and the specific order
+    /// that an order's status has changed.
+    /// </summary>
+    Task NotifyOrderStatusChangedAsync(
+        Guid orderId,
+        Guid shopId,
+        string brandSlug,
+        string previousStatus,
+        string newStatus,
+        string? customerName,
+        CancellationToken cancellationToken = default);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderStatusChangedEvent.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderStatusChangedEvent.cs
@@ -1,0 +1,19 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+
+namespace TheMillionthFoodOrderApp.Domain.Orders;
+
+/// <summary>
+/// Raised when an order transitions to a new status.
+/// Consumed by the SignalR notification handler to push real-time updates
+/// to kitchen displays, customer tracking pages, and POS interfaces.
+/// </summary>
+public sealed record OrderStatusChangedEvent(
+    Guid OrderId,
+    Guid ShopId,
+    string BrandSlug,
+    string PreviousStatus,
+    string NewStatus,
+    string? CustomerName) : IDomainEvent
+{
+    public DateTimeOffset OccurredOn { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using TheMillionthFoodOrderApp.Application.BrandSettings;
 using TheMillionthFoodOrderApp.Application.Multitenancy;
+using TheMillionthFoodOrderApp.Application.Orders;
 using TheMillionthFoodOrderApp.Domain.Brands;
 using TheMillionthFoodOrderApp.Domain.BrandSettings;
 using TheMillionthFoodOrderApp.Domain.Identity;
@@ -9,7 +10,6 @@ using TheMillionthFoodOrderApp.Domain.ModifierGroups;
 using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
 using TheMillionthFoodOrderApp.Domain.Products;
 using TheMillionthFoodOrderApp.Domain.Shops;
-using TheMillionthFoodOrderApp.Application.Orders;
 using TheMillionthFoodOrderApp.Infrastructure.Brands;
 using TheMillionthFoodOrderApp.Infrastructure.BrandSettings;
 using TheMillionthFoodOrderApp.Infrastructure.FileStorage;

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
@@ -9,12 +9,14 @@ using TheMillionthFoodOrderApp.Domain.ModifierGroups;
 using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
 using TheMillionthFoodOrderApp.Domain.Products;
 using TheMillionthFoodOrderApp.Domain.Shops;
+using TheMillionthFoodOrderApp.Application.Orders;
 using TheMillionthFoodOrderApp.Infrastructure.Brands;
 using TheMillionthFoodOrderApp.Infrastructure.BrandSettings;
 using TheMillionthFoodOrderApp.Infrastructure.FileStorage;
 using TheMillionthFoodOrderApp.Infrastructure.Identity;
 using TheMillionthFoodOrderApp.Infrastructure.MenuCategories;
 using TheMillionthFoodOrderApp.Infrastructure.ModifierGroups;
+using TheMillionthFoodOrderApp.Infrastructure.Notifications;
 using TheMillionthFoodOrderApp.Infrastructure.OrderLifecycle;
 using TheMillionthFoodOrderApp.Infrastructure.Multitenancy;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
@@ -72,6 +74,9 @@ public static class DependencyInjection
         // uploads path. In production, replace this registration with an Azure Blob Storage
         // implementation without changing Application or API layers.
         services.AddScoped<IFileStorageService, LocalFileStorageService>();
+
+        // Real-time notifications — SignalR implementation
+        services.AddScoped<IOrderNotificationService, SignalROrderNotificationService>();
 
         return services;
     }

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
@@ -75,8 +75,9 @@ public static class DependencyInjection
         // implementation without changing Application or API layers.
         services.AddScoped<IFileStorageService, LocalFileStorageService>();
 
-        // Real-time notifications — SignalR implementation
-        services.AddScoped<IOrderNotificationService, SignalROrderNotificationService>();
+        // Real-time notifications — SignalR implementation.
+        // Singleton: depends only on IHubContext<OrderHub> (singleton) and ILogger (singleton).
+        services.AddSingleton<IOrderNotificationService, SignalROrderNotificationService>();
 
         return services;
     }

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderHub.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderHub.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Notifications;
+
+/// <summary>
+/// SignalR hub for real-time order updates.
+/// Clients join groups based on what they are monitoring:
+///   - shop:{brandSlug}:{shopId} -- kitchen display, POS, floor staff
+///   - order:{orderId} -- customer order tracking page
+///
+/// The hub does not push messages directly -- the server-side
+/// <see cref="SignalROrderNotificationService"/> uses IHubContext to send messages to groups.
+/// </summary>
+[AllowAnonymous]
+public sealed class OrderHub : Hub
+{
+    /// <summary>
+    /// Join the group for a specific shop. Called by kitchen display and POS clients.
+    /// </summary>
+    public async Task JoinShopGroup(string brandSlug, string shopId)
+    {
+        var groupName = $"shop:{brandSlug}:{shopId}";
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+    }
+
+    /// <summary>
+    /// Leave a shop group.
+    /// </summary>
+    public async Task LeaveShopGroup(string brandSlug, string shopId)
+    {
+        var groupName = $"shop:{brandSlug}:{shopId}";
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+    }
+
+    /// <summary>
+    /// Join the group for a specific order. Called by customer tracking pages.
+    /// </summary>
+    public async Task JoinOrderGroup(string orderId)
+    {
+        var groupName = $"order:{orderId}";
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+    }
+
+    /// <summary>
+    /// Leave an order group.
+    /// </summary>
+    public async Task LeaveOrderGroup(string orderId)
+    {
+        var groupName = $"order:{orderId}";
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderHub.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderHub.cs
@@ -17,6 +17,8 @@ public sealed class OrderHub : Hub
 {
     /// <summary>
     /// Join the group for a specific shop. Called by kitchen display and POS clients.
+    /// TODO: Add role-based authorization (e.g. require staff role for the brand) once
+    /// auth is wired to the hub (US-FP-039). Currently [AllowAnonymous] for dev.
     /// </summary>
     public async Task JoinShopGroup(string brandSlug, string shopId)
     {
@@ -35,6 +37,8 @@ public sealed class OrderHub : Hub
 
     /// <summary>
     /// Join the group for a specific order. Called by customer tracking pages.
+    /// TODO: Validate the caller owns or has access to the order once the Order
+    /// aggregate exists (US-FP-016).
     /// </summary>
     public async Task JoinOrderGroup(string orderId)
     {

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderStatusChangedHandler.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderStatusChangedHandler.cs
@@ -1,0 +1,26 @@
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Notifications;
+
+/// <summary>
+/// Wolverine message handler that bridges domain events to SignalR.
+/// When <see cref="OrderStatusChangedEvent"/> is published, this handler
+/// forwards the notification to connected clients via <see cref="IOrderNotificationService"/>.
+///
+/// Wolverine discovers this handler by convention: HandleAsync(OrderStatusChangedEvent).
+/// </summary>
+public sealed class OrderStatusChangedHandler(IOrderNotificationService notificationService)
+{
+    public async Task HandleAsync(OrderStatusChangedEvent @event, CancellationToken cancellationToken)
+    {
+        await notificationService.NotifyOrderStatusChangedAsync(
+            @event.OrderId,
+            @event.ShopId,
+            @event.BrandSlug,
+            @event.PreviousStatus,
+            @event.NewStatus,
+            @event.CustomerName,
+            cancellationToken);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderStatusChangedHandler.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderStatusChangedHandler.cs
@@ -21,6 +21,7 @@ public sealed class OrderStatusChangedHandler(IOrderNotificationService notifica
             @event.PreviousStatus,
             @event.NewStatus,
             @event.CustomerName,
+            @event.OccurredOn,
             cancellationToken);
     }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/SignalROrderNotificationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/SignalROrderNotificationService.cs
@@ -19,18 +19,17 @@ public sealed class SignalROrderNotificationService(
         string previousStatus,
         string newStatus,
         string? customerName,
+        DateTimeOffset occurredOn,
         CancellationToken cancellationToken = default)
     {
-        var payload = new
-        {
-            OrderId = orderId,
-            ShopId = shopId,
-            BrandSlug = brandSlug,
-            PreviousStatus = previousStatus,
-            NewStatus = newStatus,
-            CustomerName = customerName,
-            Timestamp = DateTimeOffset.UtcNow,
-        };
+        var payload = new OrderStatusUpdatePayload(
+            orderId,
+            shopId,
+            brandSlug,
+            previousStatus,
+            newStatus,
+            customerName,
+            occurredOn);
 
         // Send to shop group (kitchen display, POS, floor staff)
         var shopGroup = $"shop:{brandSlug}:{shopId}";

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/SignalROrderNotificationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/SignalROrderNotificationService.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using TheMillionthFoodOrderApp.Application.Orders;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Notifications;
+
+/// <summary>
+/// Sends real-time order notifications via SignalR to connected clients.
+/// Uses IHubContext (not the Hub directly) to send from outside the hub pipeline.
+/// </summary>
+public sealed class SignalROrderNotificationService(
+    IHubContext<OrderHub> hubContext,
+    ILogger<SignalROrderNotificationService> logger) : IOrderNotificationService
+{
+    public async Task NotifyOrderStatusChangedAsync(
+        Guid orderId,
+        Guid shopId,
+        string brandSlug,
+        string previousStatus,
+        string newStatus,
+        string? customerName,
+        CancellationToken cancellationToken = default)
+    {
+        var payload = new
+        {
+            OrderId = orderId,
+            ShopId = shopId,
+            BrandSlug = brandSlug,
+            PreviousStatus = previousStatus,
+            NewStatus = newStatus,
+            CustomerName = customerName,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+
+        // Send to shop group (kitchen display, POS, floor staff)
+        var shopGroup = $"shop:{brandSlug}:{shopId}";
+        await hubContext.Clients.Group(shopGroup)
+            .SendAsync("OrderStatusChanged", payload, cancellationToken);
+
+        // Send to order-specific group (customer tracking)
+        var orderGroup = $"order:{orderId}";
+        await hubContext.Clients.Group(orderGroup)
+            .SendAsync("OrderStatusChanged", payload, cancellationToken);
+
+        logger.LogInformation(
+            "Sent OrderStatusChanged notification for order {OrderId} " +
+            "(shop: {ShopGroup}, status: {PreviousStatus} -> {NewStatus})",
+            orderId, shopGroup, previousStatus, newStatus);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/TheMillionthFoodOrderApp.Infrastructure.csproj
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/TheMillionthFoodOrderApp.Infrastructure.csproj
@@ -22,4 +22,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 </Project>

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/SignalR/OrderHubConnectionTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/SignalR/OrderHubConnectionTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.SignalR.Client;
 using Shouldly;
+using TheMillionthFoodOrderApp.Application.Orders;
 using TheMillionthFoodOrderApp.Application.Shops;
 using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
 
@@ -62,10 +63,10 @@ public sealed class OrderHubConnectionTests(IntegrationTestBase fixture)
                 options => options.HttpMessageHandlerFactory = _ => fixture.Factory.Server.CreateHandler())
             .Build();
 
-        OrderStatusUpdateDto? receivedUpdate = null;
+        OrderStatusUpdatePayload? receivedUpdate = null;
         var receivedSignal = new TaskCompletionSource<bool>();
 
-        hubConnection.On<OrderStatusUpdateDto>("OrderStatusChanged", update =>
+        hubConnection.On<OrderStatusUpdatePayload>("OrderStatusChanged", update =>
         {
             receivedUpdate = update;
             receivedSignal.TrySetResult(true);
@@ -117,8 +118,8 @@ public sealed class OrderHubConnectionTests(IntegrationTestBase fixture)
                 options => options.HttpMessageHandlerFactory = _ => fixture.Factory.Server.CreateHandler())
             .Build();
 
-        var receivedAny = false;
-        hubConnection.On<OrderStatusUpdateDto>("OrderStatusChanged", _ => receivedAny = true);
+        var unexpectedSignal = new TaskCompletionSource<bool>();
+        hubConnection.On<OrderStatusUpdatePayload>("OrderStatusChanged", _ => unexpectedSignal.TrySetResult(true));
 
         await hubConnection.StartAsync();
 
@@ -136,9 +137,9 @@ public sealed class OrderHubConnectionTests(IntegrationTestBase fixture)
 
         await httpClient.PostAsJsonAsync(SimulateUrl(IntegrationTestBase.AlphaSlug), simulateRequest);
 
-        // Wait briefly and assert no event was received
-        await Task.Delay(1000);
-        receivedAny.ShouldBeFalse("Client in a different shop group should not receive the event");
+        // Assert — signal should NOT arrive within 500ms
+        var completed = await Task.WhenAny(unexpectedSignal.Task, Task.Delay(500));
+        completed.ShouldNotBe(unexpectedSignal.Task, "Client in a different shop group should not receive the event");
 
         await hubConnection.DisposeAsync();
     }
@@ -157,10 +158,10 @@ public sealed class OrderHubConnectionTests(IntegrationTestBase fixture)
                 options => options.HttpMessageHandlerFactory = _ => fixture.Factory.Server.CreateHandler())
             .Build();
 
-        OrderStatusUpdateDto? receivedUpdate = null;
+        OrderStatusUpdatePayload? receivedUpdate = null;
         var receivedSignal = new TaskCompletionSource<bool>();
 
-        hubConnection.On<OrderStatusUpdateDto>("OrderStatusChanged", update =>
+        hubConnection.On<OrderStatusUpdatePayload>("OrderStatusChanged", update =>
         {
             receivedUpdate = update;
             receivedSignal.TrySetResult(true);
@@ -191,14 +192,4 @@ public sealed class OrderHubConnectionTests(IntegrationTestBase fixture)
 
         await hubConnection.DisposeAsync();
     }
-
-    /// <summary>DTO matching the anonymous payload shape sent by SignalROrderNotificationService.</summary>
-    private sealed record OrderStatusUpdateDto(
-        Guid OrderId,
-        Guid ShopId,
-        string BrandSlug,
-        string PreviousStatus,
-        string NewStatus,
-        string? CustomerName,
-        DateTimeOffset Timestamp);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/SignalR/OrderHubConnectionTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/SignalR/OrderHubConnectionTests.cs
@@ -1,0 +1,204 @@
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.SignalR.Client;
+using Shouldly;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.SignalR;
+
+/// <summary>
+/// Integration tests for the OrderHub SignalR hub.
+/// Verifies that clients can connect, join groups, and receive real-time order status updates.
+/// </summary>
+public sealed class OrderHubConnectionTests(IntegrationTestBase fixture)
+    : IClassFixture<IntegrationTestBase>
+{
+    private HttpClient CreateHttpClient() => fixture.Factory.CreateClient();
+
+    private static string ShopsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/shops";
+
+    private static string SimulateUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/orders/simulate-status-change";
+
+    private static async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    {
+        var uniqueSlug = $"shop-{Guid.NewGuid():N}";
+        var request = new
+        {
+            Name = "SignalR Test Shop",
+            Slug = uniqueSlug,
+            Address = new
+            {
+                Street = "Teststraat",
+                Number = "1",
+                City = "Brussel",
+                PostalCode = "1000",
+                Country = "BE"
+            },
+            ContactEmail = "shop@test.com",
+            ContactPhone = (string?)null
+        };
+
+        var response = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
+        response.EnsureSuccessStatusCode();
+
+        var shop = await response.Content.ReadFromJsonAsync<ShopResponse>();
+        shop.ShouldNotBeNull();
+        return shop.Id;
+    }
+
+    [Fact]
+    public async Task Client_CanConnect_JoinShopGroup_AndReceiveOrderStatusChanged()
+    {
+        // Arrange
+        var httpClient = CreateHttpClient();
+        var shopId = await CreateShopAsync(httpClient, IntegrationTestBase.AlphaSlug);
+
+        // Create SignalR connection via the test server
+        var hubConnection = new HubConnectionBuilder()
+            .WithUrl(
+                $"{httpClient.BaseAddress}api/hubs/orders",
+                options => options.HttpMessageHandlerFactory = _ => fixture.Factory.Server.CreateHandler())
+            .Build();
+
+        OrderStatusUpdateDto? receivedUpdate = null;
+        var receivedSignal = new TaskCompletionSource<bool>();
+
+        hubConnection.On<OrderStatusUpdateDto>("OrderStatusChanged", update =>
+        {
+            receivedUpdate = update;
+            receivedSignal.TrySetResult(true);
+        });
+
+        // Act — connect and join shop group
+        await hubConnection.StartAsync();
+        hubConnection.State.ShouldBe(HubConnectionState.Connected);
+
+        await hubConnection.InvokeAsync("JoinShopGroup", IntegrationTestBase.AlphaSlug, shopId.ToString());
+
+        // Simulate an order status change
+        var simulateRequest = new
+        {
+            ShopId = shopId,
+            PreviousStatus = "placed",
+            NewStatus = "preparing",
+            CustomerName = "Test Customer"
+        };
+
+        var response = await httpClient.PostAsJsonAsync(SimulateUrl(IntegrationTestBase.AlphaSlug), simulateRequest);
+        response.EnsureSuccessStatusCode();
+
+        // Assert — should receive the event within 5 seconds
+        var completed = await Task.WhenAny(receivedSignal.Task, Task.Delay(5000));
+        completed.ShouldBe(receivedSignal.Task, "Timed out waiting for SignalR OrderStatusChanged event");
+
+        receivedUpdate.ShouldNotBeNull();
+        receivedUpdate.BrandSlug.ShouldBe(IntegrationTestBase.AlphaSlug);
+        receivedUpdate.ShopId.ShouldBe(shopId);
+        receivedUpdate.PreviousStatus.ShouldBe("placed");
+        receivedUpdate.NewStatus.ShouldBe("preparing");
+        receivedUpdate.CustomerName.ShouldBe("Test Customer");
+
+        await hubConnection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Client_InDifferentShopGroup_DoesNotReceiveEvent()
+    {
+        // Arrange
+        var httpClient = CreateHttpClient();
+        var shopA = await CreateShopAsync(httpClient, IntegrationTestBase.AlphaSlug);
+        var shopB = await CreateShopAsync(httpClient, IntegrationTestBase.AlphaSlug);
+
+        var hubConnection = new HubConnectionBuilder()
+            .WithUrl(
+                $"{httpClient.BaseAddress}api/hubs/orders",
+                options => options.HttpMessageHandlerFactory = _ => fixture.Factory.Server.CreateHandler())
+            .Build();
+
+        var receivedAny = false;
+        hubConnection.On<OrderStatusUpdateDto>("OrderStatusChanged", _ => receivedAny = true);
+
+        await hubConnection.StartAsync();
+
+        // Join shop B group
+        await hubConnection.InvokeAsync("JoinShopGroup", IntegrationTestBase.AlphaSlug, shopB.ToString());
+
+        // Act — simulate event for shop A
+        var simulateRequest = new
+        {
+            ShopId = shopA,
+            PreviousStatus = "placed",
+            NewStatus = "confirmed",
+            CustomerName = "Other Customer"
+        };
+
+        await httpClient.PostAsJsonAsync(SimulateUrl(IntegrationTestBase.AlphaSlug), simulateRequest);
+
+        // Wait briefly and assert no event was received
+        await Task.Delay(1000);
+        receivedAny.ShouldBeFalse("Client in a different shop group should not receive the event");
+
+        await hubConnection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Client_InOrderGroup_ReceivesEventForThatOrder()
+    {
+        // Arrange
+        var httpClient = CreateHttpClient();
+        var shopId = await CreateShopAsync(httpClient, IntegrationTestBase.AlphaSlug);
+        var orderId = Guid.CreateVersion7();
+
+        var hubConnection = new HubConnectionBuilder()
+            .WithUrl(
+                $"{httpClient.BaseAddress}api/hubs/orders",
+                options => options.HttpMessageHandlerFactory = _ => fixture.Factory.Server.CreateHandler())
+            .Build();
+
+        OrderStatusUpdateDto? receivedUpdate = null;
+        var receivedSignal = new TaskCompletionSource<bool>();
+
+        hubConnection.On<OrderStatusUpdateDto>("OrderStatusChanged", update =>
+        {
+            receivedUpdate = update;
+            receivedSignal.TrySetResult(true);
+        });
+
+        await hubConnection.StartAsync();
+        await hubConnection.InvokeAsync("JoinOrderGroup", orderId.ToString());
+
+        // Act — simulate event for that specific order
+        var simulateRequest = new
+        {
+            ShopId = shopId,
+            OrderId = orderId,
+            PreviousStatus = "confirmed",
+            NewStatus = "ready",
+            CustomerName = "Order Tracker"
+        };
+
+        await httpClient.PostAsJsonAsync(SimulateUrl(IntegrationTestBase.AlphaSlug), simulateRequest);
+
+        // Assert
+        var completed = await Task.WhenAny(receivedSignal.Task, Task.Delay(5000));
+        completed.ShouldBe(receivedSignal.Task, "Timed out waiting for SignalR OrderStatusChanged event");
+
+        receivedUpdate.ShouldNotBeNull();
+        receivedUpdate.OrderId.ShouldBe(orderId);
+        receivedUpdate.NewStatus.ShouldBe("ready");
+
+        await hubConnection.DisposeAsync();
+    }
+
+    /// <summary>DTO matching the anonymous payload shape sent by SignalROrderNotificationService.</summary>
+    private sealed record OrderStatusUpdateDto(
+        Guid OrderId,
+        Guid ShopId,
+        string BrandSlug,
+        string PreviousStatus,
+        string NewStatus,
+        string? CustomerName,
+        DateTimeOffset Timestamp);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/TheMillionthFoodOrderApp.Tests.Integration.csproj
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/TheMillionthFoodOrderApp.Tests.Integration.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@microsoft/signalr": "^10.0.0",
     "@tanstack/react-query": "^5.62.7",
     "@tanstack/react-query-devtools": "^5.62.7",
     "axios": "^1.7.9",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@microsoft/signalr':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@tanstack/react-query':
         specifier: ^5.62.7
         version: 5.90.21(react@18.3.1)
@@ -1038,6 +1041,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@microsoft/signalr@10.0.0':
+    resolution: {integrity: sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1137,66 +1143,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1420,6 +1439,10 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1826,6 +1849,14 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1850,6 +1881,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-cookie@2.2.0:
+    resolution: {integrity: sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2368,6 +2402,15 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
@@ -2491,9 +2534,15 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -2577,6 +2626,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2638,6 +2690,9 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2821,9 +2876,16 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
@@ -2908,6 +2970,10 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2924,6 +2990,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -3054,6 +3123,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -3073,6 +3145,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -3163,6 +3238,18 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -4141,6 +4228,18 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@microsoft/signalr@10.0.0':
+    dependencies:
+      abort-controller: 3.0.0
+      eventsource: 2.0.2
+      fetch-cookie: 2.2.0
+      node-fetch: 2.7.0
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4537,6 +4636,10 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -5045,6 +5148,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
+  eventsource@2.0.2: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -5058,6 +5165,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fetch-cookie@2.2.0:
+    dependencies:
+      set-cookie-parser: 2.7.2
+      tough-cookie: 4.1.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5578,6 +5690,10 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.36: {}
 
   nwsapi@2.2.23: {}
@@ -5686,7 +5802,13 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
+
+  querystringify@2.2.0: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -5776,6 +5898,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  requires-port@1.0.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve@1.22.11:
@@ -5861,6 +5985,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -6072,9 +6198,18 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
+
+  tr46@0.0.3: {}
 
   tr46@1.0.1:
     dependencies:
@@ -6166,6 +6301,8 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   upath@1.2.0: {}
@@ -6179,6 +6316,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   vite-node@2.1.9(terser@5.46.0):
     dependencies:
@@ -6282,6 +6424,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
@@ -6296,6 +6440,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   whatwg-url@7.1.0:
     dependencies:
@@ -6479,6 +6628,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  ws@7.5.10: {}
 
   ws@8.19.0: {}
 

--- a/src/frontend/src/api/signalr.ts
+++ b/src/frontend/src/api/signalr.ts
@@ -1,0 +1,30 @@
+import {
+  HubConnectionBuilder,
+  HubConnection,
+  LogLevel,
+} from '@microsoft/signalr';
+
+let connection: HubConnection | null = null;
+
+/**
+ * Returns or creates the singleton SignalR connection to the order hub.
+ * The connection auto-reconnects on drops with exponential backoff.
+ *
+ * Auth: cookies are sent automatically on the WebSocket handshake
+ * (Vite proxies /api to BFF, which forwards the bearer token to the API).
+ */
+export function getOrderHubConnection(): HubConnection {
+  if (connection !== null) {
+    return connection;
+  }
+
+  connection = new HubConnectionBuilder()
+    .withUrl('/api/hubs/orders')
+    .withAutomaticReconnect([0, 2000, 10000, 30000])
+    .configureLogging(
+      import.meta.env.DEV ? LogLevel.Information : LogLevel.Warning,
+    )
+    .build();
+
+  return connection;
+}

--- a/src/frontend/src/api/signalr.ts
+++ b/src/frontend/src/api/signalr.ts
@@ -28,3 +28,18 @@ export function getOrderHubConnection(): HubConnection {
 
   return connection;
 }
+
+/**
+ * Resets the singleton connection. Used by tests and HMR cleanup.
+ */
+export function resetOrderHubConnection(): void {
+  connection = null;
+}
+
+// Clean up the connection on Vite HMR to prevent duplicate connections in dev.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    void connection?.stop();
+    connection = null;
+  });
+}

--- a/src/frontend/src/api/useOrderUpdates.ts
+++ b/src/frontend/src/api/useOrderUpdates.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+import { useSignalR, type ConnectionStatus } from './useSignalR';
+
+export interface OrderStatusUpdate {
+  orderId: string;
+  shopId: string;
+  brandSlug: string;
+  previousStatus: string;
+  newStatus: string;
+  customerName: string | null;
+  timestamp: string;
+}
+
+interface UseOrderUpdatesOptions {
+  /** Shop group to join (for kitchen/POS). */
+  shopGroup?: { brandSlug: string; shopId: string };
+  /** Order ID to track (for customer tracking). */
+  orderId?: string;
+  /** Callback fired on each status change event. */
+  onStatusChange?: (update: OrderStatusUpdate) => void;
+}
+
+/**
+ * Hook for components that need real-time order status updates.
+ * Connects to SignalR, joins the appropriate group, and invokes
+ * the callback on each status change event.
+ */
+export function useOrderUpdates(
+  options: UseOrderUpdatesOptions,
+): { status: ConnectionStatus } {
+  const { shopGroup, orderId, onStatusChange } = options;
+  const { connection, status } = useSignalR({ shopGroup, orderId });
+  const callbackRef = useRef(onStatusChange);
+  callbackRef.current = onStatusChange;
+
+  useEffect(() => {
+    if (!connection) return;
+
+    const handler = (update: OrderStatusUpdate) => {
+      callbackRef.current?.(update);
+    };
+
+    connection.on('OrderStatusChanged', handler);
+    return () => {
+      connection.off('OrderStatusChanged', handler);
+    };
+  }, [connection]);
+
+  return { status };
+}

--- a/src/frontend/src/api/useSignalR.ts
+++ b/src/frontend/src/api/useSignalR.ts
@@ -88,7 +88,10 @@ export function useSignalR(options: UseSignalROptions = {}) {
           setStatus('connected');
           void joinGroups(conn);
         })
-        .catch(() => setStatus('disconnected'));
+        .catch((err) => {
+          console.error('[SignalR] Connection failed:', err);
+          setStatus('disconnected');
+        });
     } else {
       updateStatus(conn);
       void joinGroups(conn);

--- a/src/frontend/src/api/useSignalR.ts
+++ b/src/frontend/src/api/useSignalR.ts
@@ -95,14 +95,15 @@ export function useSignalR(options: UseSignalROptions = {}) {
     }
 
     return () => {
-      // Leave groups on unmount but don't stop the shared connection
+      // Leave groups on unmount but don't stop the shared connection.
+      // Catch errors since the connection may be closing simultaneously.
       const current = groupsRef.current;
       if (conn.state === HubConnectionState.Connected) {
         if (current.shopGroup && shopGroup) {
-          void conn.invoke('LeaveShopGroup', shopGroup.brandSlug, shopGroup.shopId);
+          conn.invoke('LeaveShopGroup', shopGroup.brandSlug, shopGroup.shopId).catch(() => {});
         }
         if (current.orderGroup && orderId) {
-          void conn.invoke('LeaveOrderGroup', orderId);
+          conn.invoke('LeaveOrderGroup', orderId).catch(() => {});
         }
       }
       groupsRef.current = {};

--- a/src/frontend/src/api/useSignalR.ts
+++ b/src/frontend/src/api/useSignalR.ts
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { HubConnection, HubConnectionState } from '@microsoft/signalr';
+import { getOrderHubConnection } from './signalr';
+
+export type ConnectionStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting';
+
+interface UseSignalROptions {
+  /** Shop group to join (for kitchen/POS). */
+  shopGroup?: { brandSlug: string; shopId: string };
+  /** Order ID to track (for customer tracking). */
+  orderId?: string;
+}
+
+/**
+ * React hook that manages a SignalR connection to the order hub.
+ * Handles connection lifecycle, group membership, and auto-reconnect.
+ */
+export function useSignalR(options: UseSignalROptions = {}) {
+  const { shopGroup, orderId } = options;
+  const [status, setStatus] = useState<ConnectionStatus>('disconnected');
+  const connectionRef = useRef<HubConnection | null>(null);
+  const groupsRef = useRef<{ shopGroup?: string; orderGroup?: string }>({});
+
+  const updateStatus = useCallback((conn: HubConnection) => {
+    switch (conn.state) {
+      case HubConnectionState.Connected:
+        setStatus('connected');
+        break;
+      case HubConnectionState.Connecting:
+      case HubConnectionState.Reconnecting:
+        setStatus(
+          conn.state === HubConnectionState.Reconnecting
+            ? 'reconnecting'
+            : 'connecting',
+        );
+        break;
+      default:
+        setStatus('disconnected');
+    }
+  }, []);
+
+  // Join groups after connection is established
+  const joinGroups = useCallback(
+    async (conn: HubConnection) => {
+      if (conn.state !== HubConnectionState.Connected) return;
+
+      if (shopGroup) {
+        const groupName = `shop:${shopGroup.brandSlug}:${shopGroup.shopId}`;
+        if (groupsRef.current.shopGroup !== groupName) {
+          await conn.invoke('JoinShopGroup', shopGroup.brandSlug, shopGroup.shopId);
+          groupsRef.current.shopGroup = groupName;
+        }
+      }
+
+      if (orderId) {
+        const groupName = `order:${orderId}`;
+        if (groupsRef.current.orderGroup !== groupName) {
+          await conn.invoke('JoinOrderGroup', orderId);
+          groupsRef.current.orderGroup = groupName;
+        }
+      }
+    },
+    [shopGroup, orderId],
+  );
+
+  useEffect(() => {
+    const conn = getOrderHubConnection();
+    connectionRef.current = conn;
+
+    conn.onreconnecting(() => setStatus('reconnecting'));
+    conn.onreconnected(() => {
+      setStatus('connected');
+      // Re-join groups after reconnect
+      groupsRef.current = {};
+      void joinGroups(conn);
+    });
+    conn.onclose(() => setStatus('disconnected'));
+
+    if (conn.state === HubConnectionState.Disconnected) {
+      setStatus('connecting');
+      conn
+        .start()
+        .then(() => {
+          setStatus('connected');
+          void joinGroups(conn);
+        })
+        .catch(() => setStatus('disconnected'));
+    } else {
+      updateStatus(conn);
+      void joinGroups(conn);
+    }
+
+    return () => {
+      // Leave groups on unmount but don't stop the shared connection
+      const current = groupsRef.current;
+      if (conn.state === HubConnectionState.Connected) {
+        if (current.shopGroup && shopGroup) {
+          void conn.invoke('LeaveShopGroup', shopGroup.brandSlug, shopGroup.shopId);
+        }
+        if (current.orderGroup && orderId) {
+          void conn.invoke('LeaveOrderGroup', orderId);
+        }
+      }
+      groupsRef.current = {};
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shopGroup?.brandSlug, shopGroup?.shopId, orderId]);
+
+  return {
+    connection: connectionRef.current,
+    status,
+  };
+}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig(() => ({
       '/api': {
         target: 'http://localhost:5261',
         changeOrigin: true,
+        ws: true,
       },
       '/bff': {
         target: 'http://localhost:5261',


### PR DESCRIPTION
## Summary
- **SignalR hub** (`/api/hubs/orders`) with group-based pub/sub: `shop:{brandSlug}:{shopId}` for kitchen/POS and `order:{orderId}` for customer tracking
- **Wolverine event handler** bridges `OrderStatusChangedEvent` domain events to SignalR notifications via `IOrderNotificationService` abstraction
- **React hooks** (`useSignalR`, `useOrderUpdates`) with auto-reconnect (0s, 2s, 10s, 30s backoff)
- **Dev simulate endpoint** (`POST /api/brands/{brandSlug}/orders/simulate-status-change`) for end-to-end testing before the Order aggregate exists
- **3 integration tests** verifying shop group delivery, order group delivery, and cross-group isolation

## Test plan
- [ ] Start backend via Aspire, verify `/api/hubs/orders` accepts WebSocket connections
- [ ] Use Swagger to POST to the simulate endpoint, verify SignalR clients receive `OrderStatusChanged` events
- [ ] Verify clients in different shop groups do NOT receive cross-group events
- [ ] Run integration tests with Docker Desktop: `dotnet test --filter "FullyQualifiedName~SignalR"`

Closes #68