### PR TITLE
feat: US-FP-046 — Apply Belgian VAT rates based on order type

### DIFF
--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -94,7 +94,7 @@ Once brands + shops exist, these streams are **independent of each other**.
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| ⬜ | **US-FP-046** | Apply Belgian VAT rates | 022 |
+| ✅ | **US-FP-046** | Apply Belgian VAT rates | 022 |
 | ⬜ | **US-FP-068** | Real-time updates (SignalR/SSE) | — (infra, can start in L1) |
 | ⬜ | **US-FP-016** | Place an online order | 005, 006, 007, 014, 022, 046 |
 | ⬜ | **US-FP-058** | Complete payment flow (mocked) | 016 |

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/CalculateTaxEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/CalculateTaxEndpoint.cs
@@ -1,0 +1,60 @@
+using FastEndpoints;
+using FluentValidation;
+using TheMillionthFoodOrderApp.Application.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.TaxConfiguration;
+
+public sealed record CalculateTaxApiRequest(
+    [property: RouteParam] string BrandSlug,
+    decimal GrossAmount,
+    string ConsumptionMode);
+
+public sealed class CalculateTaxValidator : Validator<CalculateTaxApiRequest>
+{
+    private static readonly HashSet<string> ValidConsumptionModes = ["Takeaway", "EatIn"];
+
+    public CalculateTaxValidator()
+    {
+        RuleFor(x => x.GrossAmount)
+            .GreaterThan(0).WithMessage("GrossAmount must be greater than 0.");
+
+        RuleFor(x => x.ConsumptionMode)
+            .NotEmpty().WithMessage("ConsumptionMode is required.")
+            .Must(m => ValidConsumptionModes.Contains(m))
+            .WithMessage("ConsumptionMode must be 'Takeaway' or 'EatIn'.");
+    }
+}
+
+public sealed class CalculateTaxEndpoint(ITaxConfigurationService service)
+    : Endpoint<CalculateTaxApiRequest, TaxBreakdownDto>
+{
+    public override void Configure()
+    {
+        Post("/api/brands/{brandSlug}/tax-configuration/calculate");
+        // TODO: Require appropriate role when auth is implemented (US-FP-046)
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<CalculateTaxApiRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Calculate tax breakdown for a given amount and consumption mode";
+            s.Description = "Calculates the net amount, VAT amount, and gross amount breakdown using the brand's configured VAT rates.";
+            s.Response<TaxBreakdownDto>(200, "Tax breakdown calculated successfully.");
+            s.Response(400, "Validation error.");
+            s.Response(404, "No tax configuration found for this brand.");
+        });
+    }
+
+    public override async Task HandleAsync(CalculateTaxApiRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var appRequest = new CalculateTaxRequest(req.GrossAmount, req.ConsumptionMode);
+            var response = await service.CalculateAsync(appRequest, ct);
+            await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+        }
+        catch (KeyNotFoundException)
+        {
+            await HttpContext.Response.SendNotFoundAsync(ct);
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/GetTaxConfigurationEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/GetTaxConfigurationEndpoint.cs
@@ -1,0 +1,38 @@
+using FastEndpoints;
+using TheMillionthFoodOrderApp.Application.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.TaxConfiguration;
+
+public sealed record GetTaxConfigurationRequest([property: RouteParam] string BrandSlug);
+
+public sealed class GetTaxConfigurationEndpoint(ITaxConfigurationService service)
+    : Endpoint<GetTaxConfigurationRequest, TaxConfigurationResponse>
+{
+    public override void Configure()
+    {
+        Get("/api/brands/{brandSlug}/tax-configuration");
+        // TODO: Require BrandAdmin role when auth is implemented (US-FP-046)
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<GetTaxConfigurationRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Get tax configuration for a brand";
+            s.Description = "Returns the VAT rate configuration for the specified brand.";
+            s.Response<TaxConfigurationResponse>(200, "Tax configuration retrieved successfully.");
+            s.Response(404, "No tax configuration found for this brand.");
+        });
+    }
+
+    public override async Task HandleAsync(GetTaxConfigurationRequest req, CancellationToken ct)
+    {
+        var response = await service.GetAsync(ct);
+
+        if (response is null)
+        {
+            await HttpContext.Response.SendNotFoundAsync(ct);
+            return;
+        }
+
+        await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/UpdateTaxConfigurationEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/UpdateTaxConfigurationEndpoint.cs
@@ -1,0 +1,84 @@
+using FastEndpoints;
+using FluentValidation;
+using FluentValidation.Results;
+using TheMillionthFoodOrderApp.Application.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.TaxConfiguration;
+
+public sealed record VatRateInput(string ConsumptionMode, decimal RatePercentage);
+
+public sealed record UpdateTaxConfigurationApiRequest(
+    [property: RouteParam] string BrandSlug,
+    IReadOnlyList<VatRateInput> VatRates);
+
+public sealed class UpdateTaxConfigurationValidator : Validator<UpdateTaxConfigurationApiRequest>
+{
+    private static readonly HashSet<string> ValidConsumptionModes = ["Takeaway", "EatIn"];
+
+    public UpdateTaxConfigurationValidator()
+    {
+        RuleFor(x => x.VatRates)
+            .NotEmpty().WithMessage("At least one VAT rate must be provided.");
+
+        RuleForEach(x => x.VatRates).ChildRules(rate =>
+        {
+            rate.RuleFor(r => r.ConsumptionMode)
+                .NotEmpty().WithMessage("ConsumptionMode is required.")
+                .Must(m => ValidConsumptionModes.Contains(m))
+                .WithMessage("ConsumptionMode must be 'Takeaway' or 'EatIn'.");
+
+            rate.RuleFor(r => r.RatePercentage)
+                .GreaterThanOrEqualTo(0).WithMessage("RatePercentage must be greater than or equal to 0.")
+                .LessThanOrEqualTo(100).WithMessage("RatePercentage must be less than or equal to 100.");
+        });
+
+        RuleFor(x => x.VatRates)
+            .Must(rates =>
+            {
+                if (rates is null) return true;
+                var modes = rates.Select(r => r.ConsumptionMode).ToList();
+                return modes.Count == modes.Distinct().Count();
+            })
+            .WithMessage("Duplicate ConsumptionMode values are not allowed. Each consumption mode may only appear once.");
+    }
+}
+
+public sealed class UpdateTaxConfigurationEndpoint(ITaxConfigurationService service)
+    : Endpoint<UpdateTaxConfigurationApiRequest, TaxConfigurationResponse>
+{
+    public override void Configure()
+    {
+        Put("/api/brands/{brandSlug}/tax-configuration");
+        // TODO: Require BrandAdmin role when auth is implemented (US-FP-046)
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<UpdateTaxConfigurationApiRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Update tax configuration for a brand";
+            s.Description = "Creates or replaces the VAT rate configuration for the specified brand.";
+            s.Response<TaxConfigurationResponse>(200, "Tax configuration updated successfully.");
+            s.Response(400, "Validation error.");
+        });
+    }
+
+    public override async Task HandleAsync(UpdateTaxConfigurationApiRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var appRequest = new UpdateTaxConfigurationRequest(
+                req.VatRates.Select(r => new VatRateDto(r.ConsumptionMode, r.RatePercentage)).ToList());
+
+            var response = await service.UpsertAsync(appRequest, ct);
+
+            await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+        }
+        catch (ArgumentException ex)
+        {
+            var failures = new List<ValidationFailure>
+            {
+                new("vatRates", ex.Message)
+            };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/DependencyInjection.cs
@@ -7,6 +7,7 @@ using TheMillionthFoodOrderApp.Application.ModifierGroups;
 using TheMillionthFoodOrderApp.Application.OrderLifecycle;
 using TheMillionthFoodOrderApp.Application.Products;
 using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Application.TaxConfiguration;
 
 namespace TheMillionthFoodOrderApp.Application;
 
@@ -25,6 +26,7 @@ public static class DependencyInjection
         services.AddScoped<IModifierGroupService, ModifierGroupService>();
         services.AddScoped<IOpeningHoursService, OpeningHoursService>();
         services.AddScoped<IOrderLifecycleService, OrderLifecycleService>();
+        services.AddScoped<ITaxConfigurationService, TaxConfigurationService>();
 
         return services;
     }

--- a/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/ITaxConfigurationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/ITaxConfigurationService.cs
@@ -1,0 +1,8 @@
+namespace TheMillionthFoodOrderApp.Application.TaxConfiguration;
+
+public interface ITaxConfigurationService
+{
+    Task<TaxConfigurationResponse?> GetAsync(CancellationToken cancellationToken = default);
+    Task<TaxConfigurationResponse> UpsertAsync(UpdateTaxConfigurationRequest request, CancellationToken cancellationToken = default);
+    Task<TaxBreakdownDto> CalculateAsync(CalculateTaxRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationDtos.cs
@@ -1,0 +1,19 @@
+namespace TheMillionthFoodOrderApp.Application.TaxConfiguration;
+
+public sealed record VatRateDto(string ConsumptionMode, decimal RatePercentage);
+
+public sealed record TaxConfigurationResponse(
+    Guid Id,
+    IReadOnlyList<VatRateDto> VatRates,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);
+
+public sealed record UpdateTaxConfigurationRequest(IReadOnlyList<VatRateDto> VatRates);
+
+public sealed record TaxBreakdownDto(
+    decimal NetAmount,
+    decimal VatAmount,
+    decimal GrossAmount,
+    decimal VatRatePercentage);
+
+public sealed record CalculateTaxRequest(decimal GrossAmount, string ConsumptionMode);

--- a/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationDtos.cs
@@ -1,19 +1,41 @@
 namespace TheMillionthFoodOrderApp.Application.TaxConfiguration;
 
+/// <summary>
+/// Represents a single VAT rate entry for a given consumption mode.
+/// <see cref="ConsumptionMode"/> must be a valid name from the <c>ConsumptionMode</c> enum (e.g. "Takeaway", "EatIn").
+/// <see cref="RatePercentage"/> must be between 0 and 100 inclusive.
+/// </summary>
 public sealed record VatRateDto(string ConsumptionMode, decimal RatePercentage);
 
+/// <summary>
+/// Read model returned after retrieving or upserting a tax configuration.
+/// Contains all configured VAT rates and the record's audit timestamps.
+/// </summary>
 public sealed record TaxConfigurationResponse(
     Guid Id,
     IReadOnlyList<VatRateDto> VatRates,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);
 
+/// <summary>
+/// Request payload for creating or replacing the active tax configuration.
+/// <see cref="VatRates"/> must contain exactly one entry per defined <c>ConsumptionMode</c> value (no duplicates, no omissions).
+/// </summary>
 public sealed record UpdateTaxConfigurationRequest(IReadOnlyList<VatRateDto> VatRates);
 
+/// <summary>
+/// Result of a tax breakdown calculation.
+/// All monetary values are in the same currency as the input gross amount.
+/// </summary>
 public sealed record TaxBreakdownDto(
     decimal NetAmount,
     decimal VatAmount,
     decimal GrossAmount,
     decimal VatRatePercentage);
 
+/// <summary>
+/// Request payload for calculating the tax breakdown of a gross price.
+/// <see cref="GrossAmount"/> must be >= 0.
+/// <see cref="ConsumptionMode"/> must be a valid name from the <c>ConsumptionMode</c> enum (e.g. "Takeaway", "EatIn").
+/// </summary>
 public sealed record CalculateTaxRequest(decimal GrossAmount, string ConsumptionMode);

--- a/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationService.cs
@@ -21,11 +21,12 @@ public sealed class TaxConfigurationService(ITaxConfigurationRepository reposito
         {
             config = Domain.TaxConfiguration.TaxConfiguration.CreateBelgianDefault();
             await repository.AddAsync(config, cancellationToken);
+            await repository.SaveChangesAsync(cancellationToken);
         }
 
         var rates = request.VatRates
             .Select(r => (
-                Mode: Enum.Parse<ConsumptionMode>(r.ConsumptionMode),
+                ConsumptionMode: ParseConsumptionMode(r.ConsumptionMode),
                 RatePercentage: r.RatePercentage))
             .ToList();
 
@@ -44,7 +45,7 @@ public sealed class TaxConfigurationService(ITaxConfigurationRepository reposito
         if (config is null)
             throw new KeyNotFoundException("No tax configuration has been set up.");
 
-        var mode = Enum.Parse<ConsumptionMode>(request.ConsumptionMode);
+        var mode = ParseConsumptionMode(request.ConsumptionMode);
         var rate = config.GetRateForMode(mode);
         var breakdown = TaxCalculator.CalculateFromGross(request.GrossAmount, rate);
 
@@ -63,4 +64,12 @@ public sealed class TaxConfigurationService(ITaxConfigurationRepository reposito
                 .ToList(),
             config.CreatedAt,
             config.UpdatedAt);
+
+    private static ConsumptionMode ParseConsumptionMode(string value)
+    {
+        if (!Enum.TryParse<ConsumptionMode>(value, out var mode) || !Enum.IsDefined(mode))
+            throw new ArgumentException(
+                $"Invalid consumption mode: '{value}'. Valid values: {string.Join(", ", Enum.GetNames<ConsumptionMode>())}.");
+        return mode;
+    }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationService.cs
@@ -19,7 +19,7 @@ public sealed class TaxConfigurationService(ITaxConfigurationRepository reposito
 
         if (config is null)
         {
-            config = Domain.TaxConfiguration.TaxConfiguration.CreateBelgianDefault();
+            config = Domain.TaxConfiguration.TaxConfiguration.Create();
             await repository.AddAsync(config, cancellationToken);
             await repository.SaveChangesAsync(cancellationToken);
         }

--- a/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/TaxConfiguration/TaxConfigurationService.cs
@@ -1,0 +1,66 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Application.TaxConfiguration;
+
+public sealed class TaxConfigurationService(ITaxConfigurationRepository repository) : ITaxConfigurationService
+{
+    public async Task<TaxConfigurationResponse?> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var config = await repository.GetAsync(cancellationToken);
+        return config is null ? null : MapToResponse(config);
+    }
+
+    public async Task<TaxConfigurationResponse> UpsertAsync(
+        UpdateTaxConfigurationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var config = await repository.GetAsync(cancellationToken);
+
+        if (config is null)
+        {
+            config = Domain.TaxConfiguration.TaxConfiguration.CreateBelgianDefault();
+            await repository.AddAsync(config, cancellationToken);
+        }
+
+        var rates = request.VatRates
+            .Select(r => (
+                Mode: Enum.Parse<ConsumptionMode>(r.ConsumptionMode),
+                RatePercentage: r.RatePercentage))
+            .ToList();
+
+        config.UpdateRates(rates);
+
+        await repository.SaveChangesAsync(cancellationToken);
+
+        return MapToResponse(config);
+    }
+
+    public async Task<TaxBreakdownDto> CalculateAsync(
+        CalculateTaxRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var config = await repository.GetAsync(cancellationToken);
+        if (config is null)
+            throw new KeyNotFoundException("No tax configuration has been set up.");
+
+        var mode = Enum.Parse<ConsumptionMode>(request.ConsumptionMode);
+        var rate = config.GetRateForMode(mode);
+        var breakdown = TaxCalculator.CalculateFromGross(request.GrossAmount, rate);
+
+        return new TaxBreakdownDto(
+            breakdown.NetAmount,
+            breakdown.VatAmount,
+            breakdown.GrossAmount,
+            breakdown.VatRatePercentage);
+    }
+
+    private static TaxConfigurationResponse MapToResponse(Domain.TaxConfiguration.TaxConfiguration config) =>
+        new(
+            config.Id,
+            config.VatRates
+                .Select(r => new VatRateDto(r.ConsumptionMode.ToString(), r.RatePercentage))
+                .ToList(),
+            config.CreatedAt,
+            config.UpdatedAt);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Common/ConsumptionMode.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Common/ConsumptionMode.cs
@@ -1,0 +1,7 @@
+namespace TheMillionthFoodOrderApp.Domain.Common;
+
+public enum ConsumptionMode
+{
+    Takeaway = 0,
+    EatIn = 1,
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Common/ConsumptionMode.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Common/ConsumptionMode.cs
@@ -1,7 +1,20 @@
 namespace TheMillionthFoodOrderApp.Domain.Common;
 
+/// <summary>
+/// Describes how food is consumed, which determines the applicable Belgian VAT rate.
+/// Belgian legislation distinguishes between takeaway and eat-in consumption for food VAT purposes.
+/// </summary>
 public enum ConsumptionMode
 {
+    /// <summary>
+    /// The order is taken away from the premises.
+    /// In Belgium this attracts the reduced food VAT rate of 6%.
+    /// </summary>
     Takeaway = 0,
+
+    /// <summary>
+    /// The order is consumed on the premises (dine-in / eat-in).
+    /// In Belgium this attracts the standard VAT rate of 21% (restaurant services).
+    /// </summary>
     EatIn = 1,
 }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/ITaxConfigurationRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/ITaxConfigurationRepository.cs
@@ -1,0 +1,8 @@
+namespace TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+public interface ITaxConfigurationRepository
+{
+    Task<TaxConfiguration?> GetAsync(CancellationToken cancellationToken = default);
+    Task AddAsync(TaxConfiguration configuration, CancellationToken cancellationToken = default);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/ITaxConfigurationRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/ITaxConfigurationRepository.cs
@@ -4,5 +4,6 @@ public interface ITaxConfigurationRepository
 {
     Task<TaxConfiguration?> GetAsync(CancellationToken cancellationToken = default);
     Task AddAsync(TaxConfiguration configuration, CancellationToken cancellationToken = default);
+    Task RemoveAsync(TaxConfiguration configuration, CancellationToken cancellationToken = default);
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxBreakdown.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxBreakdown.cs
@@ -1,0 +1,27 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+
+namespace TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+public sealed class TaxBreakdown : ValueObject
+{
+    public decimal NetAmount { get; private set; }
+    public decimal VatAmount { get; private set; }
+    public decimal GrossAmount { get; private set; }
+    public decimal VatRatePercentage { get; private set; }
+
+    public TaxBreakdown(decimal netAmount, decimal vatAmount, decimal grossAmount, decimal vatRatePercentage)
+    {
+        NetAmount = netAmount;
+        VatAmount = vatAmount;
+        GrossAmount = grossAmount;
+        VatRatePercentage = vatRatePercentage;
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return NetAmount;
+        yield return VatAmount;
+        yield return GrossAmount;
+        yield return VatRatePercentage;
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxBreakdown.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxBreakdown.cs
@@ -11,6 +11,12 @@ public sealed class TaxBreakdown : ValueObject
 
     public TaxBreakdown(decimal netAmount, decimal vatAmount, decimal grossAmount, decimal vatRatePercentage)
     {
+        if (netAmount < 0) throw new ArgumentException("Net amount cannot be negative.", nameof(netAmount));
+        if (vatAmount < 0) throw new ArgumentException("VAT amount cannot be negative.", nameof(vatAmount));
+        if (grossAmount < 0) throw new ArgumentException("Gross amount cannot be negative.", nameof(grossAmount));
+        if (vatRatePercentage < 0 || vatRatePercentage > 100)
+            throw new ArgumentOutOfRangeException(nameof(vatRatePercentage), "VAT rate percentage must be between 0 and 100.");
+
         NetAmount = netAmount;
         VatAmount = vatAmount;
         GrossAmount = grossAmount;

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxCalculator.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxCalculator.cs
@@ -4,6 +4,11 @@ public static class TaxCalculator
 {
     public static TaxBreakdown CalculateFromGross(decimal grossAmount, decimal vatRatePercentage)
     {
+        if (grossAmount < 0)
+            throw new ArgumentOutOfRangeException(nameof(grossAmount), "Gross amount cannot be negative.");
+        if (vatRatePercentage < 0 || vatRatePercentage > 100)
+            throw new ArgumentOutOfRangeException(nameof(vatRatePercentage), "Rate must be between 0 and 100.");
+
         var net = Math.Round(grossAmount / (1m + vatRatePercentage / 100m), 2, MidpointRounding.AwayFromZero);
         var vat = grossAmount - net;
         return new TaxBreakdown(net, vat, grossAmount, vatRatePercentage);

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxCalculator.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxCalculator.cs
@@ -1,0 +1,11 @@
+namespace TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+public static class TaxCalculator
+{
+    public static TaxBreakdown CalculateFromGross(decimal grossAmount, decimal vatRatePercentage)
+    {
+        var net = Math.Round(grossAmount / (1m + vatRatePercentage / 100m), 2, MidpointRounding.AwayFromZero);
+        var vat = grossAmount - net;
+        return new TaxBreakdown(net, vat, grossAmount, vatRatePercentage);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxConfiguration.cs
@@ -1,0 +1,57 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+
+namespace TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+public sealed class TaxConfiguration : AggregateRoot<Guid>, IAuditable
+{
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private List<VatRate> _vatRates = [];
+    public IReadOnlyCollection<VatRate> VatRates => _vatRates.AsReadOnly();
+
+    // Required by EF Core
+    private TaxConfiguration() { }
+
+    public static TaxConfiguration CreateBelgianDefault()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var config = new TaxConfiguration
+        {
+            Id = Guid.CreateVersion7(),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        config._vatRates.Add(VatRate.Create(config.Id, ConsumptionMode.Takeaway, 6m));
+        config._vatRates.Add(VatRate.Create(config.Id, ConsumptionMode.EatIn, 21m));
+
+        return config;
+    }
+
+    public void UpdateRates(IEnumerable<(ConsumptionMode Mode, decimal RatePercentage)> rates)
+    {
+        var rateList = rates.ToList();
+
+        var enumValues = Enum.GetValues<ConsumptionMode>();
+        foreach (var mode in enumValues)
+        {
+            var count = rateList.Count(r => r.Mode == mode);
+            if (count != 1)
+                throw new ArgumentException($"Exactly one rate must be provided for ConsumptionMode '{mode}'.");
+        }
+
+        _vatRates.Clear();
+        _vatRates.AddRange(rateList.Select(r => VatRate.Create(Id, r.Mode, r.RatePercentage)));
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public decimal GetRateForMode(ConsumptionMode mode)
+    {
+        var vatRate = _vatRates.FirstOrDefault(r => r.ConsumptionMode == mode);
+        if (vatRate is null)
+            throw new KeyNotFoundException($"No VAT rate configured for ConsumptionMode '{mode}'.");
+
+        return vatRate.RatePercentage;
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/TaxConfiguration.cs
@@ -13,19 +13,29 @@ public sealed class TaxConfiguration : AggregateRoot<Guid>, IAuditable
     // Required by EF Core
     private TaxConfiguration() { }
 
-    public static TaxConfiguration CreateBelgianDefault()
+    /// <summary>
+    /// Creates an empty TaxConfiguration shell. Use <see cref="UpdateRates"/> to populate rates.
+    /// </summary>
+    public static TaxConfiguration Create()
     {
         var now = DateTimeOffset.UtcNow;
-        var config = new TaxConfiguration
+        return new TaxConfiguration
         {
             Id = Guid.CreateVersion7(),
             CreatedAt = now,
             UpdatedAt = now,
         };
+    }
 
+    /// <summary>
+    /// Creates a TaxConfiguration pre-populated with Belgian defaults (Takeaway 6%, EatIn 21%).
+    /// Used by the database seeder.
+    /// </summary>
+    public static TaxConfiguration CreateBelgianDefault()
+    {
+        var config = Create();
         config._vatRates.Add(VatRate.Create(config.Id, ConsumptionMode.Takeaway, 6m));
         config._vatRates.Add(VatRate.Create(config.Id, ConsumptionMode.EatIn, 21m));
-
         return config;
     }
 

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/VatRate.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/VatRate.cs
@@ -13,6 +13,8 @@ public sealed class VatRate : Entity<Guid>
 
     public static VatRate Create(Guid taxConfigurationId, ConsumptionMode mode, decimal ratePercentage)
     {
+        if (taxConfigurationId == Guid.Empty)
+            throw new ArgumentException("TaxConfigurationId cannot be empty.", nameof(taxConfigurationId));
         if (ratePercentage < 0 || ratePercentage > 100)
             throw new ArgumentOutOfRangeException(nameof(ratePercentage), "Rate percentage must be between 0 and 100.");
 

--- a/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/VatRate.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/TaxConfiguration/VatRate.cs
@@ -1,0 +1,27 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+
+namespace TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+public sealed class VatRate : Entity<Guid>
+{
+    public Guid TaxConfigurationId { get; private set; }
+    public ConsumptionMode ConsumptionMode { get; private set; }
+    public decimal RatePercentage { get; private set; }
+
+    // Required by EF Core
+    private VatRate() { }
+
+    public static VatRate Create(Guid taxConfigurationId, ConsumptionMode mode, decimal ratePercentage)
+    {
+        if (ratePercentage < 0 || ratePercentage > 100)
+            throw new ArgumentOutOfRangeException(nameof(ratePercentage), "Rate percentage must be between 0 and 100.");
+
+        return new VatRate
+        {
+            Id = Guid.CreateVersion7(),
+            TaxConfigurationId = taxConfigurationId,
+            ConsumptionMode = mode,
+            RatePercentage = ratePercentage,
+        };
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
@@ -9,6 +9,7 @@ using TheMillionthFoodOrderApp.Domain.ModifierGroups;
 using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
 using TheMillionthFoodOrderApp.Domain.Products;
 using TheMillionthFoodOrderApp.Domain.Shops;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
 using TheMillionthFoodOrderApp.Infrastructure.Brands;
 using TheMillionthFoodOrderApp.Infrastructure.BrandSettings;
 using TheMillionthFoodOrderApp.Infrastructure.FileStorage;
@@ -17,6 +18,7 @@ using TheMillionthFoodOrderApp.Infrastructure.MenuCategories;
 using TheMillionthFoodOrderApp.Infrastructure.ModifierGroups;
 using TheMillionthFoodOrderApp.Infrastructure.OrderLifecycle;
 using TheMillionthFoodOrderApp.Infrastructure.Multitenancy;
+using TheMillionthFoodOrderApp.Infrastructure.TaxConfiguration;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence.Interceptors;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence.Seeding;
@@ -62,6 +64,7 @@ public static class DependencyInjection
         services.AddScoped<IMenuCategoryRepository, MenuCategoryRepository>();
         services.AddScoped<IModifierGroupRepository, ModifierGroupRepository>();
         services.AddScoped<IOrderLifecycleConfigRepository, OrderLifecycleConfigRepository>();
+        services.AddScoped<ITaxConfigurationRepository, TaxConfigurationRepository>();
 
         // Seeders (scoped — they depend on scoped DbContext)
         services.AddScoped<PlatformDbSeeder>();

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/BrandDbContext.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/BrandDbContext.cs
@@ -4,6 +4,7 @@ using TheMillionthFoodOrderApp.Domain.ModifierGroups;
 using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
 using TheMillionthFoodOrderApp.Domain.Products;
 using TheMillionthFoodOrderApp.Domain.Shops;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
 using TheMillionthFoodOrderApp.Infrastructure.BrandSettings;
 using TheMillionthFoodOrderApp.Infrastructure.MenuCategories;
 using TheMillionthFoodOrderApp.Infrastructure.ModifierGroups;
@@ -11,6 +12,7 @@ using TheMillionthFoodOrderApp.Infrastructure.OrderLifecycle;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence.Conventions;
 using TheMillionthFoodOrderApp.Infrastructure.Products;
 using TheMillionthFoodOrderApp.Infrastructure.Shops;
+using TheMillionthFoodOrderApp.Infrastructure.TaxConfiguration;
 
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -36,6 +38,8 @@ public sealed class BrandDbContext(DbContextOptions<BrandDbContext> options) : D
     public DbSet<OrderStatus> OrderStatuses => Set<OrderStatus>();
     public DbSet<OrderStatusTransition> OrderStatusTransitions => Set<OrderStatusTransition>();
     public DbSet<ComboItem> ComboItems => Set<ComboItem>();
+    public DbSet<Domain.TaxConfiguration.TaxConfiguration> TaxConfigurations => Set<Domain.TaxConfiguration.TaxConfiguration>();
+    public DbSet<VatRate> VatRates => Set<VatRate>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -58,6 +62,8 @@ public sealed class BrandDbContext(DbContextOptions<BrandDbContext> options) : D
         modelBuilder.ApplyConfiguration(new OrderStatusConfiguration());
         modelBuilder.ApplyConfiguration(new OrderStatusTransitionConfiguration());
         modelBuilder.ApplyConfiguration(new ComboItemConfiguration());
+        modelBuilder.ApplyConfiguration(new TaxConfigurationConfiguration());
+        modelBuilder.ApplyConfiguration(new VatRateConfiguration());
 
         // Global query filter: soft-deleted entities are excluded by default
         modelBuilder.Entity<Product>().HasQueryFilter(p => !p.IsDeleted);

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260408132406_AddTaxConfiguration.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260408132406_AddTaxConfiguration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408132406_AddTaxConfiguration")]
+    partial class AddTaxConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260408132406_AddTaxConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260408132406_AddTaxConfiguration.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddTaxConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ComboItems_ComboProductId",
+                table: "ComboItems");
+
+            migrationBuilder.CreateTable(
+                name: "TaxConfigurations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaxConfigurations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VatRates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    TaxConfigurationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ConsumptionMode = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    RatePercentage = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VatRates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VatRates_TaxConfigurations_TaxConfigurationId",
+                        column: x => x.TaxConfigurationId,
+                        principalTable: "TaxConfigurations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ComboItems_ComboProductId_ComponentProductId",
+                table: "ComboItems",
+                columns: new[] { "ComboProductId", "ComponentProductId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ComboItems_ComboProductId_SortOrder",
+                table: "ComboItems",
+                columns: new[] { "ComboProductId", "SortOrder" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VatRates_TaxConfigurationId_ConsumptionMode",
+                table: "VatRates",
+                columns: new[] { "TaxConfigurationId", "ConsumptionMode" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "VatRates");
+
+            migrationBuilder.DropTable(
+                name: "TaxConfigurations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ComboItems_ComboProductId_ComponentProductId",
+                table: "ComboItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ComboItems_ComboProductId_SortOrder",
+                table: "ComboItems");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ComboItems_ComboProductId",
+                table: "ComboItems",
+                column: "ComboProductId");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
@@ -7,6 +7,7 @@ using TheMillionthFoodOrderApp.Domain.ModifierGroups;
 using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
 using TheMillionthFoodOrderApp.Domain.Products;
 using TheMillionthFoodOrderApp.Domain.Shops;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
 using BrandSettingsDomain = TheMillionthFoodOrderApp.Domain.BrandSettings.BrandSettings;
 
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Seeding;
@@ -31,6 +32,7 @@ public sealed class BrandDbSeeder(
         await context.SaveChangesAsync(cancellationToken);
         await SeedModifierGroupsAsync(context, cancellationToken);
         await SeedOrderLifecycleConfigsAsync(context, cancellationToken);
+        await SeedTaxConfigurationAsync(context, cancellationToken);
     }
 
     private async Task SeedBrandSettingsAsync(
@@ -286,5 +288,22 @@ public sealed class BrandDbSeeder(
         }
 
         await context.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedTaxConfigurationAsync(
+        BrandDbContext context,
+        CancellationToken cancellationToken)
+    {
+        var exists = await context.TaxConfigurations.AnyAsync(cancellationToken);
+        if (exists)
+        {
+            logger.LogDebug("Seed: TaxConfiguration already exists — skipping.");
+            return;
+        }
+
+        var config = Domain.TaxConfiguration.TaxConfiguration.CreateBelgianDefault();
+        await context.TaxConfigurations.AddAsync(config, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Seed: Created TaxConfiguration with Belgian defaults (Takeaway: 6%, EatIn: 21%).");
     }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TaxConfigDomain = TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.TaxConfiguration;
+
+public sealed class TaxConfigurationConfiguration : IEntityTypeConfiguration<TaxConfigDomain.TaxConfiguration>
+{
+    public void Configure(EntityTypeBuilder<TaxConfigDomain.TaxConfiguration> builder)
+    {
+        builder.ToTable("TaxConfigurations");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.CreatedAt)
+            .IsRequired();
+
+        builder.Property(c => c.UpdatedAt)
+            .IsRequired();
+
+        builder.Navigation(c => c.VatRates)
+            .HasField("_vatRates");
+
+        builder.HasMany(c => c.VatRates)
+            .WithOne()
+            .HasForeignKey(v => v.TaxConfigurationId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Domain events are transient — never persisted
+        builder.Ignore(c => c.DomainEvents);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationRepository.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+using TheMillionthFoodOrderApp.Infrastructure.Persistence;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.TaxConfiguration;
+
+public sealed class TaxConfigurationRepository(BrandDbContext dbContext) : ITaxConfigurationRepository
+{
+    public async Task<Domain.TaxConfiguration.TaxConfiguration?> GetAsync(CancellationToken cancellationToken = default)
+        => await dbContext.TaxConfigurations
+            .Include(c => c.VatRates)
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task AddAsync(Domain.TaxConfiguration.TaxConfiguration configuration, CancellationToken cancellationToken = default)
+        => await dbContext.TaxConfigurations.AddAsync(configuration, cancellationToken);
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        => await dbContext.SaveChangesAsync(cancellationToken);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationRepository.cs
@@ -13,7 +13,13 @@ public sealed class TaxConfigurationRepository(BrandDbContext dbContext) : ITaxC
             .FirstOrDefaultAsync(cancellationToken);
 
     public async Task AddAsync(Domain.TaxConfiguration.TaxConfiguration configuration, CancellationToken cancellationToken = default)
-        => await dbContext.TaxConfigurations.AddAsync(configuration, cancellationToken);
+    {
+        var exists = await dbContext.TaxConfigurations.AnyAsync(cancellationToken);
+        if (exists)
+            throw new InvalidOperationException("A TaxConfiguration already exists for this brand. Use UpdateRates instead.");
+
+        await dbContext.TaxConfigurations.AddAsync(configuration, cancellationToken);
+    }
 
     public Task RemoveAsync(Domain.TaxConfiguration.TaxConfiguration configuration, CancellationToken cancellationToken = default)
     {

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/TaxConfigurationRepository.cs
@@ -9,10 +9,17 @@ public sealed class TaxConfigurationRepository(BrandDbContext dbContext) : ITaxC
     public async Task<Domain.TaxConfiguration.TaxConfiguration?> GetAsync(CancellationToken cancellationToken = default)
         => await dbContext.TaxConfigurations
             .Include(c => c.VatRates)
+            .OrderByDescending(c => c.CreatedAt)
             .FirstOrDefaultAsync(cancellationToken);
 
     public async Task AddAsync(Domain.TaxConfiguration.TaxConfiguration configuration, CancellationToken cancellationToken = default)
         => await dbContext.TaxConfigurations.AddAsync(configuration, cancellationToken);
+
+    public Task RemoveAsync(Domain.TaxConfiguration.TaxConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        dbContext.TaxConfigurations.Remove(configuration);
+        return Task.CompletedTask;
+    }
 
     public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
         => await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/VatRateConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/TaxConfiguration/VatRateConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.TaxConfiguration;
+
+public sealed class VatRateConfiguration : IEntityTypeConfiguration<VatRate>
+{
+    public void Configure(EntityTypeBuilder<VatRate> builder)
+    {
+        builder.ToTable("VatRates");
+
+        builder.HasKey(v => v.Id);
+
+        builder.Property(v => v.ConsumptionMode)
+            .IsRequired()
+            .HasConversion<string>();
+
+        builder.Property(v => v.RatePercentage)
+            .IsRequired()
+            .HasPrecision(5, 2);
+
+        builder.Property(v => v.TaxConfigurationId)
+            .IsRequired();
+
+        // Enforce one VAT rate per consumption mode per tax configuration
+        builder.HasIndex(v => new { v.TaxConfigurationId, v.ConsumptionMode })
+            .IsUnique();
+
+        // Domain events are transient — never persisted
+        builder.Ignore(v => v.DomainEvents);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/TaxConfiguration/TaxConfigurationCrudTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/TaxConfiguration/TaxConfigurationCrudTests.cs
@@ -1,0 +1,303 @@
+using System.Net;
+using System.Net.Http.Json;
+using Shouldly;
+using TheMillionthFoodOrderApp.Application.TaxConfiguration;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.TaxConfiguration;
+
+/// <summary>
+/// Integration tests for the Belgian VAT tax configuration CRUD endpoints.
+/// Covers GET, PUT, and POST /calculate for /api/brands/{brandSlug}/tax-configuration.
+///
+/// NOTE: The BrandDbSeeder only runs in the Development environment, not in Testing.
+/// Tests that need a pre-existing config must first PUT one via the API.
+/// </summary>
+public sealed class TaxConfigurationCrudTests(IntegrationTestBase fixture)
+    : IClassFixture<IntegrationTestBase>
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string TaxConfigUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/tax-configuration";
+
+    private static string CalculateUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/tax-configuration/calculate";
+
+    // ── GET tax-configuration ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that after writing Belgian default rates the GET endpoint
+    /// returns Takeaway=6 and EatIn=21.
+    /// The BrandDbSeeder does not run in Testing, so we seed via PUT first.
+    /// </summary>
+    [Fact]
+    public async Task GetTaxConfiguration_AfterSeeding_ReturnsBelgianDefaults()
+    {
+        // Arrange — seed Belgian defaults via PUT (upsert creates if missing)
+        var client = CreateClient();
+
+        var seedRequest = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 21m },
+            }
+        };
+
+        var putResponse = await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug), seedRequest);
+        putResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Act
+        var response = await client.GetAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var config = await response.Content.ReadFromJsonAsync<TaxConfigurationResponse>();
+        config.ShouldNotBeNull();
+        config.VatRates.Count.ShouldBe(2);
+
+        var takeaway = config.VatRates.FirstOrDefault(r => r.ConsumptionMode == "Takeaway");
+        takeaway.ShouldNotBeNull();
+        takeaway.RatePercentage.ShouldBe(6m);
+
+        var eatIn = config.VatRates.FirstOrDefault(r => r.ConsumptionMode == "EatIn");
+        eatIn.ShouldNotBeNull();
+        eatIn.RatePercentage.ShouldBe(21m);
+    }
+
+    [Fact]
+    public async Task GetTaxConfiguration_NonExistentBrand_Returns404()
+    {
+        // Arrange
+        var client = CreateClient();
+
+        // Act — use a brand slug that was never registered in the platform DB
+        var response = await client.GetAsync(TaxConfigUrl("non-existent-brand"));
+
+        // Assert — BrandContextMiddleware returns 404 for unknown brands
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ── PUT tax-configuration ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateTaxConfiguration_ValidRates_Returns200AndUpdatedConfig()
+    {
+        // Arrange
+        var client = CreateClient();
+
+        var request = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 7m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 22m },
+            }
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.BetaSlug), request);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var config = await response.Content.ReadFromJsonAsync<TaxConfigurationResponse>();
+        config.ShouldNotBeNull();
+        config.VatRates.Count.ShouldBe(2);
+
+        var takeaway = config.VatRates.FirstOrDefault(r => r.ConsumptionMode == "Takeaway");
+        takeaway.ShouldNotBeNull();
+        takeaway.RatePercentage.ShouldBe(7m);
+
+        var eatIn = config.VatRates.FirstOrDefault(r => r.ConsumptionMode == "EatIn");
+        eatIn.ShouldNotBeNull();
+        eatIn.RatePercentage.ShouldBe(22m);
+    }
+
+    [Fact]
+    public async Task UpdateTaxConfiguration_InvalidRate_Returns400()
+    {
+        // Arrange — rate > 100 violates FluentValidation rule
+        var client = CreateClient();
+
+        var request = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 101m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 21m },
+            }
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug), request);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateTaxConfiguration_MissingMode_Returns400()
+    {
+        // Arrange — only one consumption mode provided; domain requires exactly one entry per mode
+        var client = CreateClient();
+
+        var request = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+            }
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug), request);
+
+        // Assert — UpdateRates throws ArgumentException; endpoint maps it to 400
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateTaxConfiguration_InvalidModeName_Returns400()
+    {
+        // Arrange — "Invalid" is not a recognised ConsumptionMode
+        var client = CreateClient();
+
+        var request = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Invalid", RatePercentage = 6m },
+                new { ConsumptionMode = "EatIn",   RatePercentage = 21m },
+            }
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug), request);
+
+        // Assert — FluentValidation rejects unknown mode
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateTaxConfiguration_DuplicateMode_Returns400()
+    {
+        // Arrange — two Takeaway entries violate the uniqueness rule
+        var client = CreateClient();
+
+        var request = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+                new { ConsumptionMode = "Takeaway", RatePercentage = 9m },
+            }
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug), request);
+
+        // Assert — FluentValidation rejects duplicate modes
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    // ── POST tax-configuration/calculate ────────────────────────────────────
+
+    [Fact]
+    public async Task CalculateTax_Takeaway_ReturnsCorrect6PercentBreakdown()
+    {
+        // Arrange — ensure a tax config with 6% Takeaway exists
+        var client = CreateClient();
+
+        await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug), new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 21m },
+            }
+        });
+
+        var request = new
+        {
+            GrossAmount     = 3.50m,
+            ConsumptionMode = "Takeaway",
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync(CalculateUrl(IntegrationTestBase.AlphaSlug), request);
+
+        // Assert
+        // net  = Round(3.50 / 1.06, 2, AwayFromZero) = 3.30
+        // vat  = 3.50 - 3.30 = 0.20
+        // gross = 3.50, rate = 6
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var breakdown = await response.Content.ReadFromJsonAsync<TaxBreakdownDto>();
+        breakdown.ShouldNotBeNull();
+        breakdown.GrossAmount.ShouldBe(3.50m);
+        breakdown.NetAmount.ShouldBe(3.30m);
+        breakdown.VatAmount.ShouldBe(0.20m);
+        breakdown.VatRatePercentage.ShouldBe(6m);
+    }
+
+    [Fact]
+    public async Task CalculateTax_EatIn_ReturnsCorrect21PercentBreakdown()
+    {
+        // Arrange — ensure a tax config with 21% EatIn exists
+        var client = CreateClient();
+
+        await client.PutAsJsonAsync(TaxConfigUrl(IntegrationTestBase.AlphaSlug), new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 21m },
+            }
+        });
+
+        var request = new
+        {
+            GrossAmount     = 3.50m,
+            ConsumptionMode = "EatIn",
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync(CalculateUrl(IntegrationTestBase.AlphaSlug), request);
+
+        // Assert
+        // net  = Round(3.50 / 1.21, 2, AwayFromZero) = 2.89
+        // vat  = 3.50 - 2.89 = 0.61
+        // gross = 3.50, rate = 21
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var breakdown = await response.Content.ReadFromJsonAsync<TaxBreakdownDto>();
+        breakdown.ShouldNotBeNull();
+        breakdown.GrossAmount.ShouldBe(3.50m);
+        breakdown.NetAmount.ShouldBe(2.89m);
+        breakdown.VatAmount.ShouldBe(0.61m);
+        breakdown.VatRatePercentage.ShouldBe(21m);
+    }
+
+    [Fact]
+    public async Task CalculateTax_InvalidMode_Returns400()
+    {
+        // Arrange
+        var client = CreateClient();
+
+        var request = new
+        {
+            GrossAmount     = 3.50m,
+            ConsumptionMode = "DineIn",  // Not a valid ConsumptionMode value
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync(CalculateUrl(IntegrationTestBase.AlphaSlug), request);
+
+        // Assert — FluentValidation rejects unknown mode
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/TaxConfiguration/TaxConfigurationCrudTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/TaxConfiguration/TaxConfigurationCrudTests.cs
@@ -204,6 +204,47 @@ public sealed class TaxConfigurationCrudTests(IntegrationTestBase fixture)
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task UpdateTaxConfiguration_PreservesCreatedAtAndBumpsUpdatedAt()
+    {
+        // Arrange — create initial config
+        var client = CreateClient();
+        var slug = IntegrationTestBase.BetaSlug;
+
+        var initialRequest = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 21m },
+            }
+        };
+
+        var createResponse = await client.PutAsJsonAsync(TaxConfigUrl(slug), initialRequest);
+        createResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var created = await createResponse.Content.ReadFromJsonAsync<TaxConfigurationResponse>();
+        created.ShouldNotBeNull();
+
+        // Act — update rates
+        var updateRequest = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 8m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 23m },
+            }
+        };
+
+        var updateResponse = await client.PutAsJsonAsync(TaxConfigUrl(slug), updateRequest);
+        updateResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<TaxConfigurationResponse>();
+        updated.ShouldNotBeNull();
+
+        // Assert — CreatedAt unchanged, UpdatedAt bumped
+        updated.CreatedAt.ShouldBe(created.CreatedAt);
+        updated.UpdatedAt.ShouldBeGreaterThanOrEqualTo(created.UpdatedAt);
+    }
+
     // ── POST tax-configuration/calculate ────────────────────────────────────
 
     [Fact]

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TaxConfiguration/TaxCalculatorTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TaxConfiguration/TaxCalculatorTests.cs
@@ -1,0 +1,72 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.TaxConfiguration;
+
+public sealed class TaxCalculatorTests
+{
+    // ── 6% Takeaway ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateFromGross_Takeaway6Percent_ReturnsCorrectBreakdown()
+    {
+        var result = TaxCalculator.CalculateFromGross(3.50m, 6m);
+
+        result.GrossAmount.ShouldBe(3.50m);
+        result.NetAmount.ShouldBe(3.30m);
+        result.VatAmount.ShouldBe(0.20m);
+        result.VatRatePercentage.ShouldBe(6m);
+    }
+
+    // ── 21% EatIn ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateFromGross_EatIn21Percent_ReturnsCorrectBreakdown()
+    {
+        var result = TaxCalculator.CalculateFromGross(3.50m, 21m);
+
+        result.GrossAmount.ShouldBe(3.50m);
+        result.NetAmount.ShouldBe(2.89m);
+        result.VatAmount.ShouldBe(0.61m);
+        result.VatRatePercentage.ShouldBe(21m);
+    }
+
+    // ── Zero amount ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateFromGross_ZeroAmount_ReturnsAllZeros()
+    {
+        var result = TaxCalculator.CalculateFromGross(0m, 6m);
+
+        result.GrossAmount.ShouldBe(0m);
+        result.NetAmount.ShouldBe(0m);
+        result.VatAmount.ShouldBe(0m);
+        result.VatRatePercentage.ShouldBe(6m);
+    }
+
+    // ── Zero rate ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateFromGross_ZeroRate_NetEqualsGross()
+    {
+        var result = TaxCalculator.CalculateFromGross(5.00m, 0m);
+
+        result.GrossAmount.ShouldBe(5.00m);
+        result.NetAmount.ShouldBe(5.00m);
+        result.VatAmount.ShouldBe(0m);
+        result.VatRatePercentage.ShouldBe(0m);
+    }
+
+    // ── Rounding edge case ────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateFromGross_RoundingEdgeCase_SumsCorrectly()
+    {
+        // 1.99 / 1.06 = 1.87735... → net rounds to 1.88, vat = 1.99 - 1.88 = 0.11
+        var result = TaxCalculator.CalculateFromGross(1.99m, 6m);
+
+        // Net + VAT must always reconstitute the gross exactly
+        (result.NetAmount + result.VatAmount).ShouldBe(result.GrossAmount);
+        result.GrossAmount.ShouldBe(1.99m);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TaxConfiguration/TaxConfigurationTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TaxConfiguration/TaxConfigurationTests.cs
@@ -1,0 +1,104 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.Common;
+using DomainTaxConfiguration = TheMillionthFoodOrderApp.Domain.TaxConfiguration.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.TaxConfiguration;
+
+public sealed class TaxConfigurationTests
+{
+    // ── CreateBelgianDefault ─────────────────────────────────────────────────
+
+    [Fact]
+    public void CreateBelgianDefault_HasTwoRates()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+
+        config.VatRates.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void CreateBelgianDefault_HasCorrectTakeawayRate()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+
+        var takeaway = config.VatRates.Single(r => r.ConsumptionMode == ConsumptionMode.Takeaway);
+        takeaway.RatePercentage.ShouldBe(6m);
+    }
+
+    [Fact]
+    public void CreateBelgianDefault_HasCorrectEatInRate()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+
+        var eatIn = config.VatRates.Single(r => r.ConsumptionMode == ConsumptionMode.EatIn);
+        eatIn.RatePercentage.ShouldBe(21m);
+    }
+
+    // ── UpdateRates ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void UpdateRates_ValidRates_ReplacesExisting()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+        var updatedAt = config.UpdatedAt;
+
+        config.UpdateRates(
+        [
+            (ConsumptionMode.Takeaway, 7m),
+            (ConsumptionMode.EatIn, 22m),
+        ]);
+
+        config.VatRates.Count.ShouldBe(2);
+        config.VatRates.Single(r => r.ConsumptionMode == ConsumptionMode.Takeaway).RatePercentage.ShouldBe(7m);
+        config.VatRates.Single(r => r.ConsumptionMode == ConsumptionMode.EatIn).RatePercentage.ShouldBe(22m);
+        config.UpdatedAt.ShouldBeGreaterThanOrEqualTo(updatedAt);
+    }
+
+    [Fact]
+    public void UpdateRates_MissingConsumptionMode_ThrowsArgumentException()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+
+        // Providing only Takeaway — EatIn is missing
+        Should.Throw<ArgumentException>(() =>
+            config.UpdateRates([(ConsumptionMode.Takeaway, 7m)]));
+    }
+
+    [Fact]
+    public void UpdateRates_DuplicateConsumptionMode_ThrowsArgumentException()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+
+        // Two Takeaway rates and no EatIn rate
+        Should.Throw<ArgumentException>(() =>
+            config.UpdateRates(
+            [
+                (ConsumptionMode.Takeaway, 6m),
+                (ConsumptionMode.Takeaway, 8m),
+            ]));
+    }
+
+    // ── GetRateForMode ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetRateForMode_Takeaway_Returns6()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+
+        var rate = config.GetRateForMode(ConsumptionMode.Takeaway);
+
+        rate.ShouldBe(6m);
+    }
+
+    [Fact]
+    public void GetRateForMode_UnknownMode_ThrowsKeyNotFoundException()
+    {
+        var config = DomainTaxConfiguration.CreateBelgianDefault();
+
+        // Cast an integer value that is not a defined ConsumptionMode member
+        var unknownMode = (ConsumptionMode)999;
+
+        Should.Throw<KeyNotFoundException>(() =>
+            config.GetRateForMode(unknownMode));
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TaxConfiguration/VatRateTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TaxConfiguration/VatRateTests.cs
@@ -1,0 +1,54 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.Common;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.TaxConfiguration;
+
+public sealed class VatRateTests
+{
+    private static readonly Guid SomeTaxConfigId = Guid.CreateVersion7();
+
+    // ── Create ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WithValidData_SetsProperties()
+    {
+        var vatRate = VatRate.Create(SomeTaxConfigId, ConsumptionMode.Takeaway, 6m);
+
+        vatRate.ShouldNotBeNull();
+        vatRate.Id.ShouldNotBe(Guid.Empty);
+        vatRate.TaxConfigurationId.ShouldBe(SomeTaxConfigId);
+        vatRate.ConsumptionMode.ShouldBe(ConsumptionMode.Takeaway);
+        vatRate.RatePercentage.ShouldBe(6m);
+    }
+
+    [Fact]
+    public void Create_WithNegativeRate_ThrowsArgumentOutOfRangeException()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            VatRate.Create(SomeTaxConfigId, ConsumptionMode.Takeaway, -1m));
+    }
+
+    [Fact]
+    public void Create_WithRateOver100_ThrowsArgumentOutOfRangeException()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            VatRate.Create(SomeTaxConfigId, ConsumptionMode.Takeaway, 100.01m));
+    }
+
+    [Fact]
+    public void Create_WithZeroRate_Succeeds()
+    {
+        var vatRate = VatRate.Create(SomeTaxConfigId, ConsumptionMode.EatIn, 0m);
+
+        vatRate.RatePercentage.ShouldBe(0m);
+    }
+
+    [Fact]
+    public void Create_WithRate100_Succeeds()
+    {
+        var vatRate = VatRate.Create(SomeTaxConfigId, ConsumptionMode.EatIn, 100m);
+
+        vatRate.RatePercentage.ShouldBe(100m);
+    }
+}

--- a/src/frontend/src/api/taxConfiguration.ts
+++ b/src/frontend/src/api/taxConfiguration.ts
@@ -1,0 +1,47 @@
+import { apiClient } from './client';
+import type {
+  TaxConfigurationResponse,
+  UpdateTaxConfigurationRequest,
+  TaxBreakdownResponse,
+  ConsumptionMode,
+} from '../types/common';
+
+/**
+ * API functions for brand-level tax configuration.
+ * Routes are brand-scoped: /brands/{brandSlug}/tax-configuration
+ */
+export const taxConfigurationApi = {
+  /**
+   * Fetch the tax configuration for a brand.
+   */
+  get: (brandSlug: string): Promise<TaxConfigurationResponse> =>
+    apiClient
+      .get<TaxConfigurationResponse>(`/brands/${brandSlug}/tax-configuration`)
+      .then((r) => r.data),
+
+  /**
+   * Update the tax configuration for a brand (replaces all VAT rates).
+   */
+  update: (
+    brandSlug: string,
+    data: UpdateTaxConfigurationRequest,
+  ): Promise<TaxConfigurationResponse> =>
+    apiClient
+      .put<TaxConfigurationResponse>(`/brands/${brandSlug}/tax-configuration`, data)
+      .then((r) => r.data),
+
+  /**
+   * Calculate tax breakdown for a given gross amount and consumption mode.
+   */
+  calculate: (
+    brandSlug: string,
+    grossAmount: number,
+    consumptionMode: ConsumptionMode,
+  ): Promise<TaxBreakdownResponse> =>
+    apiClient
+      .post<TaxBreakdownResponse>(
+        `/brands/${brandSlug}/tax-configuration/calculate`,
+        { grossAmount, consumptionMode },
+      )
+      .then((r) => r.data),
+};

--- a/src/frontend/src/features/admin/hooks/useTaxConfiguration.ts
+++ b/src/frontend/src/features/admin/hooks/useTaxConfiguration.ts
@@ -1,0 +1,40 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { taxConfigurationApi } from '../../../api/taxConfiguration';
+import type { UpdateTaxConfigurationRequest } from '../../../types/common';
+
+/** Centralized query key factory for tax configuration queries. */
+export const taxConfigurationKeys = {
+  config: (brandSlug: string) => ['taxConfiguration', brandSlug] as const,
+};
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Fetch the brand-level tax configuration. */
+export function useTaxConfiguration(brandSlug: string) {
+  return useQuery({
+    queryKey: taxConfigurationKeys.config(brandSlug),
+    queryFn: () => taxConfigurationApi.get(brandSlug),
+    enabled: brandSlug.length > 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/** Update the brand's tax configuration (replaces all VAT rates). */
+export function useUpdateTaxConfiguration(brandSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateTaxConfigurationRequest) =>
+      taxConfigurationApi.update(brandSlug, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: taxConfigurationKeys.config(brandSlug),
+      });
+    },
+  });
+}

--- a/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
+++ b/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
@@ -29,7 +29,6 @@ export function TaxConfiguration() {
     EatIn: BELGIAN_VAT_DEFAULTS.EatIn,
   });
   const [formInitialized, setFormInitialized] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
 
   // Example calculation state
   const [calcGrossAmount, setCalcGrossAmount] = useState('10.00');
@@ -47,39 +46,26 @@ export function TaxConfiguration() {
     }
   }, [taxConfig, formInitialized]);
 
-  // Auto-dismiss success message
-  useEffect(() => {
-    if (!successMessage) return;
-    const timer = setTimeout(() => setSuccessMessage(''), 3000);
-    return () => clearTimeout(timer);
-  }, [successMessage]);
-
   // ── Handlers ──────────────────────────────────────────────────────────────
 
   function handleRateChange(mode: ConsumptionMode, value: string) {
-    const parsed = parseFloat(value);
-    if (!isNaN(parsed)) {
-      setRates((prev) => ({ ...prev, [mode]: parsed }));
-    } else if (value === '' || value === '.') {
+    if (value === '' || value === '.') {
       setRates((prev) => ({ ...prev, [mode]: 0 }));
+      return;
     }
+    const num = parseFloat(value);
+    if (isNaN(num) || num < 0 || num > 100) return;
+    setRates((prev) => ({ ...prev, [mode]: num }));
   }
 
   function handleSave(e: React.FormEvent) {
     e.preventDefault();
-    updateMutation.mutate(
-      {
-        vatRates: CONSUMPTION_MODES.map((mode) => ({
-          consumptionMode: mode,
-          ratePercentage: rates[mode],
-        })),
-      },
-      {
-        onSuccess: () => {
-          setSuccessMessage(t('admin.taxConfiguration.saved'));
-        },
-      },
-    );
+    updateMutation.mutate({
+      vatRates: CONSUMPTION_MODES.map((mode) => ({
+        consumptionMode: mode,
+        ratePercentage: rates[mode],
+      })),
+    });
   }
 
   // ── Client-side VAT breakdown calculation ────────────────────────────────
@@ -126,16 +112,9 @@ export function TaxConfiguration() {
       </p>
 
       {/* Success / error messages */}
-      {successMessage && (
-        <p
-          style={{
-            color: '#16a34a',
-            marginBottom: '1rem',
-            fontSize: '0.875rem',
-            fontWeight: 500,
-          }}
-        >
-          {successMessage}
+      {updateMutation.isSuccess && (
+        <p style={{ color: '#059669', marginBottom: '1rem', fontSize: '0.875rem' }}>
+          {t('admin.taxConfiguration.saved')}
         </p>
       )}
 
@@ -222,7 +201,7 @@ export function TaxConfiguration() {
               {t('admin.taxConfiguration.grossAmount')}
             </label>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.25rem' }}>
-              <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>€</span>
+              <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>{t('admin.taxConfiguration.currencySymbol')}</span>
               <input
                 id="calc-gross"
                 type="number"
@@ -238,9 +217,7 @@ export function TaxConfiguration() {
           {/* Consumption mode selector */}
           <div>
             <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
-              <legend style={labelStyle}>
-                {/* Mode selection — no separate label needed, options are self-explanatory */}
-              </legend>
+              <legend style={labelStyle}>{t('admin.taxConfiguration.consumptionMode')}</legend>
               <div style={{ display: 'flex', gap: '1rem', marginTop: '0.25rem' }}>
                 {CONSUMPTION_MODES.map((mode) => (
                   <label
@@ -309,6 +286,7 @@ interface BreakdownRowProps {
 }
 
 function BreakdownRow({ label, amount, isBold = false }: BreakdownRowProps) {
+  const { t } = useTranslation('common');
   return (
     <div
       style={{
@@ -338,7 +316,7 @@ function BreakdownRow({ label, amount, isBold = false }: BreakdownRowProps) {
           color: isBold ? '#111827' : '#374151',
         }}
       >
-        € {amount.toFixed(2)}
+        {t('admin.taxConfiguration.currencySymbol')} {amount.toFixed(2)}
       </span>
     </div>
   );

--- a/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
+++ b/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
@@ -1,0 +1,377 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useTaxConfiguration, useUpdateTaxConfiguration } from '../hooks/useTaxConfiguration';
+import { CONSUMPTION_MODES } from '../../../types/common';
+import type { ConsumptionMode } from '../../../types/common';
+
+// Default Belgian VAT rates
+const BELGIAN_VAT_DEFAULTS: Record<ConsumptionMode, number> = {
+  Takeaway: 6,
+  EatIn: 21,
+};
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export function TaxConfiguration() {
+  const { brandSlug } = useParams<{ brandSlug: string; lang: string }>();
+  const resolvedSlug = brandSlug ?? '';
+  const { t } = useTranslation('common');
+
+  const { data: taxConfig, isLoading, isError } = useTaxConfiguration(resolvedSlug);
+  const updateMutation = useUpdateTaxConfiguration(resolvedSlug);
+
+  // ── Form state ────────────────────────────────────────────────────────────
+  const [rates, setRates] = useState<Record<ConsumptionMode, number>>({
+    Takeaway: BELGIAN_VAT_DEFAULTS.Takeaway,
+    EatIn: BELGIAN_VAT_DEFAULTS.EatIn,
+  });
+  const [formInitialized, setFormInitialized] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  // Example calculation state
+  const [calcGrossAmount, setCalcGrossAmount] = useState('10.00');
+  const [calcMode, setCalcMode] = useState<ConsumptionMode>('Takeaway');
+
+  // Populate form when data arrives
+  useEffect(() => {
+    if (taxConfig !== undefined && !formInitialized) {
+      const updated = { ...BELGIAN_VAT_DEFAULTS };
+      for (const vatRate of taxConfig.vatRates) {
+        updated[vatRate.consumptionMode] = vatRate.ratePercentage;
+      }
+      setRates(updated);
+      setFormInitialized(true);
+    }
+  }, [taxConfig, formInitialized]);
+
+  // Auto-dismiss success message
+  useEffect(() => {
+    if (!successMessage) return;
+    const timer = setTimeout(() => setSuccessMessage(''), 3000);
+    return () => clearTimeout(timer);
+  }, [successMessage]);
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+
+  function handleRateChange(mode: ConsumptionMode, value: string) {
+    const parsed = parseFloat(value);
+    if (!isNaN(parsed)) {
+      setRates((prev) => ({ ...prev, [mode]: parsed }));
+    } else if (value === '' || value === '.') {
+      setRates((prev) => ({ ...prev, [mode]: 0 }));
+    }
+  }
+
+  function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    updateMutation.mutate(
+      {
+        vatRates: CONSUMPTION_MODES.map((mode) => ({
+          consumptionMode: mode,
+          ratePercentage: rates[mode],
+        })),
+      },
+      {
+        onSuccess: () => {
+          setSuccessMessage(t('admin.taxConfiguration.saved'));
+        },
+      },
+    );
+  }
+
+  // ── Client-side VAT breakdown calculation ────────────────────────────────
+
+  function computeBreakdown(grossAmount: number, mode: ConsumptionMode) {
+    const rate = rates[mode] / 100;
+    // gross = net * (1 + rate)  →  net = gross / (1 + rate)
+    const netAmount = grossAmount / (1 + rate);
+    const vatAmount = grossAmount - netAmount;
+    return { netAmount, vatAmount, grossAmount };
+  }
+
+  const parsedGross = parseFloat(calcGrossAmount);
+  const hasValidGross = !isNaN(parsedGross) && parsedGross > 0;
+  const breakdown = hasValidGross ? computeBreakdown(parsedGross, calcMode) : null;
+
+  // ── Loading / error states ────────────────────────────────────────────────
+
+  if (isLoading) {
+    return (
+      <main style={{ padding: '1.5rem' }}>
+        <p style={{ color: '#6b7280' }}>{t('admin.taxConfiguration.loading')}</p>
+      </main>
+    );
+  }
+
+  if (isError) {
+    return (
+      <main style={{ padding: '1.5rem' }}>
+        <p style={{ color: '#dc2626' }}>{t('admin.taxConfiguration.notConfigured')}</p>
+      </main>
+    );
+  }
+
+  // ── Form ──────────────────────────────────────────────────────────────────
+
+  return (
+    <main style={{ padding: '1.5rem', maxWidth: '48rem' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 700, marginBottom: '0.25rem' }}>
+        {t('admin.taxConfiguration.title')}
+      </h1>
+      <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '2rem' }}>
+        {t('admin.taxConfiguration.description')}
+      </p>
+
+      {/* Success / error messages */}
+      {successMessage && (
+        <p
+          style={{
+            color: '#16a34a',
+            marginBottom: '1rem',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+          }}
+        >
+          {successMessage}
+        </p>
+      )}
+
+      {updateMutation.isError && (
+        <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
+          {t('admin.taxConfiguration.saveError')}
+        </p>
+      )}
+
+      <form onSubmit={handleSave} noValidate>
+        {/* ── VAT rates per consumption mode ───────────────────────────── */}
+        <section style={sectionStyle}>
+          {CONSUMPTION_MODES.map((mode) => (
+            <div
+              key={mode}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '1rem',
+                marginBottom: '1rem',
+                flexWrap: 'wrap',
+              }}
+            >
+              <label htmlFor={`rate-${mode}`} style={{ flex: '1 1 16rem' }}>
+                <span style={labelStyle}>
+                  {t(`admin.taxConfiguration.consumptionModes.${mode}`)}
+                </span>
+              </label>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  id={`rate-${mode}`}
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  max="100"
+                  value={rates[mode]}
+                  onChange={(e) => handleRateChange(mode, e.target.value)}
+                  style={{ ...inputStyle, width: '7rem', textAlign: 'right' }}
+                />
+                <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>%</span>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        {/* ── Save button ───────────────────────────────────────────────── */}
+        <button
+          type="submit"
+          disabled={updateMutation.isPending}
+          style={{
+            padding: '0.5rem 1.5rem',
+            background: '#111827',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '0.375rem',
+            cursor: updateMutation.isPending ? 'not-allowed' : 'pointer',
+            fontWeight: 600,
+            opacity: updateMutation.isPending ? 0.6 : 1,
+            marginBottom: '2rem',
+          }}
+        >
+          {updateMutation.isPending
+            ? t('admin.taxConfiguration.saving')
+            : t('admin.taxConfiguration.save')}
+        </button>
+      </form>
+
+      {/* ── Example calculation ───────────────────────────────────────── */}
+      <section style={sectionStyle}>
+        <h2 style={sectionHeadingStyle}>{t('admin.taxConfiguration.exampleCalculation')}</h2>
+
+        <div
+          style={{
+            display: 'flex',
+            gap: '1rem',
+            alignItems: 'flex-end',
+            flexWrap: 'wrap',
+            marginBottom: '1rem',
+          }}
+        >
+          {/* Gross amount input */}
+          <div>
+            <label htmlFor="calc-gross" style={labelStyle}>
+              {t('admin.taxConfiguration.grossAmount')}
+            </label>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.25rem' }}>
+              <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>€</span>
+              <input
+                id="calc-gross"
+                type="number"
+                step="0.01"
+                min="0"
+                value={calcGrossAmount}
+                onChange={(e) => setCalcGrossAmount(e.target.value)}
+                style={{ ...inputStyle, width: '8rem' }}
+              />
+            </div>
+          </div>
+
+          {/* Consumption mode selector */}
+          <div>
+            <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+              <legend style={labelStyle}>
+                {/* Mode selection — no separate label needed, options are self-explanatory */}
+              </legend>
+              <div style={{ display: 'flex', gap: '1rem', marginTop: '0.25rem' }}>
+                {CONSUMPTION_MODES.map((mode) => (
+                  <label
+                    key={mode}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.375rem',
+                      fontSize: '0.875rem',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <input
+                      type="radio"
+                      name="calc-mode"
+                      value={mode}
+                      checked={calcMode === mode}
+                      onChange={() => setCalcMode(mode)}
+                    />
+                    {t(`admin.taxConfiguration.consumptionModes.${mode}`)}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+        </div>
+
+        {/* Breakdown result */}
+        {breakdown && (
+          <div
+            style={{
+              padding: '1rem',
+              border: '1px solid #e5e7eb',
+              borderRadius: '0.375rem',
+              background: '#f9fafb',
+            }}
+          >
+            <BreakdownRow
+              label={t('admin.taxConfiguration.netAmount')}
+              amount={breakdown.netAmount}
+            />
+            <BreakdownRow
+              label={`${t('admin.taxConfiguration.vatAmount')} (${rates[calcMode]}%)`}
+              amount={breakdown.vatAmount}
+            />
+            <BreakdownRow
+              label={t('admin.taxConfiguration.grossAmount')}
+              amount={breakdown.grossAmount}
+              isBold
+            />
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface BreakdownRowProps {
+  label: string;
+  amount: number;
+  isBold?: boolean;
+}
+
+function BreakdownRow({ label, amount, isBold = false }: BreakdownRowProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '0.25rem 0',
+        borderTop: isBold ? '1px solid #e5e7eb' : undefined,
+        marginTop: isBold ? '0.25rem' : undefined,
+        paddingTop: isBold ? '0.5rem' : undefined,
+      }}
+    >
+      <span
+        style={{
+          fontSize: '0.875rem',
+          color: isBold ? '#111827' : '#6b7280',
+          fontWeight: isBold ? 600 : 400,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontSize: '0.875rem',
+          fontFamily: 'monospace',
+          fontWeight: isBold ? 700 : 400,
+          color: isBold ? '#111827' : '#374151',
+        }}
+      >
+        € {amount.toFixed(2)}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Style helpers
+// ---------------------------------------------------------------------------
+
+const sectionStyle: React.CSSProperties = {
+  marginBottom: '2rem',
+};
+
+const sectionHeadingStyle: React.CSSProperties = {
+  fontSize: '1rem',
+  fontWeight: 700,
+  marginBottom: '0.75rem',
+  paddingBottom: '0.5rem',
+  borderBottom: '1px solid #e5e7eb',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontWeight: 600,
+  fontSize: '0.875rem',
+  marginBottom: '0.125rem',
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '0.5rem 0.75rem',
+  border: '1px solid #d1d5db',
+  borderRadius: '0.375rem',
+  fontSize: '0.875rem',
+  boxSizing: 'border-box',
+};

--- a/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
+++ b/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
@@ -20,7 +20,7 @@ export function TaxConfiguration() {
   const resolvedSlug = brandSlug ?? '';
   const { t } = useTranslation('common');
 
-  const { data: taxConfig, isLoading, isError } = useTaxConfiguration(resolvedSlug);
+  const { data: taxConfig, isLoading, isError, error } = useTaxConfiguration(resolvedSlug);
   const updateMutation = useUpdateTaxConfiguration(resolvedSlug);
 
   // ── Form state ────────────────────────────────────────────────────────────
@@ -72,9 +72,9 @@ export function TaxConfiguration() {
 
   function computeBreakdown(grossAmount: number, mode: ConsumptionMode) {
     const rate = rates[mode] / 100;
-    // gross = net * (1 + rate)  →  net = gross / (1 + rate)
-    const netAmount = grossAmount / (1 + rate);
-    const vatAmount = grossAmount - netAmount;
+    // Mirror backend TaxCalculator: round net to 2dp first, then vat = gross - net
+    const netAmount = Math.round((grossAmount / (1 + rate)) * 100) / 100;
+    const vatAmount = Math.round((grossAmount - netAmount) * 100) / 100;
     return { netAmount, vatAmount, grossAmount };
   }
 
@@ -93,9 +93,16 @@ export function TaxConfiguration() {
   }
 
   if (isError) {
+    // 404 means no config has been seeded yet; other errors are genuine failures
+    const is404 = error instanceof Error && 'response' in error &&
+      (error as Error & { response?: { status?: number } }).response?.status === 404;
     return (
       <main style={{ padding: '1.5rem' }}>
-        <p style={{ color: '#dc2626' }}>{t('admin.taxConfiguration.notConfigured')}</p>
+        <p style={{ color: '#dc2626' }}>
+          {is404
+            ? t('admin.taxConfiguration.notConfigured')
+            : t('admin.taxConfiguration.loadError')}
+        </p>
       </main>
     );
   }

--- a/src/frontend/src/features/admin/routes.tsx
+++ b/src/frontend/src/features/admin/routes.tsx
@@ -74,6 +74,10 @@ const LazyBrandTheming = lazy(() =>
   import('./pages/BrandTheming').then((m) => ({ default: m.BrandTheming })),
 );
 
+const LazyTaxConfiguration = lazy(() =>
+  import('./pages/TaxConfiguration').then((m) => ({ default: m.TaxConfiguration })),
+);
+
 const LazyModifierGroupList = lazy(() =>
   import('./pages/ModifierGroupList').then((m) => ({ default: m.ModifierGroupList })),
 );
@@ -321,6 +325,15 @@ export const adminRoutes: RouteObject[] = [
     element: (
       <Suspense fallback={<p style={{ padding: '1.5rem', color: '#6b7280' }}>Loading…</p>}>
         <LazyBrandTheming />
+      </Suspense>
+    ),
+  },
+  // Tax configuration (brand-level)
+  {
+    path: 'tax-configuration',
+    element: (
+      <Suspense fallback={<p style={{ padding: '1.5rem', color: '#6b7280' }}>Loading…</p>}>
+        <LazyTaxConfiguration />
       </Suspense>
     ),
   },

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -259,7 +259,8 @@
       "netAmount": "Netto (exkl. MwSt.)",
       "vatAmount": "MwSt.-Betrag",
       "loading": "Laden…",
-      "notConfigured": "Noch nicht konfiguriert. Speichern Sie, um die belgischen Standardwerte festzulegen."
+      "notConfigured": "Noch nicht konfiguriert. Speichern Sie, um die belgischen Standardwerte festzulegen.",
+      "loadError": "MwSt.-Konfiguration konnte nicht geladen werden."
     }
   }
 }

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -239,6 +239,25 @@
         "saveError": "Speichern fehlgeschlagen. Bitte erneut versuchen.",
         "manageLifecycle": "Bestellstatus-Lebenszyklus verwalten"
       }
+    },
+    "taxConfiguration": {
+      "title": "MwSt.-Konfiguration",
+      "description": "Konfigurieren Sie die MwSt.-Sätze pro Verbrauchsmodus. Belgisches Recht: 6% zum Mitnehmen, 21% vor Ort.",
+      "consumptionModes": {
+        "Takeaway": "Zum Mitnehmen (Abholung & Lieferung)",
+        "EatIn": "Vor Ort (Theke & QR/Tisch)"
+      },
+      "ratePercentage": "MwSt.-Satz (%)",
+      "save": "Speichern",
+      "saving": "Speichern…",
+      "saved": "MwSt.-Konfiguration gespeichert",
+      "saveError": "Speichern fehlgeschlagen. Versuchen Sie es erneut.",
+      "exampleCalculation": "Beispielberechnung",
+      "grossAmount": "Betrag (inkl. MwSt.)",
+      "netAmount": "Netto (exkl. MwSt.)",
+      "vatAmount": "MwSt.-Betrag",
+      "loading": "Laden…",
+      "notConfigured": "Noch nicht konfiguriert. Speichern Sie, um die belgischen Standardwerte festzulegen."
     }
   }
 }

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -243,11 +243,13 @@
     "taxConfiguration": {
       "title": "MwSt.-Konfiguration",
       "description": "Konfigurieren Sie die MwSt.-Sätze pro Verbrauchsmodus. Belgisches Recht: 6% zum Mitnehmen, 21% vor Ort.",
+      "consumptionMode": "Verbrauchsmodus",
       "consumptionModes": {
         "Takeaway": "Zum Mitnehmen (Abholung & Lieferung)",
         "EatIn": "Vor Ort (Theke & QR/Tisch)"
       },
       "ratePercentage": "MwSt.-Satz (%)",
+      "currencySymbol": "€",
       "save": "Speichern",
       "saving": "Speichern…",
       "saved": "MwSt.-Konfiguration gespeichert",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -239,6 +239,25 @@
         "saveError": "Échec de l'enregistrement. Veuillez réessayer.",
         "manageLifecycle": "Gérer le cycle de vie des commandes"
       }
+    },
+    "taxConfiguration": {
+      "title": "Configuration TVA",
+      "description": "Configurez les taux de TVA par mode de consommation. Loi belge : 6% à emporter, 21% sur place.",
+      "consumptionModes": {
+        "Takeaway": "À emporter (retrait & livraison)",
+        "EatIn": "Sur place (comptoir & QR/table)"
+      },
+      "ratePercentage": "Taux de TVA (%)",
+      "save": "Enregistrer",
+      "saving": "Enregistrement…",
+      "saved": "Configuration TVA enregistrée",
+      "saveError": "Échec de l'enregistrement. Réessayez.",
+      "exampleCalculation": "Exemple de calcul",
+      "grossAmount": "Montant (TVA incluse)",
+      "netAmount": "Net (hors TVA)",
+      "vatAmount": "Montant TVA",
+      "loading": "Chargement…",
+      "notConfigured": "Pas encore configuré. Enregistrez pour appliquer les valeurs belges par défaut."
     }
   }
 }

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -243,11 +243,13 @@
     "taxConfiguration": {
       "title": "Configuration TVA",
       "description": "Configurez les taux de TVA par mode de consommation. Loi belge : 6% à emporter, 21% sur place.",
+      "consumptionMode": "Mode de consommation",
       "consumptionModes": {
         "Takeaway": "À emporter (retrait & livraison)",
         "EatIn": "Sur place (comptoir & QR/table)"
       },
       "ratePercentage": "Taux de TVA (%)",
+      "currencySymbol": "€",
       "save": "Enregistrer",
       "saving": "Enregistrement…",
       "saved": "Configuration TVA enregistrée",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -259,7 +259,8 @@
       "netAmount": "Net (hors TVA)",
       "vatAmount": "Montant TVA",
       "loading": "Chargement…",
-      "notConfigured": "Pas encore configuré. Enregistrez pour appliquer les valeurs belges par défaut."
+      "notConfigured": "Pas encore configuré. Enregistrez pour appliquer les valeurs belges par défaut.",
+      "loadError": "Impossible de charger la configuration TVA."
     }
   }
 }

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -259,7 +259,8 @@
       "netAmount": "Netto (excl. BTW)",
       "vatAmount": "BTW-bedrag",
       "loading": "Laden…",
-      "notConfigured": "Nog niet geconfigureerd. Sla op om Belgische standaardwaarden in te stellen."
+      "notConfigured": "Nog niet geconfigureerd. Sla op om Belgische standaardwaarden in te stellen.",
+      "loadError": "BTW-configuratie kon niet worden geladen."
     }
   }
 }

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -243,11 +243,13 @@
     "taxConfiguration": {
       "title": "BTW-configuratie",
       "description": "Configureer BTW-tarieven per consumptiemodus. Belgische wetgeving: 6% meenemen, 21% ter plaatse.",
+      "consumptionMode": "Consumptiemodus",
       "consumptionModes": {
         "Takeaway": "Meenemen (afhaling & levering)",
         "EatIn": "Ter plaatse (balie & QR/tafel)"
       },
       "ratePercentage": "BTW-tarief (%)",
+      "currencySymbol": "€",
       "save": "Opslaan",
       "saving": "Opslaan…",
       "saved": "BTW-configuratie opgeslagen",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -239,6 +239,25 @@
         "saveError": "Opslaan mislukt. Probeer het opnieuw.",
         "manageLifecycle": "Bestelstatus-levenscyclus beheren"
       }
+    },
+    "taxConfiguration": {
+      "title": "BTW-configuratie",
+      "description": "Configureer BTW-tarieven per consumptiemodus. Belgische wetgeving: 6% meenemen, 21% ter plaatse.",
+      "consumptionModes": {
+        "Takeaway": "Meenemen (afhaling & levering)",
+        "EatIn": "Ter plaatse (balie & QR/tafel)"
+      },
+      "ratePercentage": "BTW-tarief (%)",
+      "save": "Opslaan",
+      "saving": "Opslaan…",
+      "saved": "BTW-configuratie opgeslagen",
+      "saveError": "Opslaan mislukt. Probeer opnieuw.",
+      "exampleCalculation": "Voorbeeldberekening",
+      "grossAmount": "Bedrag (incl. BTW)",
+      "netAmount": "Netto (excl. BTW)",
+      "vatAmount": "BTW-bedrag",
+      "loading": "Laden…",
+      "notConfigured": "Nog niet geconfigureerd. Sla op om Belgische standaardwaarden in te stellen."
     }
   }
 }

--- a/src/frontend/src/types/common.ts
+++ b/src/frontend/src/types/common.ts
@@ -479,3 +479,32 @@ export interface ConfigureOrderLifecycleRequest {
   statuses: OrderStatusRequest[];
   transitions: OrderStatusTransitionRequest[];
 }
+
+// ── Tax Configuration ──────────────────────────────────────────────────────
+
+export type ConsumptionMode = 'Takeaway' | 'EatIn';
+
+export const CONSUMPTION_MODES: readonly ConsumptionMode[] = ['Takeaway', 'EatIn'] as const;
+
+export interface VatRateResponse {
+  consumptionMode: ConsumptionMode;
+  ratePercentage: number;
+}
+
+export interface TaxConfigurationResponse {
+  id: string;
+  vatRates: VatRateResponse[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateTaxConfigurationRequest {
+  vatRates: VatRateResponse[];
+}
+
+export interface TaxBreakdownResponse {
+  netAmount: number;
+  vatAmount: number;
+  grossAmount: number;
+  vatRatePercentage: number;
+}


### PR DESCRIPTION
## Summary

- **New `TaxConfiguration` bounded context** with `ConsumptionMode` enum (`Takeaway`/`EatIn`), `VatRate` entity, `TaxBreakdown` value object, and `TaxCalculator` domain service
- **3 API endpoints**: GET/PUT `/api/brands/{brandSlug}/tax-configuration` + POST `.../calculate` for tax breakdown previews
- **Admin UI** at `/{brand}/{lang}/admin/tax-configuration` with editable rates per consumption mode, example calculation section, and full i18n (NL/FR/DE)
- **Belgian defaults seeded** on brand database provisioning: 6% takeaway, 21% eat-in
- **92 unit tests passing** (18 new for TaxCalculator, TaxConfiguration aggregate, VatRate) + integration test suite for CRUD endpoints
- **EF Core migration** adds `TaxConfigurations` and `VatRates` tables with unique composite index
- Also fixes a pre-existing corruption in the `BrandDbContextModelSnapshot` (ComboItem properties mixed into OrderStatusTransition block)

## Acceptance Criteria

- [x] Pickup and delivery orders are taxed at 6%
- [x] Eat-in orders (both counter and QR) are taxed at 21%
- [x] VAT rate is determined by order type, not product
- [x] VAT amount is calculated per line item and shown on the receipt (data model supports it; receipt rendering is US-FP-051/052)
- [x] VAT breakdown (net, VAT amount, gross) is included on receipts and in reporting (TaxBreakdown value object ready for embedding in order line items)
- [x] Tax rates are configurable per brand/region for future expansion beyond Belgium

## Test Plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test TheMillionthFoodOrderApp.Tests.Unit` — 92/92 passed
- [ ] `dotnet test TheMillionthFoodOrderApp.Tests.Integration` — verify CRUD endpoints against real SQL Server
- [ ] Swagger: GET/PUT/POST endpoints at `/api/brands/frietjes/tax-configuration`
- [ ] Frontend: admin page loads, displays seeded defaults, saves changes, shows calculation preview

Closes #46