### PR TITLE
feat(storefront): language selector with locale persistence (US-FP-031)

### DIFF
--- a/src/frontend/src/components/AppVariantLayout.tsx
+++ b/src/frontend/src/components/AppVariantLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, NavLink, useParams } from 'react-router-dom';
 import type { AppVariant } from './useAppVariant';
+import { LanguageSelector } from '@features/storefront/components/LanguageSelector';
 
 interface Props {
   variant: AppVariant;
@@ -30,6 +31,8 @@ export function AppVariantLayout({ variant }: Props) {
         }}
       >
         <span style={{ fontWeight: 600 }}>{VARIANT_LABELS[variant]}</span>
+
+        {variant === 'storefront' && <LanguageSelector />}
 
         {variant === 'admin' && brandSlug && lang && (
           <nav style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>

--- a/src/frontend/src/features/storefront/components/LanguageSelector.tsx
+++ b/src/frontend/src/features/storefront/components/LanguageSelector.tsx
@@ -1,0 +1,73 @@
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import type { SupportedLocale } from '@/types/common';
+
+const LOCALES: SupportedLocale[] = ['nl', 'fr', 'de'];
+
+const LOCALE_LABELS: Record<SupportedLocale, string> = {
+  nl: 'NL',
+  fr: 'FR',
+  de: 'DE',
+};
+
+/** localStorage key for the user's explicit language preference. */
+export const LANGUAGE_PREF_KEY = 'language-preference';
+
+/**
+ * NL / FR / DE toggle rendered in the storefront header.
+ *
+ * On selection:
+ * - Saves the chosen locale to localStorage so the root redirect can restore it on the next visit.
+ * - Navigates to the same URL path but with the new lang segment.
+ */
+export function LanguageSelector() {
+  const { brandSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { t } = useTranslation('common');
+
+  function handleSelect(locale: SupportedLocale) {
+    if (!brandSlug || !lang || locale === lang) return;
+
+    localStorage.setItem(LANGUAGE_PREF_KEY, locale);
+
+    // Replace only the lang segment in the current path so sub-routes are preserved.
+    const newPathname = location.pathname.replace(
+      `/${brandSlug}/${lang}`,
+      `/${brandSlug}/${locale}`,
+    );
+    navigate({ pathname: newPathname, search: location.search }, { replace: false });
+  }
+
+  return (
+    <nav
+      aria-label={t('storefront.languageSelector.ariaLabel')}
+      style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}
+    >
+      {LOCALES.map((locale) => {
+        const isActive = lang === locale;
+        return (
+          <button
+            key={locale}
+            onClick={() => handleSelect(locale)}
+            aria-current={isActive ? 'true' : undefined}
+            disabled={isActive}
+            style={{
+              padding: '0.25rem 0.5rem',
+              fontSize: '0.75rem',
+              fontWeight: isActive ? 700 : 400,
+              background: isActive ? '#111827' : 'transparent',
+              color: isActive ? '#fff' : '#374151',
+              border: '1px solid #e5e7eb',
+              borderRadius: '0.25rem',
+              cursor: isActive ? 'default' : 'pointer',
+              lineHeight: 1.4,
+            }}
+          >
+            {LOCALE_LABELS[locale]}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -3,7 +3,10 @@
   "loading": "Wird geladen…",
   "error": "Ein Fehler ist aufgetreten",
   "storefront": {
-    "description": "Sehen Sie unsere Speisekarte und geben Sie Ihre Bestellung auf."
+    "description": "Sehen Sie unsere Speisekarte und geben Sie Ihre Bestellung auf.",
+    "languageSelector": {
+      "ariaLabel": "Sprache wählen"
+    }
   },
   "pos": {
     "description": "Kassensystem für den Laden."

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -3,7 +3,10 @@
   "loading": "Chargement…",
   "error": "Une erreur s'est produite",
   "storefront": {
-    "description": "Consultez notre menu et passez votre commande."
+    "description": "Consultez notre menu et passez votre commande.",
+    "languageSelector": {
+      "ariaLabel": "Choisir la langue"
+    }
   },
   "pos": {
     "description": "Système de caisse en magasin."

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -3,7 +3,10 @@
   "loading": "Laden…",
   "error": "Er is iets misgegaan",
   "storefront": {
-    "description": "Bekijk ons menu en plaats uw bestelling."
+    "description": "Bekijk ons menu en plaats uw bestelling.",
+    "languageSelector": {
+      "ariaLabel": "Taal selecteren"
+    }
   },
   "pos": {
     "description": "Kassasysteem voor in de winkel."

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -1,5 +1,7 @@
 import { lazy } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { extractPrimaryLocale } from '@/types/common';
+import { LANGUAGE_PREF_KEY } from '@features/storefront/components/LanguageSelector';
 import { AppShell } from '@components/AppShell';
 import { AppVariantLayout } from '@components/AppVariantLayout';
 import { SuspenseWrapper } from '@components/SuspenseWrapper';
@@ -19,11 +21,30 @@ const LazyPosDashboard = lazy(() =>
   import('@features/pos/pages/Dashboard').then((m) => ({ default: m.PosDashboard })),
 );
 
+/**
+ * Resolves the initial locale for the root redirect.
+ * Priority: explicit user preference (localStorage) → browser language → 'nl' (fallback).
+ */
+function resolveInitialLocale(): string {
+  const saved = localStorage.getItem(LANGUAGE_PREF_KEY);
+  if (saved) return saved;
+  return extractPrimaryLocale(navigator.language);
+}
+
+/**
+ * Root redirect component — re-evaluates on every render so that changes to
+ * the stored language preference are picked up when the user returns to "/".
+ */
+function RootRedirect() {
+  return <Navigate to={`/demo/${resolveInitialLocale()}`} replace />;
+}
+
 export const router = createBrowserRouter([
   {
-    // Root redirect: send bare "/" to the default brand/locale
+    // Root redirect: send bare "/" to the default brand/locale.
+    // Uses the saved language preference or browser locale; falls back to Dutch.
     path: '/',
-    element: <Navigate to="/demo/nl" replace />,
+    element: <RootRedirect />,
   },
   {
     // Layout route shared by all three app variants


### PR DESCRIPTION
Implements US-FP-031: NL/FR/DE language toggle in the storefront header with localStorage persistence and browser-locale detection for the initial redirect.

Closes #31

Generated with [Claude Code](https://claude.ai/code)