### PR TITLE
docs: add architecture diagrams and update planning docs

### DIFF
--- a/.claude/skills/backend-dotnet/docs/fast-endpoints.md
+++ b/.claude/skills/backend-dotnet/docs/fast-endpoints.md
@@ -6,37 +6,52 @@ API endpoint framework — one class per endpoint, replaces controllers and Medi
 ## Patterns
 
 ### Endpoint Structure
-One class per endpoint. Request/response records + validator + endpoint class in the same file (or split for large validators).
+One class per endpoint. Keep the request record, endpoint class, and validator in the same file, in this order: **request first, endpoint second, validator last** (or split into separate files for large validators).
 
 ```csharp
-public sealed record GetThingRequest([property: RouteParam] string Slug);
+public sealed record UpdateThingRequest(
+    [property: RouteParam] string Slug,
+    string Name,
+    string Currency);
 
-public sealed class GetThingEndpoint(IThingService service)
-    : Endpoint<GetThingRequest, ThingResponse>
+public sealed class UpdateThingEndpoint(IThingService service)
+    : Endpoint<UpdateThingRequest, ThingResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/things/{slug}";
+
     public override void Configure()
     {
-        Get("/api/things/{slug}");
+        Put(Route);
         AllowAnonymous(); // or Roles("Admin"), Policies("BrandAccess"), etc.
-        PreProcessor<BrandScopedPreProcessor<GetThingRequest>>(); // for brand-scoped routes
+        PreProcessor<BrandScopedPreProcessor<UpdateThingRequest>>(); // for brand-scoped routes
         Summary(s =>
         {
-            s.Summary = "Get a thing";
-            s.Description = "Returns the thing for the given slug.";
-            s.Response<ThingResponse>(200, "Thing found.");
+            s.Summary = "Update a thing";
+            s.Description = "Updates the thing for the given slug.";
+            s.Response<ThingResponse>(200, "Thing updated.");
+            s.Response(400, "Validation error.");
             s.Response(404, "Thing not found.");
         });
     }
 
-    public override async Task HandleAsync(GetThingRequest req, CancellationToken ct)
+    public override async Task HandleAsync(UpdateThingRequest req, CancellationToken ct)
     {
-        var result = await service.GetAsync(req.Slug, ct);
+        var result = await service.UpdateAsync(req, ct);
         if (result is null)
         {
             await HttpContext.Response.SendNotFoundAsync(ct);
             return;
         }
         await HttpContext.Response.SendAsync(result, statusCode: 200, cancellation: ct);
+    }
+}
+
+public sealed class UpdateThingValidator : Validator<UpdateThingRequest>
+{
+    public UpdateThingValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Currency).Length(3); // ISO 4217
     }
 }
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,51 @@ Backend starts API (http://localhost:5102), BFF (http://localhost:5261), SQL Ser
 
 Mock auth is enabled by default in dev — no external services needed. Visit `/bff/login?mock=brand-admin@frietjes` to sign in with a test persona. Set `Authentication:UseMockAuth=false` to use Keycloak.
 
+## System Architecture
+
+```mermaid
+graph TB
+    subgraph Frontend["Frontend Layer (port 5173)"]
+        SF[Storefront<br/>Customer PWA]
+        AD[Admin Panel<br/>Brand CMS]
+        POS[POS<br/>In-Store]
+    end
+
+    subgraph BFF["BFF Layer (port 5261)"]
+        AUTH[BFF .NET<br/>OIDC + Sessions]
+        YARP[YARP Proxy<br/>+ Bearer Token]
+    end
+
+    subgraph API["API Layer (port 5102)"]
+        FE[FastEndpoints<br/>42 routes]
+        APP[Application<br/>12 services]
+        DOM[Domain<br/>9 aggregates]
+    end
+
+    subgraph Infra["Infrastructure"]
+        PDB[(PlatformDb<br/>shared)]
+        BDB[(BrandDb<br/>per-brand)]
+        KC[Keycloak<br/>OIDC]
+    end
+
+    ASPIRE([.NET Aspire Orchestrator])
+
+    SF & AD & POS -->|"/api/* + /bff/*"| AUTH
+    AUTH --> YARP
+    YARP -->|"Bearer tokens"| FE
+    FE --> APP --> DOM
+    APP --> PDB & BDB
+    AUTH -.-> KC
+    ASPIRE -.->|manages| PDB & BDB & KC
+
+    style Frontend fill:#dbe4ff,stroke:#4a9eed
+    style BFF fill:#e5dbff,stroke:#8b5cf6
+    style API fill:#d3f9d8,stroke:#22c55e
+    style Infra fill:#f0fdf4,stroke:#22c55e
+```
+
+Domain bounded contexts and tech stack are detailed in the nested CLAUDE.md files (see backend and frontend).
+
 ## Key Architecture Decisions
 
 - **Database:** Azure SQL with database-per-brand isolation — one SQL Server instance, platform DB for shared data, brand DBs created dynamically at runtime

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,16 @@ Mock auth is enabled by default in dev — no external services needed. Visit `/
 - Orders: online + in-store channels, configurable lifecycle per shop
 - Belgian market: VAT (6% takeaway / 21% eat-in), languages (NL, FR, DE)
 
+## Planning & User Stories
+
+The [dependency tree](docs/dependency-tree.md) is the **source of truth** for what to build next. It tracks all 70 user stories (US-FP-001 through US-FP-070) across 5 layers with dependency chains and completion status. Always consult it when:
+- Deciding which story to work on next (pick stories whose dependencies are all ✅)
+- Understanding what a story unlocks downstream
+- Planning parallel work across worktrees (4-worktree strategy documented there)
+
+Full user stories: `docs/extract-prd/user-stories/frietjes-platform.md`
+PRD: `docs/extract-prd/new-app/frietjes-platform.md`
+
 ## Repository
 
 https://github.com/OoyeM/TheMillionthFoodOrderApp.git

--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -83,7 +83,7 @@ Once brands + shops exist, these streams are **independent of each other**.
 |--------|-------|-------------|------------|
 | ✅ | **US-FP-029** | Configure brand theming | 001 |
 | ✅ | **US-FP-030** | Provide translations for product catalog | 005 |
-| ⬜ | **US-FP-031** | Select language on the storefront | 030 |
+| ✅ | **US-FP-031** | Select language on the storefront | 030 |
 | ⬜ | **US-FP-067** | Configure custom domain for brand | 029 |
 
 > **Note:** 030 and 031 depend on products (Stream A), so they can start once 005 is done.

--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -1,7 +1,7 @@
 # User Story Dependency Tree & Progress Tracker
 
 > Generated from [frietjes-platform.md](./extract-prd/user-stories/frietjes-platform.md)
-> Last updated: 2026-03-15
+> Last updated: 2026-04-09
 
 ## Progress Legend
 
@@ -205,17 +205,17 @@ Once ordering works, these streams are **all independent**.
 ## Visual Summary
 
 ```
-L0: [069✅] → [061🚧] → [001🚧] → [070🚧] → [004✅] → [002]
+L0: [069✅] → [061✅] → [001✅] → [070✅] → [004✅] → [002✅]
 
-L1: [A: Products]   [B: Auth/Staff]   [C: Shop Config]   [D: Branding]     ← 4 parallel
+L1: [A: Products✅]  [B: Auth/Staff🚧]  [C: Shop Config🚧]  [D: Branding✅]  ← 4 parallel
          │                │                  │
-L2: [046 VAT] [068 Realtime] → [016 Ordering] → [058/017/018]              ← ordering core
-                                     │
-L3: [E: Kitchen] [F: Customer] [G: Shop Mgmt] [H: Loyalty] [I: Reports]    ← 5 parallel
+L2: [046✅ VAT] [068✅ Realtime] → [016 Ordering] → [058/017/018]             ← ordering core
+                                        │
+L3: [E: Kitchen] [F: Customer] [G: Shop Mgmt] [H: Loyalty] [I: Reports]      ← 5 parallel
          │            │
-L4: [J: Receipts] [K: Offline] [L: PWA] [M: Scheduling]                    ← 4 parallel
+L4: [J: Receipts] [K: Offline] [L: PWA] [M: Scheduling]                      ← 4 parallel
          │
-L5: [060 Dashboard] [045 Inventory] [038 Guest polish]                      ← polish
+L5: [060 Dashboard] [045 Inventory] [038 Guest polish]                        ← polish
 ```
 
 ## Worktree Strategy (4 worktrees)

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -1,5 +1,68 @@
 # Backend — CLAUDE.md
 
+## Architecture Diagrams
+
+```mermaid
+graph TB
+    subgraph API["API (port 5102)"]
+        FE[FastEndpoints<br/>42 routes]
+        APP[Application Layer<br/>12 services]
+        DOM[Domain Layer<br/>9 aggregates]
+        INF[Infrastructure<br/>EF Core + SignalR]
+    end
+
+    subgraph Data["Data Stores"]
+        PDB[(PlatformDb<br/>shared)]
+        BDB[(BrandDb<br/>per-brand)]
+    end
+
+    BFF[BFF :5261] -->|"YARP + Bearer"| FE
+    FE --> APP --> DOM
+    APP --> INF
+    INF --> PDB & BDB
+    INF -->|Wolverine| DOM
+
+    style API fill:#d3f9d8,stroke:#22c55e
+    style Data fill:#c3fae8,stroke:#06b6d4
+```
+
+```mermaid
+graph TB
+    subgraph Foundation["Foundation"]
+        Brand[Brand] --> Shop[Shop]
+        Brand --> PlatformUser
+        PlatformUser --> BrandUserRole
+    end
+
+    subgraph Products["Stream A: Products ✅"]
+        Product -->|has| ModifierGroup
+        Product -->|in| MenuCategory
+    end
+
+    subgraph Config["Stream C: Config"]
+        OrderLifecycleConfig
+        TaxConfiguration
+        BrandSettings
+    end
+
+    subgraph Ordering["Ordering Core (next)"]
+        Order["Order ⬜"]
+        OrderHub["SignalR Hub ✅"]
+    end
+
+    Brand -.-> Product
+    Shop -.-> OrderLifecycleConfig
+    Product -.-> Order
+    TaxConfiguration -.-> Order
+    OrderLifecycleConfig -.-> Order
+    Order -->|real-time| OrderHub
+
+    style Foundation fill:#dbe4ff,stroke:#4a9eed
+    style Products fill:#d3f9d8,stroke:#22c55e
+    style Config fill:#e5dbff,stroke:#8b5cf6
+    style Ordering fill:#fff3bf,stroke:#f59e0b
+```
+
 ## Tech Stack
 
 - .NET (C#), ASP.NET Web API, .NET Aspire
@@ -18,13 +81,15 @@
 ## Solution Structure
 
 ```
-TheMillionthFoodOrderApp.AppHost/        — .NET Aspire orchestrator (run this)
-TheMillionthFoodOrderApp.Api/            — FastEndpoints API host (http://localhost:5102, Swagger at /swagger)
-TheMillionthFoodOrderApp.Bff/            — Backend-for-frontend (auth/session, YARP proxy to API)
-TheMillionthFoodOrderApp.Application/    — Use cases, services, DTOs
-TheMillionthFoodOrderApp.Domain/         — DDD aggregates, entities, value objects, domain events
-TheMillionthFoodOrderApp.Infrastructure/ — EF Core (PlatformDbContext, BrandDbContext), repositories
-TheMillionthFoodOrderApp.ServiceDefaults/ — Aspire shared config (telemetry, health)
+TheMillionthFoodOrderApp.AppHost/            — .NET Aspire orchestrator (run this)
+TheMillionthFoodOrderApp.Api/                — FastEndpoints API host (http://localhost:5102, Swagger at /swagger)
+TheMillionthFoodOrderApp.Bff/                — Backend-for-frontend (auth/session, YARP proxy to API)
+TheMillionthFoodOrderApp.Application/        — Use cases, services, DTOs
+TheMillionthFoodOrderApp.Domain/             — DDD aggregates, entities, value objects, domain events
+TheMillionthFoodOrderApp.Infrastructure/     — EF Core (PlatformDbContext, BrandDbContext), repositories, SignalR
+TheMillionthFoodOrderApp.ServiceDefaults/    — Aspire shared config (telemetry, health)
+TheMillionthFoodOrderApp.Tests.Unit/         — xUnit unit tests (Shouldly assertions)
+TheMillionthFoodOrderApp.Tests.Integration/  — Integration tests (Testcontainers, real SQL Server)
 ```
 
 ## Local Development
@@ -72,12 +137,93 @@ This project uses **.NET Aspire** as the orchestrator. Aspire's `Add*` extension
 - `dotnet ef migrations add <Name> --project TheMillionthFoodOrderApp.Infrastructure --startup-project TheMillionthFoodOrderApp.Api --context PlatformDbContext --output-dir Persistence/Migrations/Platform` — add platform migration
 - `dotnet ef migrations add <Name> --project TheMillionthFoodOrderApp.Infrastructure --startup-project TheMillionthFoodOrderApp.Api --context BrandDbContext --output-dir Persistence/Migrations/Brand` — add brand migration
 
+## Domain Bounded Contexts
+
+```
+Domain/
+  Brands/              — Brand aggregate (name, slug, active status, StaffAuthMethod enum)
+  Shops/               — Shop aggregate, Address value object, OpeningHoursTimeBlock, ShopCreatedEvent
+  Products/            — Product aggregate (simple, modifier groups, combos), ProductTranslation, ComboItem
+  ModifierGroups/      — ModifierGroup aggregate, Modifier, ProductModifierGroup, translations
+  MenuCategories/      — MenuCategory aggregate, MenuCategoryTranslation
+  BrandSettings/       — BrandSettings aggregate, BrandColors/BrandTypography value objects, PresetFonts
+  Identity/            — PlatformUser aggregate, BrandUserRole entity, StaffRole enum
+  OrderLifecycle/      — OrderLifecycleConfig aggregate, OrderStatus, OrderStatusTransition
+  TaxConfiguration/    — TaxConfiguration aggregate, VatRate entity, TaxCalculator, TaxBreakdown value object
+  Orders/              — OrderStatusChangedEvent (domain event for SignalR)
+  Common/              — AggregateRoot, Entity, ValueObject base classes; Money VO; ConsumptionMode enum; IAuditable, ISoftDeletable interfaces
+```
+
+## Domain Aggregates & Marker Interfaces
+
+| Aggregate | IAuditable | ISoftDeletable |
+|-----------|:----------:|:--------------:|
+| Brand | ✅ | — |
+| Shop | ✅ | — |
+| Product | ✅ | ✅ |
+| ModifierGroup | ✅ | ✅ |
+| MenuCategory | ✅ | ✅ |
+| BrandSettings | ✅ | — |
+| PlatformUser | ✅ | — |
+| OrderLifecycleConfig | ✅ | — |
+| TaxConfiguration | ✅ | — |
+
+## Domain Enums
+
+- `Allergen` — 14 EU allergens (Products)
+- `DietaryTag` — dietary labels (Products)
+- `ProductType` — simple / combo (Products)
+- `StaffAuthMethod` — auth method per brand (Brands)
+- `StaffRole` — brand-admin, counter-staff, etc. (Identity)
+- `ConsumptionMode` — eat-in / takeaway (Common, used by VAT)
+- `BrandValidationResult` — middleware validation outcomes (Application/Multitenancy)
+
+## Application Layer Pattern
+
+Each bounded context follows `IXxxService` (interface in Application) → `XxxService` (implementation in Application). `IFileStorageService` → `LocalFileStorageService` lives in Infrastructure.
+
+## Infrastructure Conventions
+
+- **EF entity configurations:** One `IEntityTypeConfiguration<T>` per entity (e.g. `BrandConfiguration`, `MenuCategoryConfiguration`)
+- **AuditSaveChangesInterceptor** — auto-sets CreatedAt/UpdatedAt on entities implementing `IAuditable`
+- **DateTimeOffsetConvention** — ensures all DateTimeOffset properties use `datetimeoffset(7)` SQL type
+- **BrandDbSeeder** — seeds default data (e.g. Frietjes brand, sample products) in dev
+
 ## Domain Patterns
 
 - **Soft-delete:** Implement `ISoftDeletable` (IsDeleted + DeletedAt). Add a global query filter on `BrandDbContext`: `HasQueryFilter(e => !e.IsDeleted)`. Use `IgnoreQueryFilters()` only when historical data is needed.
 - **Translations:** Use a child entity (e.g. `ProductTranslation`) with composite unique index on `(ParentId, LanguageCode)`. Load eagerly with `Include()`. On update, clear the collection and re-add — avoids EF Core orphan tracking issues.
 - **Money:** `Money` value object (Amount + Currency), mapped as EF owned entity with explicit column names (`BasePrice_Amount`, `BasePrice_Currency`).
 - **Sort ordering:** Use an `int SortOrder` field. Reorder via a dedicated endpoint that accepts an ordered list of IDs and assigns 0..n-1 sequentially. Last-write-wins for MVP.
+- **Domain events:** Wolverine handles domain events in-memory (e.g. `ShopCreatedEvent` triggers brand DB provisioning, `OrderStatusChangedEvent` triggers SignalR notifications).
+
+## Real-Time Notifications
+
+- **SignalR** hub at `OrderHub` — pushes order status changes to connected clients
+- `IOrderNotificationService` abstraction in Application, `SignalROrderNotificationService` in Infrastructure
+- `OrderStatusChangedHandler` (Wolverine handler) bridges domain events to SignalR
+- Frontend connects via `@microsoft/signalr` client (`useSignalR`, `useOrderUpdates` hooks)
+
+## API Routes (42 endpoints)
+
+All brand-scoped routes are prefixed with `/brands/{brandSlug}/` and guarded by `BrandScopedPreProcessor`.
+
+| Resource | Routes |
+|----------|--------|
+| Brands | `GET/POST /brands`, `GET/PUT /brands/:id`, `POST .../activate`, `POST .../deactivate` |
+| Staff Auth | `PUT /brands/:slug/staff-auth` |
+| Shops | `GET/POST /brands/:slug/shops`, `GET/PUT /brands/:slug/shops/:id`, `POST .../activate`, `POST .../deactivate` |
+| Opening Hours | `GET/PUT /brands/:slug/shops/:shopId/opening-hours`, `GET .../status` |
+| Order Lifecycle | `GET/PUT /brands/:slug/shops/:shopId/order-lifecycle`, `POST .../reset` |
+| Staff | `GET/POST /brands/:slug/staff`, `GET /brands/:slug/shops/:shopId/staff`, `POST .../staff/:roleId/deactivate` |
+| Products | `GET/POST /brands/:slug/products`, `GET/PUT/DELETE /brands/:slug/products/:id` |
+| Combos | `POST /brands/:slug/combo-products`, `PUT /brands/:slug/combo-products/:id` |
+| Modifier Groups | `GET/POST /brands/:slug/modifier-groups`, `GET/PUT/DELETE .../modifier-groups/:id`, `GET /brands/:slug/products/:productId/modifier-groups` |
+| Menu Categories | `GET/POST /brands/:slug/menu-categories`, `GET/PUT/DELETE .../menu-categories/:id`, `PUT .../sort-order`, `POST .../assign-product`, `GET .../menu-categories/:catId/products`, `PUT .../products/order` |
+| Brand Settings | `GET/PUT /brands/:slug/settings`, `PUT .../settings/theming`, `POST .../settings/logo`, `GET /brands/:slug/theme` |
+| Tax Config | `GET/PUT /brands/:slug/tax-configuration`, `POST .../calculate` |
+| Platform Admins | `GET/POST /platform-admins`, `POST /platform-admins/:id/deactivate` |
+| Orders (infra) | `POST /brands/:slug/orders/simulate-status-change` (dev-only) |
 
 ## Domain Constraints
 

--- a/src/frontend/CLAUDE.md
+++ b/src/frontend/CLAUDE.md
@@ -1,5 +1,39 @@
 # Frontend — CLAUDE.md
 
+## Architecture Diagrams
+
+```mermaid
+graph TB
+    subgraph Apps["Three Apps — One Codebase"]
+        SF[Storefront<br/>Customer PWA]
+        AD[Admin Panel<br/>Brand CMS]
+        POS[POS<br/>In-Store Touch]
+    end
+
+    subgraph Core["Shared Core"]
+        Shell[AppShell<br/>Brand + Lang routing]
+        Auth[Auth Module<br/>Mock / BFF providers]
+        API[API Clients<br/>16 modules]
+        TQ[TanStack Query<br/>Hooks per feature]
+        I18N[i18n<br/>NL / FR / DE]
+        SIG[SignalR Client<br/>useOrderUpdates]
+    end
+
+    subgraph Backend["Backend (via BFF proxy)"]
+        BFF["/api/* → BFF :5261"]
+    end
+
+    SF & AD & POS --> Shell
+    Shell --> Auth & API
+    API --> TQ
+    API --> SIG
+    TQ & SIG --> BFF
+
+    style Apps fill:#dbe4ff,stroke:#4a9eed
+    style Core fill:#f0fdf4,stroke:#22c55e
+    style Backend fill:#e5dbff,stroke:#8b5cf6
+```
+
 ## Tech Stack
 
 - React + TypeScript, Vite, pnpm
@@ -13,11 +47,31 @@
 - URL structure: `/{brand}/{lang}/...` — brand and language resolved by AppShell
 - Admin panel: `/{brand}/{lang}/admin/brands` for brand management
 - Feature-based folder structure: `src/features/{storefront,pos,admin}/`
+- Shared components in `src/components/` — AppShell, AppVariantLayout, ErrorBoundary, SuspenseWrapper
 - API client modules in `src/api/` — axios with Vite proxy to BFF (`/api/*` and `/bff/*` → `http://localhost:5261`)
 - Auth module in `src/auth/` — AuthContext, providers, route guards, session keepalive
 - TanStack Query hooks per feature in `src/features/*/hooks/`
+- SignalR client in `src/api/signalr.ts` with hooks: `useSignalR`, `useOrderUpdates`
 - Strict TypeScript — no `any`
-- i18n from day one: NL, FR, DE (react-i18next)
+- i18n from day one: NL, FR, DE (react-i18next) — locale files in `src/i18n/locales/{nl,fr,de}/`
+
+## Admin Panel Pages
+
+Brand CRUD (list/create/edit), brand theming, shop CRUD (list/create/edit), shop opening hours, shop order lifecycle, product CRUD (list/create/edit), combo product CRUD, modifier group CRUD, menu category CRUD (list/create/edit), platform admin list, staff list, tax configuration, dashboard
+
+## Type Definitions (`src/types/`)
+
+- `auth.ts` — `AuthUser`, `AuthState` interfaces
+- `common.ts` — shared domain types: `Brand`, `BrandSettings`, `BrandColors`, `BrandTypography`, `BrandTheme`, `ComboItemResponse`, `ConfigureOrderLifecycleRequest`, and all API request/response shapes
+
+## Storefront
+
+- Components: `LanguageSelector` (NL/FR/DE switcher with locale persistence), `ThemeProvider` (brand theming), `ShopStatusBadge`
+- Pages: Home
+
+## POS
+
+- Pages: Dashboard (placeholder)
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- Add mermaid architecture diagrams: system overview (root), domain bounded contexts + layering (backend), app/core/BFF wiring (frontend)
- Document backend domain aggregates, enums, infra conventions, SignalR pattern, and the 42 API routes
- Refresh dependency tree: Layer 0-2 foundation stories complete (US-FP-001/002/031/046/061/068/070 marked ✅); mark US-FP-031 done and add Planning section to root CLAUDE.md
- Tighten FastEndpoints skill: canonical request/endpoint/validator ordering with `Route` const and validator example

## Test plan
- [ ] Render the mermaid blocks in GitHub PR preview to confirm diagrams display correctly
- [ ] Skim nested CLAUDE.md files as self-contained references (not relying on root)
- [ ] Verify dependency-tree status ticks match current merged work

🤖 Generated with [Claude Code](https://claude.com/claude-code)