### PR TITLE
refactor: extract Route const in ComboProducts endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ComboProducts/CreateComboProductEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ComboProducts/CreateComboProductEndpoint.cs
@@ -61,9 +61,11 @@ public sealed class CreateComboProductRequestValidator : Validator<CreateComboPr
 public sealed class CreateComboProductEndpoint(IProductService productService)
     : Endpoint<CreateComboProductApiRequest, ProductResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/combo-products";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/combo-products");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ComboProducts/UpdateComboProductEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ComboProducts/UpdateComboProductEndpoint.cs
@@ -65,9 +65,11 @@ public sealed class UpdateComboProductRequestValidator : Validator<UpdateComboPr
 public sealed class UpdateComboProductEndpoint(IProductService productService)
     : Endpoint<UpdateComboProductApiRequest, ProductResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/combo-products/{id}";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/combo-products/{id}");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {


### PR DESCRIPTION
## Summary
- Extract hard-coded route strings in `CreateComboProductEndpoint` and `UpdateComboProductEndpoint` into `public const string Route = ...` members, bringing both endpoints into conformance with the canonical FastEndpoints pattern documented in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- `Configure()` now calls `Post(Route)` / `Put(Route)` instead of embedding the literal path.
- No functional changes: request types, validators, handlers, HTTP verbs, and route values are unchanged.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors)
- [ ] Integration tests not run (require Docker, out of scope per task)

Generated with [Claude Code](https://claude.com/claude-code)