### PR TITLE
refactor: extract Route const in BrandSettings endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/GetBrandSettingsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/GetBrandSettingsEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record GetBrandSettingsRequest([property: RouteParam] string Brand
 public sealed class GetBrandSettingsEndpoint(IBrandSettingsService brandSettingsService)
     : Endpoint<GetBrandSettingsRequest, BrandSettingsResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/settings";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/settings");
+        Get(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<GetBrandSettingsRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/GetBrandThemeEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/GetBrandThemeEndpoint.cs
@@ -12,9 +12,11 @@ public sealed record GetBrandThemeRequest([property: RouteParam] string BrandSlu
 public sealed class GetBrandThemeEndpoint(IBrandSettingsService brandSettingsService)
     : Endpoint<GetBrandThemeRequest, BrandThemeResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/theme";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/theme");
+        Get(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<GetBrandThemeRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/UpdateBrandSettingsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/UpdateBrandSettingsEndpoint.cs
@@ -31,9 +31,11 @@ public sealed class UpdateBrandSettingsRequestValidator : Validator<UpdateBrandS
 public sealed class UpdateBrandSettingsEndpoint(IBrandSettingsService brandSettingsService)
     : Endpoint<UpdateBrandSettingsRequest, BrandSettingsResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/settings";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/settings");
+        Put(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<UpdateBrandSettingsRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/UpdateBrandThemingEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/UpdateBrandThemingEndpoint.cs
@@ -62,9 +62,11 @@ public sealed class UpdateBrandThemingRequestValidator : Validator<UpdateBrandTh
 public sealed class UpdateBrandThemingEndpoint(IBrandSettingsService brandSettingsService)
     : Endpoint<UpdateBrandThemingRequest, BrandSettingsResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/settings/theming";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/settings/theming");
+        Put(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<UpdateBrandThemingRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/UploadBrandLogoEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandSettings/UploadBrandLogoEndpoint.cs
@@ -47,9 +47,11 @@ public sealed class UploadBrandLogoRequestValidator : Validator<UploadBrandLogoR
 public sealed class UploadBrandLogoEndpoint(IBrandSettingsService brandSettingsService)
     : Endpoint<UploadBrandLogoRequest, UploadBrandLogoResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/settings/logo";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/settings/logo");
+        Post(Route);
         AllowAnonymous();
         AllowFileUploads();
         PreProcessor<BrandScopedPreProcessor<UploadBrandLogoRequest>>();


### PR DESCRIPTION
## Summary
- Adds `public const string Route = "..."` to each of the 5 `BrandSettings` FastEndpoints (Get/Update settings, Get theme, Update theming, Upload logo)
- Replaces the hard-coded string literal passed to `Get`/`Put`/`Post` inside `Configure()` with the `Route` constant
- Brings these endpoints in line with the canonical structure in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`

No behavior change: HTTP verbs, route values, request/response types, validators, pre-processors, and handler bodies are all untouched.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors)
- [ ] Integration tests (out of scope here — require Docker)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)