### PR TITLE
refactor: extract Route const in BrandStaff endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/DeactivateBrandStaffEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/DeactivateBrandStaffEndpoint.cs
@@ -11,9 +11,11 @@ public sealed record DeactivateBrandStaffRequest(
 public sealed class DeactivateBrandStaffEndpoint(IBrandStaffService brandStaffService)
     : Endpoint<DeactivateBrandStaffRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/staff/{roleId}/deactivate";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/staff/{roleId}/deactivate");
+        Post(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<DeactivateBrandStaffRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/InviteBrandStaffEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/InviteBrandStaffEndpoint.cs
@@ -43,9 +43,11 @@ public sealed class InviteBrandStaffRequestValidator : Validator<InviteBrandStaf
 public sealed class InviteBrandStaffEndpoint(IBrandStaffService brandStaffService)
     : Endpoint<InviteBrandStaffRequest, StaffMemberResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/staff";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/staff");
+        Post(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<InviteBrandStaffRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/ListBrandStaffEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/ListBrandStaffEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record ListBrandStaffRequest([property: RouteParam] string BrandSl
 public sealed class ListBrandStaffEndpoint(IBrandStaffService brandStaffService)
     : Endpoint<ListBrandStaffRequest, IReadOnlyList<StaffMemberResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/staff";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/staff");
+        Get(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<ListBrandStaffRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/ListShopStaffEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/ListShopStaffEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record ListShopStaffRequest(
 public sealed class ListShopStaffEndpoint(IBrandStaffService brandStaffService)
     : Endpoint<ListShopStaffRequest, IReadOnlyList<StaffMemberResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/staff";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/shops/{shopId}/staff");
+        Get(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<ListShopStaffRequest>>();
         Summary(s =>


### PR DESCRIPTION
## Summary
- Extract hard-coded route strings in `BrandStaff` FastEndpoints into a `public const string Route` on each endpoint class, per the canonical structure in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Replace the literal in `Configure()` with the new `Route` constant so the route is defined once and can be referenced from tests/clients.
- Covers all four endpoints in `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/BrandStaff/`: `DeactivateBrandStaffEndpoint`, `InviteBrandStaffEndpoint`, `ListBrandStaffEndpoint`, `ListShopStaffEndpoint`.

No behavioral changes: HTTP verbs, route values, request/response types, validator, and handler bodies are untouched.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors)
- [ ] Integration tests skipped (Docker required, out of scope)

Generated with Claude Code