### PR TITLE
refactor: extract Route const in Brands endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/ActivateBrandEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/ActivateBrandEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record ActivateBrandRequest([property: RouteParam] Guid Id);
 public sealed class ActivateBrandEndpoint(IBrandService brandService)
     : Endpoint<ActivateBrandRequest>
 {
+    public const string Route = "/api/brands/{id}/activate";
+
     public override void Configure()
     {
-        Post("/api/brands/{id}/activate");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/ConfigureStaffAuthEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/ConfigureStaffAuthEndpoint.cs
@@ -24,9 +24,11 @@ public sealed class ConfigureStaffAuthRequestValidator : Validator<ConfigureStaf
 public sealed class ConfigureStaffAuthEndpoint(IBrandService brandService)
     : Endpoint<ConfigureStaffAuthRequest, BrandResponse>
 {
+    public const string Route = "/api/brands/{slug}/staff-auth";
+
     public override void Configure()
     {
-        Put("/api/brands/{slug}/staff-auth");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/CreateBrandEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/CreateBrandEndpoint.cs
@@ -39,9 +39,11 @@ public sealed class CreateBrandRequestValidator : Validator<CreateBrandRequest>
 public sealed class CreateBrandEndpoint(IBrandService brandService)
     : Endpoint<CreateBrandRequest, BrandResponse>
 {
+    public const string Route = "/api/brands";
+
     public override void Configure()
     {
-        Post("/api/brands");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/DeactivateBrandEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/DeactivateBrandEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record DeactivateBrandRequest([property: RouteParam] Guid Id);
 public sealed class DeactivateBrandEndpoint(IBrandService brandService)
     : Endpoint<DeactivateBrandRequest>
 {
+    public const string Route = "/api/brands/{id}/deactivate";
+
     public override void Configure()
     {
-        Post("/api/brands/{id}/deactivate");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/GetBrandEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/GetBrandEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record GetBrandRequest([property: RouteParam] Guid Id);
 public sealed class GetBrandEndpoint(IBrandService brandService)
     : Endpoint<GetBrandRequest, BrandResponse>
 {
+    public const string Route = "/api/brands/{id}";
+
     public override void Configure()
     {
-        Get("/api/brands/{id}");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/ListBrandsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/ListBrandsEndpoint.cs
@@ -6,9 +6,11 @@ namespace TheMillionthFoodOrderApp.Api.Endpoints.Brands;
 public sealed class ListBrandsEndpoint(IBrandService brandService)
     : EndpointWithoutRequest<IReadOnlyList<BrandResponse>>
 {
+    public const string Route = "/api/brands";
+
     public override void Configure()
     {
-        Get("/api/brands");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/UpdateBrandEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/UpdateBrandEndpoint.cs
@@ -35,9 +35,11 @@ public sealed class UpdateBrandRequestValidator : Validator<UpdateBrandRequest>
 public sealed class UpdateBrandEndpoint(IBrandService brandService)
     : Endpoint<UpdateBrandRequest, BrandResponse>
 {
+    public const string Route = "/api/brands/{id}";
+
     public override void Configure()
     {
-        Put("/api/brands/{id}");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {


### PR DESCRIPTION
## Summary
- Brings the 7 FastEndpoint classes under `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Brands/` into conformance with the canonical structure documented in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Each endpoint now declares `public const string Route = "..."` above `Configure()`, and the HTTP-verb call inside `Configure()` references that constant.
- Routes, HTTP verbs, request/response types, validators, and handler bodies are unchanged.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors; pre-existing warnings only)
- [ ] Integration tests (require Docker; out of scope for this refactor)

Generated with Claude Code