### PR TITLE
refactor: extract Route const in MenuCategories endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/AssignProductCategoryEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/AssignProductCategoryEndpoint.cs
@@ -24,9 +24,11 @@ public sealed class AssignProductCategoryRequestValidator : Validator<AssignProd
 public sealed class AssignProductCategoryEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<AssignProductCategoryApiRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories/assign-product";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/menu-categories/assign-product");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/CreateMenuCategoryEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/CreateMenuCategoryEndpoint.cs
@@ -53,9 +53,11 @@ public sealed class CreateMenuCategoryRequestValidator : Validator<CreateMenuCat
 public sealed class CreateMenuCategoryEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<CreateMenuCategoryApiRequest, MenuCategoryResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/menu-categories");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/DeleteMenuCategoryEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/DeleteMenuCategoryEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record DeleteMenuCategoryRequest(
 public sealed class DeleteMenuCategoryEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<DeleteMenuCategoryRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories/{id}";
+
     public override void Configure()
     {
-        Delete("/api/brands/{brandSlug}/menu-categories/{id}");
+        Delete(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/GetMenuCategoryEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/GetMenuCategoryEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetMenuCategoryRequest(
 public sealed class GetMenuCategoryEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<GetMenuCategoryRequest, MenuCategoryResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories/{id}";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/menu-categories/{id}");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ListCategoryProductsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ListCategoryProductsEndpoint.cs
@@ -21,9 +21,11 @@ public sealed class ListCategoryProductsRequestValidator : Validator<ListCategor
 public sealed class ListCategoryProductsEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<ListCategoryProductsRequest, IReadOnlyList<ProductListItemResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories/{id}/products";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/menu-categories/{id}/products");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ListMenuCategoriesEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ListMenuCategoriesEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record ListMenuCategoriesRequest([property: RouteParam] string Bra
 public sealed class ListMenuCategoriesEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<ListMenuCategoriesRequest, IReadOnlyList<MenuCategoryListItemResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/menu-categories");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ReorderCategoryProductsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ReorderCategoryProductsEndpoint.cs
@@ -29,9 +29,11 @@ public sealed class ReorderCategoryProductsRequestValidator : Validator<ReorderC
 public sealed class ReorderCategoryProductsEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<ReorderCategoryProductsApiRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories/{id}/products/order";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/menu-categories/{id}/products/order");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ReorderMenuCategoryEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/ReorderMenuCategoryEndpoint.cs
@@ -24,9 +24,11 @@ public sealed class ReorderMenuCategoryRequestValidator : Validator<ReorderMenuC
 public sealed class ReorderMenuCategoryEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<ReorderMenuCategoryApiRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories/{id}/sort-order";
+
     public override void Configure()
     {
-        Patch("/api/brands/{brandSlug}/menu-categories/{id}/sort-order");
+        Patch(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/UpdateMenuCategoryEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/MenuCategories/UpdateMenuCategoryEndpoint.cs
@@ -55,9 +55,11 @@ public sealed class UpdateMenuCategoryRequestValidator : Validator<UpdateMenuCat
 public sealed class UpdateMenuCategoryEndpoint(IMenuCategoryService menuCategoryService)
     : Endpoint<UpdateMenuCategoryApiRequest, MenuCategoryResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/menu-categories/{id}";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/menu-categories/{id}");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {


### PR DESCRIPTION
## Summary
- Extracted hard-coded route strings from each MenuCategories FastEndpoint into a `public const string Route` field, per the canonical pattern in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Replaced the literal in `Configure()` with the `Route` constant for all 9 endpoints (`AssignProductCategory`, `CreateMenuCategory`, `DeleteMenuCategory`, `GetMenuCategory`, `ListCategoryProducts`, `ListMenuCategories`, `ReorderCategoryProducts`, `ReorderMenuCategory`, `UpdateMenuCategory`).
- No behavioural changes; request types, validators, handlers, HTTP verbs, and route values are untouched.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors, pre-existing warnings only).
- [ ] Integration tests (skipped — require Docker, out of scope per task).

Generated with Claude Code