### PR TITLE
refactor: extract Route const in Products endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/CreateProductEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/CreateProductEndpoint.cs
@@ -76,9 +76,11 @@ public sealed class CreateProductRequestValidator : Validator<CreateProductApiRe
 public sealed class CreateProductEndpoint(IProductService productService)
     : Endpoint<CreateProductApiRequest, ProductResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/products";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/products");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/DeleteProductEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/DeleteProductEndpoint.cs
@@ -11,9 +11,11 @@ public sealed record DeleteProductRequest(
 public sealed class DeleteProductEndpoint(IProductService productService)
     : Endpoint<DeleteProductRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/products/{id}";
+
     public override void Configure()
     {
-        Delete("/api/brands/{brandSlug}/products/{id}");
+        Delete(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/GetProductEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/GetProductEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetProductRequest(
 public sealed class GetProductEndpoint(IProductService productService)
     : Endpoint<GetProductRequest, ProductResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/products/{id}";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/products/{id}");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/ListProductsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/ListProductsEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record ListProductsRequest([property: RouteParam] string BrandSlug
 public sealed class ListProductsEndpoint(IProductService productService)
     : Endpoint<ListProductsRequest, IReadOnlyList<ProductListItemResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/products";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/products");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/UpdateProductEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/UpdateProductEndpoint.cs
@@ -78,9 +78,11 @@ public sealed class UpdateProductRequestValidator : Validator<UpdateProductApiRe
 public sealed class UpdateProductEndpoint(IProductService productService)
     : Endpoint<UpdateProductApiRequest, ProductResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/products/{id}";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/products/{id}");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {


### PR DESCRIPTION
## Summary
- Bring every FastEndpoint under `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Products/` into line with the canonical structure documented in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Each endpoint now exposes its route as `public const string Route = "..."` and passes that constant to the HTTP verb method in `Configure()`, replacing the hard-coded string literal.
- Touched files: `CreateProductEndpoint.cs`, `DeleteProductEndpoint.cs`, `GetProductEndpoint.cs`, `ListProductsEndpoint.cs`, `UpdateProductEndpoint.cs`. No changes to request types, response types, validators, handler bodies, HTTP verbs, or route values.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` from `src/backend` — succeeds with 0 errors (pre-existing warnings only).
- [ ] Integration tests (skipped per task — require Docker).

Generated with Claude Code