### PR TITLE
refactor: extract Route const in PlatformAdmins endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/PlatformAdmins/DeactivatePlatformAdminEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/PlatformAdmins/DeactivatePlatformAdminEndpoint.cs
@@ -9,9 +9,11 @@ public sealed record DeactivatePlatformAdminRequest([property: RouteParam] Guid 
 public sealed class DeactivatePlatformAdminEndpoint(IPlatformAdminService platformAdminService)
     : Endpoint<DeactivatePlatformAdminRequest>
 {
+    public const string Route = "/api/platform-admins/{id}/deactivate";
+
     public override void Configure()
     {
-        Post("/api/platform-admins/{id}/deactivate");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/PlatformAdmins/InvitePlatformAdminEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/PlatformAdmins/InvitePlatformAdminEndpoint.cs
@@ -25,9 +25,11 @@ public sealed class InvitePlatformAdminRequestValidator : Validator<InvitePlatfo
 public sealed class InvitePlatformAdminEndpoint(IPlatformAdminService platformAdminService)
     : Endpoint<InvitePlatformAdminRequest, PlatformAdminResponse>
 {
+    public const string Route = "/api/platform-admins";
+
     public override void Configure()
     {
-        Post("/api/platform-admins");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/PlatformAdmins/ListPlatformAdminsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/PlatformAdmins/ListPlatformAdminsEndpoint.cs
@@ -6,9 +6,11 @@ namespace TheMillionthFoodOrderApp.Api.Endpoints.PlatformAdmins;
 public sealed class ListPlatformAdminsEndpoint(IPlatformAdminService platformAdminService)
     : EndpointWithoutRequest<IReadOnlyList<PlatformAdminResponse>>
 {
+    public const string Route = "/api/platform-admins";
+
     public override void Configure()
     {
-        Get("/api/platform-admins");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {


### PR DESCRIPTION
## Summary
- Align the three endpoints under `Api/Endpoints/PlatformAdmins/` with the canonical FastEndpoints structure documented in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Each endpoint now declares `public const string Route = "..."` above `Configure()` and passes `Route` to the HTTP verb method (`Get`/`Post`) instead of a string literal.
- No behavioral changes: request/response types, validators, handlers, HTTP verbs, and route values are untouched.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors, pre-existing warnings only)
- [ ] Integration tests (out of scope; require Docker)

Generated with Claude Code