### PR TITLE
refactor: extract Route const in TaxConfiguration endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/CalculateTaxEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/CalculateTaxEndpoint.cs
@@ -28,9 +28,11 @@ public sealed class CalculateTaxValidator : Validator<CalculateTaxApiRequest>
 public sealed class CalculateTaxEndpoint(ITaxConfigurationService service)
     : Endpoint<CalculateTaxApiRequest, TaxBreakdownDto>
 {
+    public const string Route = "/api/brands/{brandSlug}/tax-configuration/calculate";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/tax-configuration/calculate");
+        Post(Route);
         // TODO: Require appropriate role when auth is implemented (US-FP-046)
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<CalculateTaxApiRequest>>();

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/GetTaxConfigurationEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/GetTaxConfigurationEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record GetTaxConfigurationRequest([property: RouteParam] string Br
 public sealed class GetTaxConfigurationEndpoint(ITaxConfigurationService service)
     : Endpoint<GetTaxConfigurationRequest, TaxConfigurationResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/tax-configuration";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/tax-configuration");
+        Get(Route);
         // TODO: Require BrandAdmin role when auth is implemented (US-FP-046)
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<GetTaxConfigurationRequest>>();

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/UpdateTaxConfigurationEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/TaxConfiguration/UpdateTaxConfigurationEndpoint.cs
@@ -46,9 +46,11 @@ public sealed class UpdateTaxConfigurationValidator : Validator<UpdateTaxConfigu
 public sealed class UpdateTaxConfigurationEndpoint(ITaxConfigurationService service)
     : Endpoint<UpdateTaxConfigurationApiRequest, TaxConfigurationResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/tax-configuration";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/tax-configuration");
+        Put(Route);
         // TODO: Require BrandAdmin role when auth is implemented (US-FP-046)
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<UpdateTaxConfigurationApiRequest>>();


### PR DESCRIPTION
## Summary
- Extract the hard-coded route string from each TaxConfiguration endpoint's `Configure()` into a `public const string Route` on the endpoint class, aligning with the canonical FastEndpoints structure documented in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Applied to `CalculateTaxEndpoint`, `GetTaxConfigurationEndpoint`, and `UpdateTaxConfigurationEndpoint`. No behavior, verb, or route value changes.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors)
- [ ] Integration tests skipped (require Docker, out of scope)

Generated with [Claude Code](https://claude.com/claude-code)