### PR TITLE
refactor: extract Route const in OrderLifecycle and Orders endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/OrderLifecycle/ConfigureOrderLifecycleEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/OrderLifecycle/ConfigureOrderLifecycleEndpoint.cs
@@ -75,9 +75,11 @@ public sealed class ConfigureOrderLifecycleValidator : Validator<ConfigureOrderL
 public sealed class ConfigureOrderLifecycleEndpoint(IOrderLifecycleService service)
     : Endpoint<ConfigureOrderLifecycleApiRequest, OrderLifecycleResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle");
+        Put(Route);
         // TODO: Require ShopManager role when auth is implemented (US-FP-039)
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<ConfigureOrderLifecycleApiRequest>>();

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/OrderLifecycle/GetOrderLifecycleEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/OrderLifecycle/GetOrderLifecycleEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetOrderLifecycleRequest(
 public sealed class GetOrderLifecycleEndpoint(IOrderLifecycleService service)
     : Endpoint<GetOrderLifecycleRequest, OrderLifecycleResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle");
+        Get(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<GetOrderLifecycleRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/OrderLifecycle/ResetOrderLifecycleEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/OrderLifecycle/ResetOrderLifecycleEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record ResetOrderLifecycleRequest(
 public sealed class ResetOrderLifecycleEndpoint(IOrderLifecycleService service)
     : Endpoint<ResetOrderLifecycleRequest, OrderLifecycleResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle/reset";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle/reset");
+        Post(Route);
         // TODO: Require ShopManager role when auth is implemented (US-FP-039)
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<ResetOrderLifecycleRequest>>();

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/SimulateOrderStatusChangeEndpoint.cs
@@ -28,9 +28,11 @@ public sealed record SimulateOrderStatusChangeResponse(Guid OrderId, string Mess
 public sealed class SimulateOrderStatusChangeEndpoint(IMessageBus messageBus, IWebHostEnvironment env)
     : Endpoint<SimulateOrderStatusChangeRequest, SimulateOrderStatusChangeResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/orders/simulate-status-change";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/orders/simulate-status-change");
+        Post(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<SimulateOrderStatusChangeRequest>>();
         Tags("development");


### PR DESCRIPTION
## Summary
- Brings the three `OrderLifecycle` endpoints and the `SimulateOrderStatusChangeEndpoint` into conformance with the canonical FastEndpoints structure documented in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Each endpoint now declares `public const string Route = "..."` above `Configure()` and passes `Route` to `Put/Post/Get(...)` instead of the raw literal.
- No behavior change: routes, verbs, request/response types, validators, and handlers are untouched.

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors).
- [ ] Integration tests skipped per task scope (require Docker).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)