### PR TITLE
refactor: extract Route const in Shops endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/ActivateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/ActivateShopEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record ActivateShopRequest(
 public sealed class ActivateShopEndpoint(IShopService shopService)
     : Endpoint<ActivateShopRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{id}/activate";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/shops/{id}/activate");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/CreateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/CreateShopEndpoint.cs
@@ -70,9 +70,11 @@ public sealed class CreateShopRequestValidator : Validator<CreateShopRequest>
 public sealed class CreateShopEndpoint(IShopService shopService)
     : Endpoint<CreateShopRequest, ShopResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/shops");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/DeactivateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/DeactivateShopEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record DeactivateShopRequest(
 public sealed class DeactivateShopEndpoint(IShopService shopService)
     : Endpoint<DeactivateShopRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{id}/deactivate";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/shops/{id}/deactivate");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/GetOpeningHoursEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/GetOpeningHoursEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetOpeningHoursRequest(
 public sealed class GetOpeningHoursEndpoint(IOpeningHoursService openingHoursService)
     : Endpoint<GetOpeningHoursRequest, OpeningHoursResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{id}/opening-hours";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/shops/{id}/opening-hours");
+        Get(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<GetOpeningHoursRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/GetShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/GetShopEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetShopRequest(
 public sealed class GetShopEndpoint(IShopService shopService)
     : Endpoint<GetShopRequest, ShopResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{id}";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/shops/{id}");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/GetShopStatusEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/GetShopStatusEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetShopStatusRequest(
 public sealed class GetShopStatusEndpoint(IOpeningHoursService openingHoursService)
     : Endpoint<GetShopStatusRequest, ShopStatusResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{id}/status";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/shops/{id}/status");
+        Get(Route);
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<GetShopStatusRequest>>();
         Summary(s =>

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/ListShopsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/ListShopsEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record ListShopsRequest([property: RouteParam] string BrandSlug);
 public sealed class ListShopsEndpoint(IShopService shopService)
     : Endpoint<ListShopsRequest, IReadOnlyList<ShopResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/shops");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/SetOpeningHoursEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/SetOpeningHoursEndpoint.cs
@@ -82,9 +82,11 @@ public sealed class SetOpeningHoursRequestValidator : Validator<SetOpeningHoursR
 public sealed class SetOpeningHoursEndpoint(IOpeningHoursService openingHoursService)
     : Endpoint<SetOpeningHoursRequest, OpeningHoursResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{id}/opening-hours";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/shops/{id}/opening-hours");
+        Put(Route);
         // TODO: Require ShopManager role when auth is implemented (US-FP-039)
         AllowAnonymous();
         PreProcessor<BrandScopedPreProcessor<SetOpeningHoursRequest>>();

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
@@ -59,9 +59,11 @@ public sealed class UpdateShopRequestValidator : Validator<UpdateShopRequest>
 public sealed class UpdateShopEndpoint(IShopService shopService)
     : Endpoint<UpdateShopRequest, ShopResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/shops/{id}";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/shops/{id}");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {


### PR DESCRIPTION
## Summary
- Bring all 9 FastEndpoints in `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/` into conformance with the canonical structure in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- For each endpoint: add `public const string Route = "..."` as the first class member and replace the hard-coded route literal inside `Configure()` with the `Route` constant.
- Request types, response types, validators, handler bodies, HTTP verbs, and route values are unchanged.

## Files changed
- ActivateShopEndpoint, CreateShopEndpoint, DeactivateShopEndpoint
- GetOpeningHoursEndpoint, GetShopEndpoint, GetShopStatusEndpoint
- ListShopsEndpoint, SetOpeningHoursEndpoint, UpdateShopEndpoint

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors)
- [ ] Integration tests skipped (require Docker; out of scope per task)

Generated with Claude Code