### PR TITLE
refactor: extract Route const in ModifierGroups endpoints

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/CreateModifierGroupEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/CreateModifierGroupEndpoint.cs
@@ -72,9 +72,11 @@ public sealed class CreateModifierGroupRequestValidator : Validator<CreateModifi
 public sealed class CreateModifierGroupEndpoint(IModifierGroupService modifierGroupService)
     : Endpoint<CreateModifierGroupApiRequest, ModifierGroupResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/modifier-groups";
+
     public override void Configure()
     {
-        Post("/api/brands/{brandSlug}/modifier-groups");
+        Post(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/DeleteModifierGroupEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/DeleteModifierGroupEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record DeleteModifierGroupRequest(
 public sealed class DeleteModifierGroupEndpoint(IModifierGroupService modifierGroupService)
     : Endpoint<DeleteModifierGroupRequest>
 {
+    public const string Route = "/api/brands/{brandSlug}/modifier-groups/{id}";
+
     public override void Configure()
     {
-        Delete("/api/brands/{brandSlug}/modifier-groups/{id}");
+        Delete(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/GetModifierGroupEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/GetModifierGroupEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetModifierGroupRequest(
 public sealed class GetModifierGroupEndpoint(IModifierGroupService modifierGroupService)
     : Endpoint<GetModifierGroupRequest, ModifierGroupResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/modifier-groups/{id}";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/modifier-groups/{id}");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/GetProductModifierGroupsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/GetProductModifierGroupsEndpoint.cs
@@ -10,9 +10,11 @@ public sealed record GetProductModifierGroupsRequest(
 public sealed class GetProductModifierGroupsEndpoint(IModifierGroupService modifierGroupService)
     : Endpoint<GetProductModifierGroupsRequest, IReadOnlyList<ProductModifierGroupResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/products/{productId}/modifier-groups";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/products/{productId}/modifier-groups");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/ListModifierGroupsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/ListModifierGroupsEndpoint.cs
@@ -8,9 +8,11 @@ public sealed record ListModifierGroupsRequest([property: RouteParam] string Bra
 public sealed class ListModifierGroupsEndpoint(IModifierGroupService modifierGroupService)
     : Endpoint<ListModifierGroupsRequest, IReadOnlyList<ModifierGroupListItemResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/modifier-groups";
+
     public override void Configure()
     {
-        Get("/api/brands/{brandSlug}/modifier-groups");
+        Get(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/SetProductModifierGroupsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/SetProductModifierGroupsEndpoint.cs
@@ -40,9 +40,11 @@ public sealed class SetProductModifierGroupsRequestValidator : Validator<SetProd
 public sealed class SetProductModifierGroupsEndpoint(IModifierGroupService modifierGroupService)
     : Endpoint<SetProductModifierGroupsApiRequest, IReadOnlyList<ProductModifierGroupResponse>>
 {
+    public const string Route = "/api/brands/{brandSlug}/products/{productId}/modifier-groups";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/products/{productId}/modifier-groups");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/UpdateModifierGroupEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/UpdateModifierGroupEndpoint.cs
@@ -67,9 +67,11 @@ public sealed class UpdateModifierGroupRequestValidator : Validator<UpdateModifi
 public sealed class UpdateModifierGroupEndpoint(IModifierGroupService modifierGroupService)
     : Endpoint<UpdateModifierGroupApiRequest, ModifierGroupResponse>
 {
+    public const string Route = "/api/brands/{brandSlug}/modifier-groups/{id}";
+
     public override void Configure()
     {
-        Put("/api/brands/{brandSlug}/modifier-groups/{id}");
+        Put(Route);
         AllowAnonymous();
         Summary(s =>
         {


### PR DESCRIPTION
## Summary
- Bring every FastEndpoint in `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/ModifierGroups/` into conformance with the canonical structure in `.claude/skills/backend-dotnet/docs/fast-endpoints.md`.
- Each endpoint now declares `public const string Route = "..."` above `Configure()` and passes `Route` to the HTTP verb method (`Post(Route)`, `Get(Route)`, `Put(Route)`, `Delete(Route)`) instead of a literal string.
- No behavioral change: request types, response types, validators, handlers, HTTP verbs, and route values are unchanged.

## Files changed
- `CreateModifierGroupEndpoint.cs`
- `DeleteModifierGroupEndpoint.cs`
- `GetModifierGroupEndpoint.cs`
- `GetProductModifierGroupsEndpoint.cs`
- `ListModifierGroupsEndpoint.cs`
- `SetProductModifierGroupsEndpoint.cs`
- `UpdateModifierGroupEndpoint.cs`

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` succeeds (0 errors).
- [ ] Integration tests (out of scope here — require Docker).

Generated with Claude Code