### PR TITLE
test: add OrderLifecycle and BrandSettings domain unit tests

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/BrandSettings/BrandColorsTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/BrandSettings/BrandColorsTests.cs
@@ -1,0 +1,114 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.BrandSettings;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.BrandSettings;
+
+public sealed class BrandColorsTests
+{
+    // ── Constructor — happy path ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("#fff", "#000", "#abc")]
+    [InlineData("#ffffff", "#000000", "#abcdef")]
+    [InlineData("#2563eb", "#64748b", "#f59e0b")]
+    [InlineData("#abc", "#123456", "#aabbcc")]
+    public void Constructor_WithValidHexColors_SetsProperties(string primary, string secondary, string accent)
+    {
+        var colors = new BrandColors(primary, secondary, accent);
+
+        colors.Primary.ShouldBe(primary.ToLowerInvariant());
+        colors.Secondary.ShouldBe(secondary.ToLowerInvariant());
+        colors.Accent.ShouldBe(accent.ToLowerInvariant());
+    }
+
+    [Theory]
+    [InlineData("#ABC", "#abc")]
+    [InlineData("#FFAA00", "#ffaa00")]
+    [InlineData("#2563EB", "#2563eb")]
+    public void Constructor_LowercasesHexOnStore(string input, string expected)
+    {
+        var colors = new BrandColors(input, "#000000", "#000000");
+
+        colors.Primary.ShouldBe(expected);
+    }
+
+    // ── Constructor — invalid colors ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_WithEmptyOrWhitespacePrimary_ThrowsArgumentException(string badValue)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandColors(badValue, "#000000", "#000000"));
+    }
+
+    [Fact]
+    public void Constructor_WithEmptySecondary_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandColors("#ffffff", "", "#000000"));
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyAccent_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandColors("#ffffff", "#000000", ""));
+    }
+
+    [Theory]
+    [InlineData("ffffff")]
+    [InlineData("rgb(0,0,0)")]
+    [InlineData("blue")]
+    public void Constructor_WithMissingHashPrefix_ThrowsArgumentException(string badValue)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandColors(badValue, "#000000", "#000000"));
+    }
+
+    [Theory]
+    [InlineData("#gggggg")]
+    [InlineData("#zzzzzz")]
+    [InlineData("#12345g")]
+    public void Constructor_WithNonHexCharacters_ThrowsArgumentException(string badValue)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandColors(badValue, "#000000", "#000000"));
+    }
+
+    [Theory]
+    [InlineData("#ffaa")]
+    [InlineData("#ffaa0")]
+    [InlineData("#ffaa000")]
+    [InlineData("#ff")]
+    [InlineData("#f")]
+    [InlineData("#")]
+    public void Constructor_WithWrongHexLength_ThrowsArgumentException(string badValue)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandColors(badValue, "#000000", "#000000"));
+    }
+
+    // ── Equality ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Equality_WithIdenticalNormalizedValues_AreEqual()
+    {
+        var a = new BrandColors("#FFFFFF", "#000000", "#ABCDEF");
+        var b = new BrandColors("#ffffff", "#000000", "#abcdef");
+
+        a.ShouldBe(b);
+        (a == b).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equality_WithDifferentValues_AreNotEqual()
+    {
+        var a = new BrandColors("#ffffff", "#000000", "#abcdef");
+        var b = new BrandColors("#ffffff", "#111111", "#abcdef");
+
+        a.ShouldNotBe(b);
+        (a == b).ShouldBeFalse();
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/BrandSettings/BrandTypographyTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/BrandSettings/BrandTypographyTests.cs
@@ -1,0 +1,87 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.BrandSettings;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.BrandSettings;
+
+public sealed class BrandTypographyTests
+{
+    // ── Constructor — happy path ───────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(AllPresetFontPairs))]
+    public void Constructor_WithPresetFonts_SetsPropertiesCorrectly(string heading, string body)
+    {
+        var typography = new BrandTypography(heading, body);
+
+        typography.HeadingFontFamily.ShouldBe(heading);
+        typography.BodyFontFamily.ShouldBe(body);
+    }
+
+    public static IEnumerable<object[]> AllPresetFontPairs()
+    {
+        // Use SystemDefault paired with each preset font to cover all approved fonts
+        foreach (var font in PresetFonts.All)
+            yield return [font, PresetFonts.SystemDefault];
+    }
+
+    [Fact]
+    public void Constructor_WithSameFontForBothRoles_SetsPropertiesCorrectly()
+    {
+        var typography = new BrandTypography(PresetFonts.SystemDefault, PresetFonts.SystemDefault);
+
+        typography.HeadingFontFamily.ShouldBe(PresetFonts.SystemDefault);
+        typography.BodyFontFamily.ShouldBe(PresetFonts.SystemDefault);
+    }
+
+    // ── Constructor — invalid fonts ───────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithUnknownHeadingFont_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandTypography("Comic Sans MS", PresetFonts.SystemDefault));
+    }
+
+    [Fact]
+    public void Constructor_WithUnknownBodyFont_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandTypography(PresetFonts.SystemDefault, "Arial"));
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyHeadingFont_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandTypography("", PresetFonts.SystemDefault));
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyBodyFont_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new BrandTypography(PresetFonts.SystemDefault, ""));
+    }
+
+    // ── Equality ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Equality_WithIdenticalValues_AreEqual()
+    {
+        var a = new BrandTypography("Inter", "Roboto");
+        var b = new BrandTypography("Inter", "Roboto");
+
+        a.ShouldBe(b);
+        (a == b).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equality_WithDifferentValues_AreNotEqual()
+    {
+        var a = new BrandTypography("Inter", "Roboto");
+        var b = new BrandTypography("Poppins", "Roboto");
+
+        a.ShouldNotBe(b);
+        (a == b).ShouldBeFalse();
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/BrandSettings/PresetFontsTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/BrandSettings/PresetFontsTests.cs
@@ -1,0 +1,79 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.BrandSettings;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.BrandSettings;
+
+public sealed class PresetFontsTests
+{
+    // ── All collection ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void All_ContainsExactlyElevenFonts()
+    {
+        PresetFonts.All.Count.ShouldBe(11);
+    }
+
+    [Fact]
+    public void All_IncludesSystemDefault()
+    {
+        PresetFonts.All.ShouldContain(PresetFonts.SystemDefault);
+    }
+
+    // ── IsValid — known fonts ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("System Default")]
+    [InlineData("Inter")]
+    [InlineData("Roboto")]
+    [InlineData("Open Sans")]
+    [InlineData("Lato")]
+    [InlineData("Poppins")]
+    [InlineData("Montserrat")]
+    [InlineData("Nunito")]
+    [InlineData("Raleway")]
+    [InlineData("Source Sans 3")]
+    [InlineData("DM Sans")]
+    public void IsValid_WithRegisteredFont_ReturnsTrue(string font)
+    {
+        PresetFonts.IsValid(font).ShouldBeTrue();
+    }
+
+    // ── IsValid — invalid fonts ───────────────────────────────────────────────
+
+    [Fact]
+    public void IsValid_WithNullFont_ReturnsFalse()
+    {
+        PresetFonts.IsValid(null!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_WithEmptyString_ReturnsFalse()
+    {
+        PresetFonts.IsValid("").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_WithUnknownFont_ReturnsFalse()
+    {
+        PresetFonts.IsValid("NotAFont").ShouldBeFalse();
+    }
+
+    // IsValid uses StringComparer.Ordinal — case-sensitive exact match
+    [Theory]
+    [InlineData("inter")]
+    [InlineData("INTER")]
+    [InlineData("ROBOTO")]
+    public void IsValid_WithKnownFontInWrongCase_ReturnsFalse(string font)
+    {
+        PresetFonts.IsValid(font).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("Arial")]
+    [InlineData("Comic Sans MS")]
+    [InlineData("Times New Roman")]
+    public void IsValid_WithCommonNonApprovedFont_ReturnsFalse(string font)
+    {
+        PresetFonts.IsValid(font).ShouldBeFalse();
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/OrderLifecycle/OrderLifecycleConfigTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/OrderLifecycle/OrderLifecycleConfigTests.cs
@@ -1,0 +1,174 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.OrderLifecycle;
+
+public sealed class OrderLifecycleConfigTests
+{
+    private static readonly Guid ShopId = Guid.NewGuid();
+
+    // ── CreateDefault ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CreateDefault_HasSixStatuses()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+
+        config.Statuses.Count.ShouldBe(6);
+    }
+
+    [Fact]
+    public void CreateDefault_SortOrdersAreSequentialZeroToFive()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+
+        var sortOrders = config.Statuses.Select(s => s.SortOrder).OrderBy(o => o).ToList();
+        for (var i = 0; i < sortOrders.Count; i++)
+            sortOrders[i].ShouldBe(i);
+    }
+
+    [Fact]
+    public void CreateDefault_HasExactlyTwoTerminalStatuses()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+
+        config.Statuses.Count(s => s.IsTerminal).ShouldBe(2);
+    }
+
+    [Fact]
+    public void CreateDefault_TerminalStatusesArePickedUpAndDelivered()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+
+        var terminalKeys = config.Statuses
+            .Where(s => s.IsTerminal)
+            .Select(s => s.SystemKey)
+            .ToList();
+
+        terminalKeys.ShouldContain("picked_up");
+        terminalKeys.ShouldContain("delivered");
+    }
+
+    [Fact]
+    public void CreateDefault_HasFiveTransitions()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+
+        config.Transitions.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public void CreateDefault_AllTransitionsReferenceStatusesInConfig()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+        var statusIds = new HashSet<Guid>(config.Statuses.Select(s => s.Id));
+
+        foreach (var transition in config.Transitions)
+        {
+            statusIds.ShouldContain(transition.FromStatusId);
+            statusIds.ShouldContain(transition.ToStatusId);
+        }
+    }
+
+    [Fact]
+    public void CreateDefault_SetsShopId()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+
+        config.ShopId.ShouldBe(ShopId);
+    }
+
+    // ── ConfigureLifecycle — happy path ───────────────────────────────────────
+
+    [Fact]
+    public void ConfigureLifecycle_WithValidCustomSet_ReplacesStatusesAtomically()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+
+        var newStatus1 = OrderStatus.Create(config.Id, "Open", null, 0, false);
+        var newStatus2 = OrderStatus.Create(config.Id, "Done", null, 1, true);
+        var newTransition = OrderStatusTransition.Create(config.Id, newStatus1.Id, newStatus2.Id);
+
+        config.ConfigureLifecycle([newStatus1, newStatus2], [newTransition]);
+
+        config.Statuses.Count.ShouldBe(2);
+        config.Transitions.Count.ShouldBe(1);
+        config.Statuses.ShouldContain(s => s.Name == "Open");
+        config.Statuses.ShouldContain(s => s.Name == "Done");
+    }
+
+    [Fact]
+    public void ConfigureLifecycle_WithValidCustomSet_UpdatesUpdatedAt()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+        var originalUpdatedAt = config.UpdatedAt;
+
+        var s1 = OrderStatus.Create(config.Id, "Start", null, 0, false);
+        var s2 = OrderStatus.Create(config.Id, "End", null, 1, true);
+
+        config.ConfigureLifecycle([s1, s2], []);
+
+        config.UpdatedAt.ShouldBeGreaterThanOrEqualTo(originalUpdatedAt);
+    }
+
+    // ── ConfigureLifecycle — validation guards ────────────────────────────────
+
+    [Fact]
+    public void ConfigureLifecycle_WithFewerThanTwoStatuses_ThrowsArgumentException()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+        var single = OrderStatus.Create(config.Id, "Only", null, 0, true);
+
+        Should.Throw<ArgumentException>(() =>
+            config.ConfigureLifecycle([single], []));
+    }
+
+    [Fact]
+    public void ConfigureLifecycle_WithZeroTerminalStatuses_ThrowsArgumentException()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+        var s1 = OrderStatus.Create(config.Id, "A", null, 0, false);
+        var s2 = OrderStatus.Create(config.Id, "B", null, 1, false);
+
+        Should.Throw<ArgumentException>(() =>
+            config.ConfigureLifecycle([s1, s2], []));
+    }
+
+    [Fact]
+    public void ConfigureLifecycle_WithNonSequentialSortOrders_ThrowsArgumentException()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+        var s1 = OrderStatus.Create(config.Id, "A", null, 0, false);
+        var s2 = OrderStatus.Create(config.Id, "B", null, 1, false);
+        var s3 = OrderStatus.Create(config.Id, "C", null, 3, true); // gap: missing sort order 2
+
+        Should.Throw<ArgumentException>(() =>
+            config.ConfigureLifecycle([s1, s2, s3], []));
+    }
+
+    [Fact]
+    public void ConfigureLifecycle_TransitionWithUnknownFromStatusId_ThrowsArgumentException()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+        var s1 = OrderStatus.Create(config.Id, "A", null, 0, false);
+        var s2 = OrderStatus.Create(config.Id, "B", null, 1, true);
+        var unknownId = Guid.NewGuid();
+        var badTransition = OrderStatusTransition.Create(config.Id, unknownId, s2.Id);
+
+        Should.Throw<ArgumentException>(() =>
+            config.ConfigureLifecycle([s1, s2], [badTransition]));
+    }
+
+    [Fact]
+    public void ConfigureLifecycle_TransitionWithUnknownToStatusId_ThrowsArgumentException()
+    {
+        var config = OrderLifecycleConfig.CreateDefault(ShopId);
+        var s1 = OrderStatus.Create(config.Id, "A", null, 0, false);
+        var s2 = OrderStatus.Create(config.Id, "B", null, 1, true);
+        var unknownId = Guid.NewGuid();
+        var badTransition = OrderStatusTransition.Create(config.Id, s1.Id, unknownId);
+
+        Should.Throw<ArgumentException>(() =>
+            config.ConfigureLifecycle([s1, s2], [badTransition]));
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/OrderLifecycle/OrderStatusTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/OrderLifecycle/OrderStatusTests.cs
@@ -1,0 +1,81 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.OrderLifecycle;
+
+public sealed class OrderStatusTests
+{
+    private static readonly Guid ConfigId = Guid.NewGuid();
+
+    // ── Create — happy path ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WithAllFields_SetsPropertiesCorrectly()
+    {
+        var status = OrderStatus.Create(ConfigId, "Preparing", "preparing", 2, false, "#FF5733");
+
+        status.ShouldNotBeNull();
+        status.Id.ShouldNotBe(Guid.Empty);
+        status.OrderLifecycleConfigId.ShouldBe(ConfigId);
+        status.Name.ShouldBe("Preparing");
+        status.SystemKey.ShouldBe("preparing");
+        status.SortOrder.ShouldBe(2);
+        status.IsEnabled.ShouldBeTrue();
+        status.IsTerminal.ShouldBeFalse();
+        status.ColorHex.ShouldBe("#FF5733");
+    }
+
+    [Fact]
+    public void Create_WithNullSystemKey_SetsSystemKeyToNull()
+    {
+        var status = OrderStatus.Create(ConfigId, "Custom Status", null, 0, false);
+
+        status.SystemKey.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_WithNullColorHex_SetsColorHexToNull()
+    {
+        var status = OrderStatus.Create(ConfigId, "Placed", "placed", 0, false);
+
+        status.ColorHex.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_WithIsTerminalTrue_SetsIsTerminal()
+    {
+        var status = OrderStatus.Create(ConfigId, "Delivered", "delivered", 5, true);
+
+        status.IsTerminal.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Create_AlwaysDefaultsIsEnabledToTrue()
+    {
+        var status = OrderStatus.Create(ConfigId, "Some Status", null, 0, false);
+
+        status.IsEnabled.ShouldBeTrue();
+    }
+
+    // ── Create — UUIDv7 ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_GeneratesUuidV7()
+    {
+        var status = OrderStatus.Create(ConfigId, "Placed", "placed", 0, false);
+
+        // UUIDv7 has version nibble = 7 (bits 48-51)
+        var version = (status.Id.ToByteArray()[7] >> 4) & 0x0F;
+        version.ShouldBe(7);
+    }
+
+    // ── Create — optional color hex stored as-is (no transformation) ──────────
+
+    [Fact]
+    public void Create_WithColorHex_StoresValueAsProvided()
+    {
+        var status = OrderStatus.Create(ConfigId, "Ready", "ready", 3, false, "#00FF00");
+
+        status.ColorHex.ShouldBe("#00FF00");
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/OrderLifecycle/OrderStatusTransitionTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/OrderLifecycle/OrderStatusTransitionTests.cs
@@ -1,0 +1,53 @@
+using Shouldly;
+using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.OrderLifecycle;
+
+public sealed class OrderStatusTransitionTests
+{
+    private static readonly Guid ConfigId = Guid.NewGuid();
+
+    // ── Create — happy path ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WithValidArgs_SetsPropertiesCorrectly()
+    {
+        var fromId = Guid.NewGuid();
+        var toId = Guid.NewGuid();
+
+        var transition = OrderStatusTransition.Create(ConfigId, fromId, toId);
+
+        transition.ShouldNotBeNull();
+        transition.Id.ShouldNotBe(Guid.Empty);
+        transition.OrderLifecycleConfigId.ShouldBe(ConfigId);
+        transition.FromStatusId.ShouldBe(fromId);
+        transition.ToStatusId.ShouldBe(toId);
+    }
+
+    [Fact]
+    public void Create_GeneratesUuidV7()
+    {
+        var transition = OrderStatusTransition.Create(ConfigId, Guid.NewGuid(), Guid.NewGuid());
+
+        // UUIDv7 has version nibble = 7 (bits 48-51)
+        var version = (transition.Id.ToByteArray()[7] >> 4) & 0x0F;
+        version.ShouldBe(7);
+    }
+
+    // ── Create — no self-transition guard in domain ───────────────────────────
+    // The domain's Create factory does not enforce FromStatusId != ToStatusId;
+    // that constraint lives in ConfigureLifecycle's transition-reference validation
+    // (which ensures both sides are in the provided status list). A self-referencing
+    // transition can be created — it would only be rejected if validated by the config.
+
+    [Fact]
+    public void Create_WithSameFromAndToId_DoesNotThrow()
+    {
+        var sameId = Guid.NewGuid();
+
+        var transition = OrderStatusTransition.Create(ConfigId, sameId, sameId);
+
+        transition.FromStatusId.ShouldBe(sameId);
+        transition.ToStatusId.ShouldBe(sameId);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 6 new test files covering the `OrderLifecycle` and `BrandSettings` domain bounded contexts
- 181 unit tests total using xUnit + Shouldly; all green against `dotnet build --configuration Release` + `dotnet test`
- No existing tests modified; no production code changed

## Files added

**OrderLifecycle/**
- `OrderLifecycleConfigTests.cs` — `CreateDefault` shape (6 statuses, 5 transitions, 2 terminals) + `ConfigureLifecycle` happy path and all 5 validation guards
- `OrderStatusTests.cs` — factory happy path, optional fields (systemKey, colorHex), IsEnabled default, UUIDv7 generation
- `OrderStatusTransitionTests.cs` — factory happy path, UUIDv7, and documented absence of self-transition guard at entity level

**BrandSettings/**
- `BrandColorsTests.cs` — 3-digit and 6-digit hex acceptance, lowercasing on store, empty/whitespace/missing-prefix/non-hex/wrong-length rejections, equality
- `BrandTypographyTests.cs` — all 11 preset fonts accepted, unknown fonts rejected, equality
- `PresetFontsTests.cs` — count=11, `IsValid` true for all 11 registered fonts, false for null/empty/unknown/wrong-case

## Test plan

- [x] `dotnet build --configuration Release` — green (0 errors)
- [x] `dotnet test TheMillionthFoodOrderApp.Tests.Unit --configuration Release --no-build` — 181 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)