### PR TITLE
test: frontend test infrastructure + api/auth suites (Wave 1 slice 4)

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -48,6 +48,7 @@
     "vite": "^6.0.7",
     "vite-plugin-pwa": "^0.21.1",
     "vite-tsconfig-paths": "^5.1.4",
+    "msw": "^2.7.0",
     "vitest": "^2.1.8"
   },
   "pnpm": {

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -65,10 +65,10 @@ importers:
         version: 8.57.0(eslint@9.39.4)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(terser@5.46.0))
+        version: 4.7.0(vite@6.4.1(@types/node@25.6.0)(terser@5.46.0))
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.9(vitest@2.1.9(jsdom@25.0.1)(terser@5.46.0))
+        version: 2.1.9(vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.0))
       eslint:
         specifier: ^9.17.0
         version: 9.39.4
@@ -84,6 +84,9 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
+      msw:
+        specifier: ^2.7.0
+        version: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
@@ -95,16 +98,16 @@ importers:
         version: 8.57.0(eslint@9.39.4)(typescript@5.9.3)
       vite:
         specifier: ^6.0.7
-        version: 6.4.1(terser@5.46.0)
+        version: 6.4.1(@types/node@25.6.0)(terser@5.46.0)
       vite-plugin-pwa:
         specifier: ^0.21.1
-        version: 0.21.2(vite@6.4.1(terser@5.46.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+        version: 0.21.2(vite@6.4.1(@types/node@25.6.0)(terser@5.46.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(terser@5.46.0))
+        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@25.6.0)(terser@5.46.0))
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(jsdom@25.0.1)(terser@5.46.0)
+        version: 2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.0)
 
 packages:
 
@@ -1010,6 +1013,41 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.12':
+    resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.9':
+    resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1043,6 +1081,22 @@ packages:
 
   '@microsoft/signalr@10.0.0':
     resolution: {integrity: sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==}
+
+  '@mswjs/interceptors@0.41.4':
+    resolution: {integrity: sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==}
+    engines: {node: '>=18'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1320,6 +1374,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1333,6 +1390,12 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1607,6 +1670,14 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1630,6 +1701,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js-compat@3.48.0:
     resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
@@ -1870,8 +1945,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1956,6 +2040,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2008,6 +2096,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2034,6 +2126,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -2157,6 +2252,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2394,6 +2492,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.13.4:
+    resolution: {integrity: sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2432,6 +2544,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -2473,6 +2588,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2622,6 +2740,10 @@ packages:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -2637,6 +2759,9 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  rettime@0.11.8:
+    resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
 
   rollup@2.80.0:
     resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
@@ -2693,6 +2818,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2764,12 +2892,19 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2830,6 +2965,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -2872,8 +3011,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
   tough-cookie@4.1.4:
@@ -2882,6 +3028,10 @@ packages:
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
   tr46@0.0.3:
@@ -2918,6 +3068,10 @@ packages:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
 
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -2950,6 +3104,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -2977,6 +3134,9 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
@@ -3270,8 +3430,20 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4191,6 +4363,33 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.12(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/core@11.1.9(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@25.6.0)':
+    optionalDependencies:
+      '@types/node': 25.6.0
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4239,6 +4438,26 @@ snapshots:
       - bufferutil
       - encoding
       - utf-8-validate
+
+  '@mswjs/interceptors@0.41.4':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4461,6 +4680,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
@@ -4473,6 +4696,12 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
+
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/statuses@2.0.6': {}
 
   '@types/trusted-types@2.0.7': {}
 
@@ -4567,7 +4796,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(terser@5.46.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.6.0)(terser@5.46.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4575,11 +4804,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(terser@5.46.0)
+      vite: 6.4.1(@types/node@25.6.0)(terser@5.46.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(jsdom@25.0.1)(terser@5.46.0))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -4593,7 +4822,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(jsdom@25.0.1)(terser@5.46.0)
+      vitest: 2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4604,13 +4833,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(terser@5.46.0))':
+  '@vitest/mocker@2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@5.4.21(@types/node@25.6.0)(terser@5.46.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(terser@5.46.0)
+      msw: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.46.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -4811,6 +5041,14 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  cli-width@4.1.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4828,6 +5066,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   core-js-compat@3.48.0:
     dependencies:
@@ -5160,7 +5400,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -5240,6 +5490,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5303,6 +5555,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphql@16.13.2: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -5324,6 +5578,11 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -5449,6 +5708,8 @@ snapshots:
   is-module@1.0.0: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -5686,6 +5947,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.12(@types/node@25.6.0)
+      '@mswjs/interceptors': 0.41.4
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.8
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
@@ -5719,6 +6007,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  outvariant@1.4.3: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -5759,6 +6049,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.7
       minipass: 7.1.3
+
+  path-to-regexp@6.3.0: {}
 
   pathe@1.1.2: {}
 
@@ -5896,6 +6188,8 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
@@ -5907,6 +6201,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rettime@0.11.8: {}
 
   rollup@2.80.0:
     optionalDependencies:
@@ -5988,6 +6284,8 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  set-cookie-parser@3.1.0: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -6067,12 +6365,16 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6155,6 +6457,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -6194,9 +6498,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
+  tldts-core@7.0.28: {}
+
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
 
   tough-cookie@4.1.4:
     dependencies:
@@ -6208,6 +6518,10 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
 
   tr46@0.0.3: {}
 
@@ -6232,6 +6546,10 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.16.0: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -6286,6 +6604,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@7.19.2: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -6305,6 +6625,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  until-async@3.0.2: {}
+
   upath@1.2.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
@@ -6322,13 +6644,13 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  vite-node@2.1.9(terser@5.46.0):
+  vite-node@2.1.9(@types/node@25.6.0)(terser@5.46.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(terser@5.46.0)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.46.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6340,38 +6662,39 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-pwa@0.21.2(vite@6.4.1(terser@5.46.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
+  vite-plugin-pwa@0.21.2(vite@6.4.1(@types/node@25.6.0)(terser@5.46.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.15
-      vite: 6.4.1(terser@5.46.0)
+      vite: 6.4.1(@types/node@25.6.0)(terser@5.46.0)
       workbox-build: 7.4.0(@types/babel__core@7.20.5)
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(terser@5.46.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@25.6.0)(terser@5.46.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 6.4.1(terser@5.46.0)
+      vite: 6.4.1(@types/node@25.6.0)(terser@5.46.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.21(terser@5.46.0):
+  vite@5.4.21(@types/node@25.6.0)(terser@5.46.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.8
       rollup: 4.59.0
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       terser: 5.46.0
 
-  vite@6.4.1(terser@5.46.0):
+  vite@6.4.1(@types/node@25.6.0)(terser@5.46.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6380,13 +6703,14 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       terser: 5.46.0
 
-  vitest@2.1.9(jsdom@25.0.1)(terser@5.46.0):
+  vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(terser@5.46.0))
+      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@5.4.21(@types/node@25.6.0)(terser@5.46.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -6402,10 +6726,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(terser@5.46.0)
-      vite-node: 2.1.9(terser@5.46.0)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@25.6.0)(terser@5.46.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.6.0
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less
@@ -6637,6 +6962,20 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}

--- a/src/frontend/src/api/__tests__/auth.test.ts
+++ b/src/frontend/src/api/__tests__/auth.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { getUser, login, logout, keepalive } from '../auth';
+
+/**
+ * Tests for src/api/auth.ts — BFF auth endpoints.
+ *
+ * bffClient uses baseURL '/bff'. MSW matches by relative path.
+ */
+describe('auth API', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  describe('getUser', () => {
+    it('maps authenticated BFF response to AuthUser', async () => {
+      const user = await getUser();
+
+      expect(user).toEqual({
+        userId: 'user-1',
+        displayName: 'Test User',
+        email: 'test@example.com',
+        roles: ['brand-admin'],
+        brandSlug: 'frietjes',
+      });
+    });
+
+    it('returns null when user is not authenticated', async () => {
+      server.use(
+        http.get('/bff/user', () =>
+          HttpResponse.json({ isAuthenticated: false }),
+        ),
+      );
+
+      const user = await getUser();
+      expect(user).toBeNull();
+    });
+
+    it('filters out unknown role strings', async () => {
+      server.use(
+        http.get('/bff/user', () =>
+          HttpResponse.json({
+            isAuthenticated: true,
+            userId: 'user-2',
+            displayName: 'Test',
+            email: 'test@test.com',
+            roles: ['brand-admin', 'unknown-role', 'super-hacker'],
+            brandSlug: null,
+          }),
+        ),
+      );
+
+      const user = await getUser();
+      expect(user?.roles).toEqual(['brand-admin']);
+    });
+  });
+
+  describe('login', () => {
+    it('sets window.location.href to /bff/login without params', () => {
+      let capturedHref = '';
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          ...window.location,
+          set href(url: string) {
+            capturedHref = url;
+          },
+        },
+      });
+
+      login();
+      expect(capturedHref).toBe('/bff/login');
+    });
+
+    it('includes mock persona in query string when provided', () => {
+      let capturedHref = '';
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          ...window.location,
+          set href(url: string) {
+            capturedHref = url;
+          },
+        },
+      });
+
+      login('brand-admin@frietjes');
+      expect(capturedHref).toContain('mock=brand-admin%40frietjes');
+    });
+
+    it('includes returnUrl in query string when provided', () => {
+      let capturedHref = '';
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          ...window.location,
+          set href(url: string) {
+            capturedHref = url;
+          },
+        },
+      });
+
+      login(undefined, '/admin/brands');
+      expect(capturedHref).toContain('returnUrl=%2Fadmin%2Fbrands');
+    });
+  });
+
+  describe('logout', () => {
+    it('posts to /bff/logout and reloads the page', async () => {
+      let logoutCalled = false;
+      let reloadCalled = false;
+      server.use(
+        http.post('/bff/logout', () => {
+          logoutCalled = true;
+          return new HttpResponse(null, { status: 200 });
+        }),
+      );
+
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          ...window.location,
+          reload: () => {
+            reloadCalled = true;
+          },
+        },
+      });
+
+      await logout();
+
+      expect(logoutCalled).toBe(true);
+      expect(reloadCalled).toBe(true);
+    });
+  });
+
+  describe('keepalive', () => {
+    it('returns true on successful keepalive', async () => {
+      const result = await keepalive();
+      expect(result).toBe(true);
+    });
+
+    it('returns false on 401 (session expired)', async () => {
+      server.use(
+        http.post('/bff/session/keepalive', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const result = await keepalive();
+      expect(result).toBe(false);
+    });
+
+    it('returns false on network error', async () => {
+      server.use(
+        http.post('/bff/session/keepalive', () => HttpResponse.error()),
+      );
+
+      const result = await keepalive();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/brandSettings.test.ts
+++ b/src/frontend/src/api/__tests__/brandSettings.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { brandSettingsApi } from '../brandSettings';
+
+/**
+ * Tests for src/api/brandSettings.ts
+ */
+describe('brandSettingsApi', () => {
+  describe('get', () => {
+    it('returns brand settings', async () => {
+      const settings = await brandSettingsApi.get('frietjes');
+
+      expect(settings).toMatchObject({
+        id: 'settings-1',
+        defaultLanguage: 'nl',
+        timezone: 'Europe/Brussels',
+        currency: 'EUR',
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/settings', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await brandSettingsApi.get('frietjes');
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('updateTheming', () => {
+    it('updates theming and returns updated settings', async () => {
+      const settings = await brandSettingsApi.updateTheming('frietjes', {
+        colors: { primary: '#ff0000', secondary: '#00ff00', accent: '#0000ff' },
+        typography: { headingFontFamily: 'Inter', bodyFontFamily: 'Roboto' },
+        customDomain: 'www.frietjes.be',
+      });
+
+      expect(settings).toMatchObject({ customDomain: 'www.frietjes.be' });
+      expect(settings.colors).toMatchObject({ primary: '#ff0000' });
+    });
+  });
+
+  describe('uploadLogo', () => {
+    it('uploads a logo file and returns the logo URL', async () => {
+      // Mock the multipart handler to return a logo URL
+      server.use(
+        http.post('/api/brands/:slug/settings/logo', () =>
+          HttpResponse.json({ logoUrl: 'https://cdn.example.com/custom-logo.png' }),
+        ),
+      );
+
+      const file = new File(['(logo)'], 'logo.png', { type: 'image/png' });
+      const response = await brandSettingsApi.uploadLogo('frietjes', file);
+
+      expect(response.logoUrl).toBe('https://cdn.example.com/custom-logo.png');
+    });
+  });
+
+  describe('getTheme', () => {
+    it('returns the public brand theme', async () => {
+      const theme = await brandSettingsApi.getTheme('frietjes');
+
+      expect(theme).toMatchObject({
+        primaryColor: '#2563eb',
+        headingFontFamily: 'Inter',
+      });
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/brandStaff.test.ts
+++ b/src/frontend/src/api/__tests__/brandStaff.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { brandStaffApi } from '../brandStaff';
+
+/**
+ * Tests for src/api/brandStaff.ts
+ */
+describe('brandStaffApi', () => {
+  describe('list', () => {
+    it('returns brand staff members', async () => {
+      const staff = await brandStaffApi.list('frietjes');
+
+      expect(staff).toHaveLength(1);
+      expect(staff[0]).toMatchObject({
+        id: 'staff-1',
+        email: 'staff@frietjes.be',
+        displayName: 'Staff Member',
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/staff', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await brandStaffApi.list('frietjes');
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('listByShop', () => {
+    it('returns staff members for a specific shop', async () => {
+      const staff = await brandStaffApi.listByShop('frietjes', 'shop-1');
+      expect(Array.isArray(staff)).toBe(true);
+    });
+  });
+
+  describe('invite', () => {
+    it('invites a staff member and returns the created entity', async () => {
+      const member = await brandStaffApi.invite('frietjes', {
+        email: 'newstaff@frietjes.be',
+        displayName: 'New Staff',
+        role: 2,
+        shopId: 'shop-1',
+      });
+
+      expect(member).toMatchObject({
+        email: 'newstaff@frietjes.be',
+        displayName: 'New Staff',
+      });
+    });
+  });
+
+  describe('deactivate', () => {
+    it('deactivates a staff role assignment without throwing', async () => {
+      await expect(brandStaffApi.deactivate('frietjes', 'role-1')).resolves.toBeUndefined();
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.post('/api/brands/:slug/staff/:roleId/deactivate', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await brandStaffApi.deactivate('frietjes', 'role-1');
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/brands.test.ts
+++ b/src/frontend/src/api/__tests__/brands.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { brandsApi } from '../brands';
+
+/**
+ * Tests for src/api/brands.ts
+ */
+describe('brandsApi', () => {
+  describe('list', () => {
+    it('returns a list of brands', async () => {
+      const brands = await brandsApi.list();
+
+      expect(brands).toHaveLength(1);
+      expect(brands[0]).toMatchObject({
+        id: 'brand-1',
+        slug: 'frietjes',
+        name: 'Frietjes?',
+        isActive: true,
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await brandsApi.list();
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('get', () => {
+    it('returns a single brand by id', async () => {
+      const brand = await brandsApi.get('brand-1');
+      expect(brand).toMatchObject({ id: 'brand-1', slug: 'frietjes' });
+    });
+  });
+
+  describe('create', () => {
+    it('creates a brand and returns the created entity', async () => {
+      const brand = await brandsApi.create({
+        name: 'New Brand',
+        slug: 'new-brand',
+        contactEmail: 'new@brand.com',
+      });
+
+      expect(brand).toMatchObject({
+        slug: 'new-brand',
+        name: 'New Brand',
+        contactEmail: 'new@brand.com',
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('updates a brand and returns the updated entity', async () => {
+      const brand = await brandsApi.update('brand-1', {
+        name: 'Updated Name',
+        contactEmail: 'updated@frietjes.be',
+      });
+
+      expect(brand).toMatchObject({ name: 'Updated Name' });
+    });
+  });
+
+  describe('deactivate / activate', () => {
+    it('deactivates a brand without throwing', async () => {
+      await expect(brandsApi.deactivate('brand-1')).resolves.toBeUndefined();
+    });
+
+    it('activates a brand without throwing', async () => {
+      await expect(brandsApi.activate('brand-1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('configureStaffAuth', () => {
+    it('updates the staff auth method', async () => {
+      const brand = await brandsApi.configureStaffAuth('frietjes', 'GoogleSso');
+      expect(brand).toMatchObject({ staffAuthMethod: 'GoogleSso' });
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/client.test.ts
+++ b/src/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { apiClient, setActiveBrandSlug, getActiveBrandSlug } from '../client';
+
+/**
+ * Tests for the shared axios client:
+ * - X-Brand-Slug header injection via active-brand helper
+ * - 401 → dispatches auth:session-expired window event
+ * - 403 → dispatches auth:access-denied window event
+ */
+describe('apiClient interceptors', () => {
+  afterEach(() => {
+    // Reset brand slug between tests to avoid state leakage
+    setActiveBrandSlug('');
+  });
+
+  describe('active brand helper', () => {
+    it('getActiveBrandSlug returns null by default', () => {
+      // Module-level state may be set from previous test suites; we reset above
+      // but the initial value is null — test the getter/setter contract.
+      setActiveBrandSlug('frietjes');
+      expect(getActiveBrandSlug()).toBe('frietjes');
+    });
+
+    it('setActiveBrandSlug updates the stored slug', () => {
+      setActiveBrandSlug('brand-x');
+      expect(getActiveBrandSlug()).toBe('brand-x');
+    });
+  });
+
+  describe('X-Brand-Slug header', () => {
+    it('attaches X-Brand-Slug when an active brand is set', async () => {
+      let capturedSlug: string | null = null;
+
+      server.use(
+        http.get('/api/brands', ({ request }) => {
+          capturedSlug = request.headers.get('X-Brand-Slug');
+          return HttpResponse.json([]);
+        }),
+      );
+
+      setActiveBrandSlug('frietjes');
+      await apiClient.get('/brands');
+
+      expect(capturedSlug).toBe('frietjes');
+    });
+
+    it('does not attach X-Brand-Slug when no active brand is set', async () => {
+      let capturedSlug: string | null = 'sentinel';
+
+      server.use(
+        http.get('/api/brands', ({ request }) => {
+          capturedSlug = request.headers.get('X-Brand-Slug');
+          return HttpResponse.json([]);
+        }),
+      );
+
+      setActiveBrandSlug('');
+      await apiClient.get('/brands');
+
+      expect(capturedSlug).toBeNull();
+    });
+  });
+
+  describe('401 → auth:session-expired event', () => {
+    it('dispatches auth:session-expired on 401 response', async () => {
+      server.use(
+        http.get('/api/brands', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await apiClient.get('/brands');
+      } catch {
+        // Expected rejection
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT dispatch auth:session-expired on 403 response', async () => {
+      server.use(
+        http.get('/api/brands', () => new HttpResponse(null, { status: 403 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await apiClient.get('/brands');
+      } catch {
+        // Expected rejection
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('403 → auth:access-denied event', () => {
+    it('dispatches auth:access-denied on 403 response', async () => {
+      server.use(
+        http.get('/api/brands', () => new HttpResponse(null, { status: 403 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:access-denied', listener);
+
+      try {
+        await apiClient.get('/brands');
+      } catch {
+        // Expected rejection
+      } finally {
+        window.removeEventListener('auth:access-denied', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT dispatch auth:access-denied on 401 response', async () => {
+      server.use(
+        http.get('/api/brands', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:access-denied', listener);
+
+      try {
+        await apiClient.get('/brands');
+      } catch {
+        // Expected rejection
+      } finally {
+        window.removeEventListener('auth:access-denied', listener);
+      }
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful responses', () => {
+    it('returns 2xx responses normally without dispatching events', async () => {
+      const sessionExpiredListener = vi.fn();
+      const accessDeniedListener = vi.fn();
+      window.addEventListener('auth:session-expired', sessionExpiredListener);
+      window.addEventListener('auth:access-denied', accessDeniedListener);
+
+      try {
+        const response = await apiClient.get('/brands');
+        expect(response.status).toBe(200);
+      } finally {
+        window.removeEventListener('auth:session-expired', sessionExpiredListener);
+        window.removeEventListener('auth:access-denied', accessDeniedListener);
+      }
+
+      expect(sessionExpiredListener).not.toHaveBeenCalled();
+      expect(accessDeniedListener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/menuCategories.test.ts
+++ b/src/frontend/src/api/__tests__/menuCategories.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { menuCategoriesApi } from '../menuCategories';
+
+const BRAND_SLUG = 'frietjes';
+
+/**
+ * Tests for src/api/menuCategories.ts
+ */
+describe('menuCategoriesApi', () => {
+  describe('list', () => {
+    it('returns a list of menu category list items', async () => {
+      const categories = await menuCategoriesApi.list(BRAND_SLUG);
+
+      expect(categories).toHaveLength(1);
+      expect(categories[0]).toMatchObject({
+        id: 'cat-1',
+        name: 'Frietjes',
+        sortOrder: 1,
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/menu-categories', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await menuCategoriesApi.list(BRAND_SLUG);
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('get', () => {
+    it('returns a single menu category with translations', async () => {
+      const category = await menuCategoriesApi.get(BRAND_SLUG, 'cat-1');
+      expect(category).toMatchObject({ id: 'cat-1', sortOrder: 1 });
+      expect(category.translations).toHaveLength(1);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a category and returns the created entity', async () => {
+      const category = await menuCategoriesApi.create(BRAND_SLUG, {
+        sortOrder: 2,
+        imageUrl: null,
+        translations: [{ languageCode: 'nl', name: 'Sauzen' }],
+      });
+
+      expect(category).toMatchObject({ sortOrder: 2, productCount: 0 });
+    });
+  });
+
+  describe('update', () => {
+    it('updates a category and returns the updated entity', async () => {
+      const category = await menuCategoriesApi.update(BRAND_SLUG, 'cat-1', {
+        sortOrder: 1,
+        imageUrl: null,
+        translations: [{ languageCode: 'nl', name: 'Frietjes Updated' }],
+      });
+
+      expect(category).toMatchObject({ id: 'cat-1' });
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes a category without throwing', async () => {
+      await expect(menuCategoriesApi.remove(BRAND_SLUG, 'cat-1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('reorder', () => {
+    it('reorders a category without throwing', async () => {
+      await expect(
+        menuCategoriesApi.reorder(BRAND_SLUG, 'cat-1', { sortOrder: 2 }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('assignProduct', () => {
+    it('assigns a product to a category without throwing', async () => {
+      await expect(
+        menuCategoriesApi.assignProduct(BRAND_SLUG, {
+          productId: 'prod-1',
+          categoryId: 'cat-1',
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('listProducts', () => {
+    it('returns products for a category', async () => {
+      const products = await menuCategoriesApi.listProducts(BRAND_SLUG, 'cat-1');
+      expect(Array.isArray(products)).toBe(true);
+    });
+  });
+
+  describe('reorderProducts', () => {
+    it('reorders products in a category without throwing', async () => {
+      await expect(
+        menuCategoriesApi.reorderProducts(BRAND_SLUG, 'cat-1', {
+          productIds: ['prod-1', 'prod-2'],
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/modifierGroups.test.ts
+++ b/src/frontend/src/api/__tests__/modifierGroups.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { modifierGroupsApi } from '../modifierGroups';
+
+const BRAND_SLUG = 'frietjes';
+
+/**
+ * Tests for src/api/modifierGroups.ts
+ */
+describe('modifierGroupsApi', () => {
+  describe('list', () => {
+    it('returns a list of modifier group list items', async () => {
+      const groups = await modifierGroupsApi.list(BRAND_SLUG);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0]).toMatchObject({ id: 'mg-1', name: 'Sauzen', modifierCount: 3 });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/modifier-groups', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await modifierGroupsApi.list(BRAND_SLUG);
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('get', () => {
+    it('returns a single modifier group with modifiers', async () => {
+      const group = await modifierGroupsApi.get(BRAND_SLUG, 'mg-1');
+      expect(group).toMatchObject({ id: 'mg-1' });
+      expect(group.modifiers).toHaveLength(1);
+      expect(group.modifiers[0]).toMatchObject({ id: 'mod-1' });
+    });
+  });
+
+  describe('create', () => {
+    it('creates a modifier group and returns the created entity', async () => {
+      const group = await modifierGroupsApi.create(BRAND_SLUG, {
+        translations: [{ languageCode: 'nl', name: 'Extras' }],
+        modifiers: [
+          {
+            translations: [{ languageCode: 'nl', name: 'Extra kaas' }],
+            priceAdjustment: 0.5,
+            sortOrder: 1,
+          },
+        ],
+      });
+
+      expect(group).toMatchObject({ id: 'mg-new' });
+    });
+  });
+
+  describe('update', () => {
+    it('updates a modifier group and returns the updated entity', async () => {
+      const group = await modifierGroupsApi.update(BRAND_SLUG, 'mg-1', {
+        translations: [{ languageCode: 'nl', name: 'Sauzen Updated' }],
+        modifiers: [],
+      });
+
+      expect(group).toMatchObject({ id: 'mg-1' });
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes a modifier group without throwing', async () => {
+      await expect(modifierGroupsApi.remove(BRAND_SLUG, 'mg-1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getProductModifierGroups', () => {
+    it('returns modifier groups for a product', async () => {
+      const groups = await modifierGroupsApi.getProductModifierGroups(BRAND_SLUG, 'prod-1');
+      expect(groups).toHaveLength(1);
+      expect(groups[0]).toMatchObject({ modifierGroupId: 'mg-1' });
+    });
+  });
+
+  describe('setProductModifierGroups', () => {
+    it('sets modifier groups on a product without throwing', async () => {
+      await expect(
+        modifierGroupsApi.setProductModifierGroups(BRAND_SLUG, 'prod-1', {
+          modifierGroups: [{ modifierGroupId: 'mg-1', sortOrder: 1 }],
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/openingHours.test.ts
+++ b/src/frontend/src/api/__tests__/openingHours.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { openingHoursApi } from '../openingHours';
+
+const BRAND_SLUG = 'frietjes';
+const SHOP_ID = 'shop-1';
+
+/**
+ * Tests for src/api/openingHours.ts
+ */
+describe('openingHoursApi', () => {
+  describe('get', () => {
+    it('returns opening hours for a shop', async () => {
+      const hours = await openingHoursApi.get(BRAND_SLUG, SHOP_ID);
+
+      expect(hours.timeBlocks).toHaveLength(1);
+      expect(hours.timeBlocks[0]).toMatchObject({
+        dayOfWeek: 1,
+        openTime: '09:00',
+        closeTime: '18:00',
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/shops/:shopId/opening-hours', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await openingHoursApi.get(BRAND_SLUG, SHOP_ID);
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('set', () => {
+    it('sets opening hours and returns the updated schedule', async () => {
+      const result = await openingHoursApi.set(BRAND_SLUG, SHOP_ID, {
+        timeBlocks: [
+          { dayOfWeek: 1, openTime: '10:00', closeTime: '20:00' },
+          { dayOfWeek: 2, openTime: '10:00', closeTime: '20:00' },
+        ],
+      });
+
+      expect(result.timeBlocks).toHaveLength(2);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns the real-time open/closed status', async () => {
+      const status = await openingHoursApi.getStatus(BRAND_SLUG, SHOP_ID);
+
+      expect(status).toMatchObject({
+        isOpen: true,
+        nextOpeningTime: null,
+        timeZoneId: 'Europe/Brussels',
+      });
+    });
+
+    it('reports closed status correctly', async () => {
+      server.use(
+        http.get('/api/brands/:slug/shops/:shopId/status', () =>
+          HttpResponse.json({
+            isOpen: false,
+            nextOpeningTime: '2024-06-01T10:00:00Z',
+            timeZoneId: 'Europe/Brussels',
+          }),
+        ),
+      );
+
+      const status = await openingHoursApi.getStatus(BRAND_SLUG, SHOP_ID);
+      expect(status.isOpen).toBe(false);
+      expect(status.nextOpeningTime).toBeDefined();
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/orderLifecycle.test.ts
+++ b/src/frontend/src/api/__tests__/orderLifecycle.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { orderLifecycleApi } from '../orderLifecycle';
+
+const BRAND_SLUG = 'frietjes';
+const SHOP_ID = 'shop-1';
+
+/**
+ * Tests for src/api/orderLifecycle.ts
+ */
+describe('orderLifecycleApi', () => {
+  describe('get', () => {
+    it('returns the order lifecycle configuration for a shop', async () => {
+      const lifecycle = await orderLifecycleApi.get(BRAND_SLUG, SHOP_ID);
+
+      expect(lifecycle).toMatchObject({ shopId: SHOP_ID });
+      expect(lifecycle.statuses).toHaveLength(1);
+      expect(lifecycle.statuses[0]).toMatchObject({
+        id: 'status-1',
+        name: 'New',
+        systemKey: 'new',
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/shops/:shopId/order-lifecycle', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await orderLifecycleApi.get(BRAND_SLUG, SHOP_ID);
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('configure', () => {
+    it('updates the lifecycle and returns the updated config', async () => {
+      const config = {
+        statuses: [
+          {
+            name: 'Pending',
+            systemKey: 'pending',
+            sortOrder: 1,
+            isTerminal: false,
+            colorHex: '#f59e0b',
+          },
+          {
+            name: 'Done',
+            systemKey: 'done',
+            sortOrder: 2,
+            isTerminal: true,
+            colorHex: '#22c55e',
+          },
+        ],
+        transitions: [{ fromSortOrder: 1, toSortOrder: 2 }],
+      };
+
+      const result = await orderLifecycleApi.configure(BRAND_SLUG, SHOP_ID, config);
+
+      expect(result.shopId).toBe(SHOP_ID);
+      expect(result.statuses).toHaveLength(2);
+    });
+  });
+
+  describe('reset', () => {
+    it('resets the lifecycle to defaults and returns the reset config', async () => {
+      const result = await orderLifecycleApi.reset(BRAND_SLUG, SHOP_ID);
+      expect(result.shopId).toBe(SHOP_ID);
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/platformAdmins.test.ts
+++ b/src/frontend/src/api/__tests__/platformAdmins.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { platformAdminsApi } from '../platformAdmins';
+
+/**
+ * Tests for src/api/platformAdmins.ts
+ */
+describe('platformAdminsApi', () => {
+  describe('list', () => {
+    it('returns a list of platform admins', async () => {
+      const admins = await platformAdminsApi.list();
+
+      expect(admins).toHaveLength(1);
+      expect(admins[0]).toMatchObject({
+        id: 'pa-1',
+        email: 'admin@platform.dev',
+        isPlatformAdmin: true,
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/platform-admins', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await platformAdminsApi.list();
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('invite', () => {
+    it('invites a platform admin and returns the created entity', async () => {
+      const admin = await platformAdminsApi.invite({
+        email: 'new-admin@platform.dev',
+        displayName: 'New Admin',
+      });
+
+      expect(admin).toMatchObject({
+        email: 'new-admin@platform.dev',
+        displayName: 'New Admin',
+        isPlatformAdmin: true,
+      });
+    });
+  });
+
+  describe('deactivate', () => {
+    it('deactivates a platform admin without throwing', async () => {
+      await expect(platformAdminsApi.deactivate('pa-1')).resolves.toBeUndefined();
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.post('/api/platform-admins/:id/deactivate', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await platformAdminsApi.deactivate('pa-1');
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/products.test.ts
+++ b/src/frontend/src/api/__tests__/products.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { productsApi } from '../products';
+
+const BRAND_SLUG = 'frietjes';
+
+const SIMPLE_PRODUCT_REQUEST = {
+  basePrice: 3.5,
+  imageUrl: null,
+  translations: [{ languageCode: 'nl', name: 'Kleine friet', description: null }],
+  allergens: [],
+  dietaryTags: [],
+};
+
+/**
+ * Tests for src/api/products.ts
+ */
+describe('productsApi', () => {
+  describe('list', () => {
+    it('returns a list of product list items', async () => {
+      const products = await productsApi.list(BRAND_SLUG);
+
+      expect(products).toHaveLength(1);
+      expect(products[0]).toMatchObject({
+        id: 'prod-1',
+        productType: 'Simple',
+        name: 'Kleine friet',
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/products', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await productsApi.list(BRAND_SLUG);
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('get', () => {
+    it('returns a single product with full details', async () => {
+      const product = await productsApi.get(BRAND_SLUG, 'prod-1');
+      expect(product).toMatchObject({
+        id: 'prod-1',
+        productType: 'Simple',
+        comboItems: null,
+      });
+      expect(product.translations).toHaveLength(1);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a simple product and returns the created entity', async () => {
+      const product = await productsApi.create(BRAND_SLUG, SIMPLE_PRODUCT_REQUEST);
+
+      expect(product).toMatchObject({
+        id: 'prod-new',
+        productType: 'Simple',
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('updates a product and returns the updated entity', async () => {
+      const product = await productsApi.update(BRAND_SLUG, 'prod-1', {
+        ...SIMPLE_PRODUCT_REQUEST,
+        basePrice: 4.0,
+      });
+
+      expect(product).toMatchObject({ id: 'prod-1' });
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes a product without throwing', async () => {
+      await expect(productsApi.remove(BRAND_SLUG, 'prod-1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('createCombo', () => {
+    it('creates a combo product and returns the created entity', async () => {
+      const product = await productsApi.createCombo(BRAND_SLUG, {
+        basePrice: 9.99,
+        imageUrl: null,
+        translations: [{ languageCode: 'nl', name: 'Frietjes menu', description: null }],
+        componentProductIds: ['prod-1', 'prod-2'],
+      });
+
+      expect(product).toMatchObject({ id: 'combo-new', productType: 'Combo' });
+      expect(product.comboItems).toHaveLength(2);
+    });
+  });
+
+  describe('updateCombo', () => {
+    it('updates a combo product and returns the updated entity', async () => {
+      const product = await productsApi.updateCombo(BRAND_SLUG, 'combo-1', {
+        basePrice: 10.99,
+        imageUrl: null,
+        translations: [{ languageCode: 'nl', name: 'Frietjes menu XL', description: null }],
+        componentProductIds: ['prod-1', 'prod-2', 'prod-3'],
+      });
+
+      expect(product).toMatchObject({ productType: 'Combo' });
+      expect(product.comboItems).toHaveLength(3);
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/shops.test.ts
+++ b/src/frontend/src/api/__tests__/shops.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { shopsApi } from '../shops';
+
+const BRAND_SLUG = 'frietjes';
+const SHOP_ADDRESS = {
+  street: 'Veldstraat',
+  number: '1',
+  city: 'Gent',
+  postalCode: '9000',
+  country: 'BE',
+};
+
+/**
+ * Tests for src/api/shops.ts
+ */
+describe('shopsApi', () => {
+  describe('list', () => {
+    it('returns a list of shops', async () => {
+      const shops = await shopsApi.list(BRAND_SLUG);
+
+      expect(shops).toHaveLength(1);
+      expect(shops[0]).toMatchObject({
+        id: 'shop-1',
+        name: 'Gent Centrum',
+        slug: 'gent-centrum',
+      });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/shops', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await shopsApi.list(BRAND_SLUG);
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('get', () => {
+    it('returns a single shop by id', async () => {
+      const shop = await shopsApi.get(BRAND_SLUG, 'shop-1');
+      expect(shop).toMatchObject({ id: 'shop-1', name: 'Gent Centrum' });
+    });
+  });
+
+  describe('create', () => {
+    it('creates a shop and returns the created entity', async () => {
+      const shop = await shopsApi.create(BRAND_SLUG, {
+        name: 'Brussel Noord',
+        slug: 'brussel-noord',
+        address: SHOP_ADDRESS,
+        contactEmail: 'brussel@frietjes.be',
+      });
+
+      expect(shop).toMatchObject({
+        name: 'Brussel Noord',
+        slug: 'brussel-noord',
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('updates a shop and returns the updated entity', async () => {
+      const shop = await shopsApi.update(BRAND_SLUG, 'shop-1', {
+        name: 'Gent Centrum Updated',
+        address: SHOP_ADDRESS,
+        contactEmail: 'gent-updated@frietjes.be',
+      });
+
+      expect(shop).toMatchObject({ name: 'Gent Centrum Updated' });
+    });
+  });
+
+  describe('deactivate / activate', () => {
+    it('deactivates a shop without throwing', async () => {
+      await expect(shopsApi.deactivate(BRAND_SLUG, 'shop-1')).resolves.toBeUndefined();
+    });
+
+    it('activates a shop without throwing', async () => {
+      await expect(shopsApi.activate(BRAND_SLUG, 'shop-1')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/frontend/src/api/__tests__/taxConfiguration.test.ts
+++ b/src/frontend/src/api/__tests__/taxConfiguration.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { taxConfigurationApi } from '../taxConfiguration';
+
+const BRAND_SLUG = 'frietjes';
+
+/**
+ * Tests for src/api/taxConfiguration.ts
+ */
+describe('taxConfigurationApi', () => {
+  describe('get', () => {
+    it('returns the tax configuration for a brand', async () => {
+      const config = await taxConfigurationApi.get(BRAND_SLUG);
+
+      expect(config).toMatchObject({ id: 'tax-1' });
+      expect(config.vatRates).toHaveLength(2);
+      expect(config.vatRates).toContainEqual({ consumptionMode: 'Takeaway', ratePercentage: 6 });
+      expect(config.vatRates).toContainEqual({ consumptionMode: 'EatIn', ratePercentage: 21 });
+    });
+
+    it('dispatches auth:session-expired on 401', async () => {
+      server.use(
+        http.get('/api/brands/:slug/tax-configuration', () =>
+          new HttpResponse(null, { status: 401 }),
+        ),
+      );
+
+      const listener = vi.fn();
+      window.addEventListener('auth:session-expired', listener);
+
+      try {
+        await taxConfigurationApi.get(BRAND_SLUG);
+      } catch {
+        // Expected
+      } finally {
+        window.removeEventListener('auth:session-expired', listener);
+      }
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('update', () => {
+    it('updates the VAT rates and returns the updated config', async () => {
+      const updated = await taxConfigurationApi.update(BRAND_SLUG, {
+        vatRates: [
+          { consumptionMode: 'Takeaway', ratePercentage: 9 },
+          { consumptionMode: 'EatIn', ratePercentage: 21 },
+        ],
+      });
+
+      expect(updated.vatRates).toContainEqual({
+        consumptionMode: 'Takeaway',
+        ratePercentage: 9,
+      });
+    });
+  });
+
+  describe('calculate', () => {
+    it('calculates VAT breakdown for takeaway consumption mode', async () => {
+      const result = await taxConfigurationApi.calculate(BRAND_SLUG, 10.6, 'Takeaway');
+
+      // 6% VAT on 10.60 gross: VAT = 10.60 * 6/106 ≈ 0.60; net ≈ 10.00
+      expect(result.grossAmount).toBe(10.6);
+      expect(result.vatRatePercentage).toBe(6);
+      expect(result.vatAmount).toBeGreaterThan(0);
+      expect(result.netAmount + result.vatAmount).toBeCloseTo(result.grossAmount, 1);
+    });
+
+    it('calculates VAT breakdown for eat-in consumption mode', async () => {
+      const result = await taxConfigurationApi.calculate(BRAND_SLUG, 12.1, 'EatIn');
+
+      expect(result.vatRatePercentage).toBe(21);
+      expect(result.grossAmount).toBe(12.1);
+    });
+  });
+});

--- a/src/frontend/src/auth/__tests__/AuthProviderSwitch.test.tsx
+++ b/src/frontend/src/auth/__tests__/AuthProviderSwitch.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProviderSwitch } from '../AuthProviderSwitch';
+
+/**
+ * Helper that renders AuthProviderSwitch in a QueryClientProvider.
+ * BffAuthProvider requires TanStack Query; MockAuthProvider does not.
+ */
+function renderSwitch(children: React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <AuthProviderSwitch>{children}</AuthProviderSwitch>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * Tests for src/auth/AuthProviderSwitch.tsx
+ *
+ * - Renders MockAuthProvider when VITE_MOCK_AUTH === 'true'
+ * - Renders BffAuthProvider otherwise (fetches /bff/user)
+ */
+describe('AuthProviderSwitch', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('renders MockAuthProvider (shows MOCK AUTH toolbar) when VITE_MOCK_AUTH=true', () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'true');
+
+    renderSwitch(<div data-testid="child">Child content</div>);
+
+    expect(screen.getByText('MOCK AUTH')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('does NOT show MOCK AUTH toolbar when VITE_MOCK_AUTH=false', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'false');
+
+    // BffAuthProvider fetches /bff/user — MSW handler returns authenticated user
+    renderSwitch(<div data-testid="child">Child content</div>);
+
+    // Wait for BffAuthProvider to settle
+    await waitFor(() => {
+      expect(screen.getByTestId('child')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('MOCK AUTH')).not.toBeInTheDocument();
+  });
+
+  it('renders BffAuthProvider when VITE_MOCK_AUTH is unset', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', '');
+
+    renderSwitch(<div data-testid="bff-child">BFF child</div>);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bff-child')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('MOCK AUTH')).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/auth/__tests__/BffAuthProvider.test.tsx
+++ b/src/frontend/src/auth/__tests__/BffAuthProvider.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BffAuthProvider } from '../BffAuthProvider';
+import { useAuth } from '../useAuth';
+import * as useSessionKeepaliveModule from '../useSessionKeepalive';
+
+// bffClient uses baseURL '/bff' which resolves to /bff in jsdom
+
+/**
+ * Helper component that shows auth state.
+ */
+function AuthDisplay() {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  if (isLoading) return <div data-testid="loading">Loading...</div>;
+  return (
+    <div>
+      <span data-testid="is-authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="display-name">{user?.displayName ?? 'null'}</span>
+    </div>
+  );
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+/**
+ * Tests for src/auth/BffAuthProvider.tsx
+ *
+ * - Fetches /bff/user via TanStack Query on mount
+ * - auth:session-expired event invalidates the user query
+ * - useSessionKeepalive is invoked on mount
+ */
+describe('BffAuthProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state while /bff/user is being fetched', async () => {
+    // Make /bff/user hang for a moment
+    server.use(
+      http.get('/bff/user', async () => {
+        await new Promise((r) => setTimeout(r, 200));
+        return HttpResponse.json({ isAuthenticated: false });
+      }),
+    );
+
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <BffAuthProvider>
+          <AuthDisplay />
+        </BffAuthProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+  });
+
+  it('renders authenticated state after /bff/user resolves', async () => {
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <BffAuthProvider>
+          <AuthDisplay />
+        </BffAuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
+    });
+    expect(screen.getByTestId('display-name').textContent).toBe('Test User');
+  });
+
+  it('renders unauthenticated state when /bff/user returns isAuthenticated=false', async () => {
+    server.use(
+      http.get('/bff/user', () => HttpResponse.json({ isAuthenticated: false })),
+    );
+
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <BffAuthProvider>
+          <AuthDisplay />
+        </BffAuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
+    });
+  });
+
+  it('invalidates user query when auth:session-expired event fires', async () => {
+    // First render with authenticated user
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <BffAuthProvider>
+          <AuthDisplay />
+        </BffAuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
+    });
+
+    // Switch server to return unauthenticated
+    server.use(
+      http.get('/bff/user', () => HttpResponse.json({ isAuthenticated: false })),
+    );
+
+    // Dispatch the session-expired event
+    window.dispatchEvent(new CustomEvent('auth:session-expired'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-authenticated').textContent).toBe('false');
+    });
+  });
+
+  it('calls useSessionKeepalive on mount', async () => {
+    const keepaliveSpy = vi
+      .spyOn(useSessionKeepaliveModule, 'useSessionKeepalive')
+      .mockImplementation(() => undefined);
+
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <BffAuthProvider>
+          <div />
+        </BffAuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(keepaliveSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/frontend/src/auth/__tests__/MockAuthProvider.test.tsx
+++ b/src/frontend/src/auth/__tests__/MockAuthProvider.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MockAuthProvider } from '../MockAuthProvider';
+import { useAuth } from '../useAuth';
+
+/**
+ * Helper component that exposes auth context values via accessible text.
+ */
+function AuthDisplay() {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  return (
+    <div>
+      <span data-testid="is-authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="is-loading">{String(isLoading)}</span>
+      <span data-testid="display-name">{user?.displayName ?? 'null'}</span>
+      <span data-testid="role">{user?.roles[0] ?? 'null'}</span>
+    </div>
+  );
+}
+
+/**
+ * Tests for src/auth/MockAuthProvider.tsx
+ *
+ * - Reads VITE_MOCK_ROLE / VITE_MOCK_DISPLAY_NAME via mocked import.meta.env
+ * - Role-switcher toolbar updates context
+ * - Always authenticated (isLoading=false, isAuthenticated=true)
+ */
+describe('MockAuthProvider', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('is always authenticated with isLoading=false', () => {
+    render(
+      <MockAuthProvider>
+        <AuthDisplay />
+      </MockAuthProvider>,
+    );
+
+    expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
+    expect(screen.getByTestId('is-loading').textContent).toBe('false');
+  });
+
+  it('uses VITE_MOCK_ROLE env var for the initial role', () => {
+    vi.stubEnv('VITE_MOCK_ROLE', 'platform-admin');
+
+    render(
+      <MockAuthProvider>
+        <AuthDisplay />
+      </MockAuthProvider>,
+    );
+
+    expect(screen.getByTestId('role').textContent).toBe('platform-admin');
+  });
+
+  it('uses VITE_MOCK_DISPLAY_NAME env var for the display name', () => {
+    vi.stubEnv('VITE_MOCK_ROLE', 'brand-admin');
+    vi.stubEnv('VITE_MOCK_DISPLAY_NAME', 'Friet Baron');
+
+    render(
+      <MockAuthProvider>
+        <AuthDisplay />
+      </MockAuthProvider>,
+    );
+
+    expect(screen.getByTestId('display-name').textContent).toBe('Friet Baron');
+  });
+
+  it('falls back to platform-admin role when VITE_MOCK_ROLE is not set', () => {
+    // Do NOT stub VITE_MOCK_ROLE — leave it undefined so the ?? fallback triggers.
+    // When neither env var is stubbed, import.meta.env.VITE_MOCK_ROLE is undefined.
+    vi.stubEnv('VITE_MOCK_DISPLAY_NAME', 'Dev User');
+
+    render(
+      <MockAuthProvider>
+        <AuthDisplay />
+      </MockAuthProvider>,
+    );
+
+    // undefined ?? 'platform-admin' → 'platform-admin'
+    expect(screen.getByTestId('role').textContent).toBe('platform-admin');
+    expect(screen.getByTestId('display-name').textContent).toBe('Dev User');
+  });
+
+  it('renders the role-switcher toolbar', () => {
+    render(
+      <MockAuthProvider>
+        <div />
+      </MockAuthProvider>,
+    );
+
+    expect(screen.getByText('MOCK AUTH')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('updates auth context when the role switcher changes', () => {
+    vi.stubEnv('VITE_MOCK_ROLE', 'brand-admin');
+
+    render(
+      <MockAuthProvider>
+        <AuthDisplay />
+      </MockAuthProvider>,
+    );
+
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'counter-staff' } });
+
+    expect(screen.getByTestId('role').textContent).toBe('counter-staff');
+  });
+});

--- a/src/frontend/src/auth/__tests__/RequireAuth.test.tsx
+++ b/src/frontend/src/auth/__tests__/RequireAuth.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthContext } from '../AuthContext';
+import { RequireAuth } from '../RequireAuth';
+import type { AuthContextValue } from '../AuthContext';
+import type { UserRole } from '@/types/auth';
+
+/**
+ * Factory for AuthContextValue to reduce boilerplate in tests.
+ */
+function makeAuthContext(overrides: Partial<AuthContextValue>): AuthContextValue {
+  return {
+    isAuthenticated: false,
+    user: null,
+    isLoading: false,
+    login: () => undefined,
+    logout: () => Promise.resolve(),
+    hasRole: () => false,
+    hasAnyRole: () => false,
+    ...overrides,
+  };
+}
+
+function renderRequireAuth(ctx: AuthContextValue, roles?: UserRole[]) {
+  const guarded = roles ? (
+    <RequireAuth roles={roles}>
+      <div data-testid="protected-content">Protected</div>
+    </RequireAuth>
+  ) : (
+    <RequireAuth>
+      <div data-testid="protected-content">Protected</div>
+    </RequireAuth>
+  );
+
+  return render(
+    <MemoryRouter>
+      <AuthContext.Provider value={ctx}>{guarded}</AuthContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Tests for src/auth/RequireAuth.tsx
+ *
+ * Four states:
+ * 1. isLoading → spinner
+ * 2. not authenticated → login button
+ * 3. authenticated but missing required role → access denied
+ * 4. authenticated + role matched → renders children
+ */
+describe('RequireAuth', () => {
+  it('renders a spinner while loading', () => {
+    const { container } = renderRequireAuth(makeAuthContext({ isLoading: true }));
+
+    // The spinner is the element with animate-spin class
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+  });
+
+  it('renders a login button when not authenticated', () => {
+    renderRequireAuth(makeAuthContext({ isAuthenticated: false, isLoading: false }));
+
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+  });
+
+  it('renders access denied when authenticated but missing required role', () => {
+    renderRequireAuth(
+      makeAuthContext({
+        isAuthenticated: true,
+        user: {
+          userId: 'user-1',
+          displayName: 'User',
+          email: 'user@test.com',
+          roles: ['counter-staff'],
+          brandSlug: 'frietjes',
+        },
+        hasAnyRole: () => false,
+      }),
+      ['brand-admin', 'platform-admin'],
+    );
+
+    expect(screen.getByText('Access denied.')).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+  });
+
+  it('renders children when authenticated and role matches', () => {
+    renderRequireAuth(
+      makeAuthContext({
+        isAuthenticated: true,
+        user: {
+          userId: 'user-1',
+          displayName: 'Brand Admin',
+          email: 'admin@frietjes.be',
+          roles: ['brand-admin'],
+          brandSlug: 'frietjes',
+        },
+        hasAnyRole: (roles) => roles.includes('brand-admin'),
+      }),
+      ['brand-admin'],
+    );
+
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+    expect(screen.queryByText('Access denied.')).not.toBeInTheDocument();
+  });
+
+  it('renders children when authenticated and no roles are required', () => {
+    renderRequireAuth(
+      makeAuthContext({
+        isAuthenticated: true,
+        user: {
+          userId: 'user-1',
+          displayName: 'Any User',
+          email: 'user@test.com',
+          roles: ['customer'],
+          brandSlug: null,
+        },
+        hasAnyRole: () => false,
+      }),
+      // No roles argument — public route
+    );
+
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/auth/__tests__/useAuth.test.tsx
+++ b/src/frontend/src/auth/__tests__/useAuth.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { AuthContext } from '../AuthContext';
+import { useAuth } from '../useAuth';
+import type { AuthContextValue } from '../AuthContext';
+
+/**
+ * Tests for src/auth/useAuth.ts
+ *
+ * - Throws when called outside an AuthContext provider (context is null)
+ * - Returns context value when called inside a provider
+ */
+describe('useAuth', () => {
+  it('throws when called outside an AuthContext provider', () => {
+    // renderHook without a wrapper — context defaults to null
+    expect(() => {
+      renderHook(() => useAuth());
+    }).toThrow('useAuth must be used within an AuthProviderSwitch (AuthContext is null).');
+  });
+
+  it('returns the context value when called inside a provider', () => {
+    const mockContextValue: AuthContextValue = {
+      isAuthenticated: true,
+      user: {
+        userId: 'user-1',
+        displayName: 'Test User',
+        email: 'test@example.com',
+        roles: ['brand-admin'],
+        brandSlug: 'frietjes',
+      },
+      isLoading: false,
+      login: () => undefined,
+      logout: () => Promise.resolve(),
+      hasRole: (role) => role === 'brand-admin',
+      hasAnyRole: (roles) => roles.includes('brand-admin'),
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={mockContextValue}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user?.displayName).toBe('Test User');
+    expect(result.current.hasRole('brand-admin')).toBe(true);
+    expect(result.current.hasRole('platform-admin')).toBe(false);
+    expect(result.current.hasAnyRole(['platform-admin', 'brand-admin'])).toBe(true);
+  });
+
+  it('returns isLoading state from context', () => {
+    const loadingContextValue: AuthContextValue = {
+      isAuthenticated: false,
+      user: null,
+      isLoading: true,
+      login: () => undefined,
+      logout: () => Promise.resolve(),
+      hasRole: () => false,
+      hasAnyRole: () => false,
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={loadingContextValue}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+});

--- a/src/frontend/src/auth/__tests__/useSessionKeepalive.test.tsx
+++ b/src/frontend/src/auth/__tests__/useSessionKeepalive.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw/server';
+import { useSessionKeepalive } from '../useSessionKeepalive';
+
+/**
+ * Tests for src/auth/useSessionKeepalive.ts
+ *
+ * The hook uses:
+ * - setInterval at 15 min to send keepalive (only when active)
+ * - lastActivityRef updated on mousemove/keydown/click with debounce
+ * - Skips when VITE_MOCK_AUTH=true or isAuthenticated=false
+ *
+ * NOTE: bffClient uses baseURL '/bff' which in jsdom resolves to
+ * /bff. MSW node intercepts /bff/*.
+ */
+describe('useSessionKeepalive', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv('VITE_MOCK_AUTH', 'false');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('does nothing when VITE_MOCK_AUTH=true (mock mode)', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'true');
+
+    let keepaliveCalled = false;
+    server.use(
+      http.post('/bff/session/keepalive', () => {
+        keepaliveCalled = true;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    renderHook(() => useSessionKeepalive(true));
+
+    window.dispatchEvent(new MouseEvent('mousemove'));
+    await act(async () => {
+      vi.advanceTimersByTime(15 * 60 * 1000 + 100);
+      await Promise.resolve();
+    });
+
+    expect(keepaliveCalled).toBe(false);
+  });
+
+  it('does nothing when not authenticated', async () => {
+    let keepaliveCalled = false;
+    server.use(
+      http.post('/bff/session/keepalive', () => {
+        keepaliveCalled = true;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    renderHook(() => useSessionKeepalive(false));
+
+    window.dispatchEvent(new MouseEvent('mousemove'));
+    await act(async () => {
+      vi.advanceTimersByTime(15 * 60 * 1000 + 100);
+      await Promise.resolve();
+    });
+
+    expect(keepaliveCalled).toBe(false);
+  });
+
+  it('calls keepalive when there was recent user activity', async () => {
+    let keepaliveCalled = false;
+    server.use(
+      http.post('/bff/session/keepalive', () => {
+        keepaliveCalled = true;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    renderHook(() => useSessionKeepalive(true));
+
+    // Simulate activity at mount time (within the same fake-timer tick)
+    window.dispatchEvent(new MouseEvent('mousemove'));
+
+    // Let the activity debounce settle (500ms)
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // Now advance to just past the keepalive interval
+    await act(async () => {
+      vi.advanceTimersByTime(15 * 60 * 1000);
+      await Promise.resolve();
+    });
+
+    expect(keepaliveCalled).toBe(true);
+  });
+
+  it('dispatches auth:session-expired when keepalive returns 401', async () => {
+    server.use(
+      http.post('/bff/session/keepalive', () =>
+        new HttpResponse(null, { status: 401 }),
+      ),
+    );
+
+    const listener = vi.fn();
+    window.addEventListener('auth:session-expired', listener);
+
+    renderHook(() => useSessionKeepalive(true));
+
+    // Trigger activity so keepalive fires
+    window.dispatchEvent(new MouseEvent('mousemove'));
+    await act(async () => {
+      vi.advanceTimersByTime(600); // debounce
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(15 * 60 * 1000);
+      await Promise.resolve();
+    });
+
+    window.removeEventListener('auth:session-expired', listener);
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('cleans up event listeners and interval on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useSessionKeepalive(true));
+    unmount();
+
+    // Should clean up at least mousemove, keydown, click listeners
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+  });
+});

--- a/src/frontend/src/test/msw/handlers.ts
+++ b/src/frontend/src/test/msw/handlers.ts
@@ -1,0 +1,699 @@
+import { http, HttpResponse } from 'msw';
+
+/**
+ * MSW v2 request handlers covering all API routes used by src/api/* modules.
+ *
+ * These handlers provide sensible defaults that return valid fixture data.
+ * Individual tests can override specific handlers via server.use(...) to
+ * simulate error conditions (401, 403, 404, 500).
+ */
+export const handlers = [
+  // ── BFF Auth endpoints (/bff/*) ──────────────────────────────────────────
+
+  http.get('/bff/user', () =>
+    HttpResponse.json({
+      isAuthenticated: true,
+      userId: 'user-1',
+      displayName: 'Test User',
+      email: 'test@example.com',
+      roles: ['brand-admin'],
+      brandSlug: 'frietjes',
+    }),
+  ),
+
+  http.post('/bff/logout', () => new HttpResponse(null, { status: 200 })),
+
+  http.post('/bff/session/keepalive', () => new HttpResponse(null, { status: 200 })),
+
+  // ── Brands (/api/brands) ─────────────────────────────────────────────────
+
+  http.get('/api/brands', () =>
+    HttpResponse.json([
+      {
+        id: 'brand-1',
+        slug: 'frietjes',
+        name: 'Frietjes?',
+        contactEmail: 'admin@frietjes.be',
+        contactPhone: null,
+        isActive: true,
+        databaseName: 'BrandDb_frietjes',
+        staffAuthMethod: 'EmailPassword',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    ]),
+  ),
+
+  http.get('/api/brands/:id', ({ params }) =>
+    HttpResponse.json({
+      id: params.id,
+      slug: 'frietjes',
+      name: 'Frietjes?',
+      contactEmail: 'admin@frietjes.be',
+      contactPhone: null,
+      isActive: true,
+      databaseName: 'BrandDb_frietjes',
+      staffAuthMethod: 'EmailPassword',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }),
+  ),
+
+  http.post('/api/brands', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'brand-new',
+        slug: body.slug,
+        name: body.name,
+        contactEmail: body.contactEmail,
+        contactPhone: null,
+        isActive: true,
+        databaseName: `BrandDb_${String(body.slug)}`,
+        staffAuthMethod: 'EmailPassword',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.put('/api/brands/:id', async ({ params, request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: params.id,
+      slug: 'frietjes',
+      name: body.name,
+      contactEmail: body.contactEmail,
+      contactPhone: null,
+      isActive: true,
+      databaseName: 'BrandDb_frietjes',
+      staffAuthMethod: 'EmailPassword',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  http.post('/api/brands/:id/deactivate', () => new HttpResponse(null, { status: 200 })),
+  http.post('/api/brands/:id/activate', () => new HttpResponse(null, { status: 200 })),
+
+  http.put('/api/brands/:slug/staff-auth', () =>
+    HttpResponse.json({
+      id: 'brand-1',
+      slug: 'frietjes',
+      name: 'Frietjes?',
+      contactEmail: 'admin@frietjes.be',
+      contactPhone: null,
+      isActive: true,
+      databaseName: 'BrandDb_frietjes',
+      staffAuthMethod: 'GoogleSso',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    }),
+  ),
+
+  // ── Brand Settings (/api/brands/:slug/settings) ──────────────────────────
+
+  http.get('/api/brands/:slug/settings', () =>
+    HttpResponse.json({
+      id: 'settings-1',
+      defaultLanguage: 'nl',
+      timezone: 'Europe/Brussels',
+      currency: 'EUR',
+      logoUrl: null,
+      customDomain: null,
+      colors: null,
+      typography: null,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }),
+  ),
+
+  http.put('/api/brands/:slug/settings/theming', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: 'settings-1',
+      defaultLanguage: 'nl',
+      timezone: 'Europe/Brussels',
+      currency: 'EUR',
+      logoUrl: null,
+      customDomain: body.customDomain ?? null,
+      colors: body.colors ?? null,
+      typography: body.typography ?? null,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  http.post('/api/brands/:slug/settings/logo', () =>
+    HttpResponse.json({ logoUrl: 'https://cdn.example.com/logo.png' }),
+  ),
+
+  http.get('/api/brands/:slug/theme', () =>
+    HttpResponse.json({
+      logoUrl: null,
+      customDomain: null,
+      primaryColor: '#2563eb',
+      secondaryColor: '#64748b',
+      accentColor: '#f59e0b',
+      headingFontFamily: 'Inter',
+      bodyFontFamily: 'System Default',
+    }),
+  ),
+
+  // ── Brand Staff (/api/brands/:slug/staff) ───────────────────────────────
+
+  http.get('/api/brands/:slug/staff', () =>
+    HttpResponse.json([
+      {
+        id: 'staff-1',
+        email: 'staff@frietjes.be',
+        displayName: 'Staff Member',
+        roleId: 'role-1',
+        role: 0,
+        shopId: null,
+        shopName: null,
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]),
+  ),
+
+  http.get('/api/brands/:slug/shops/:shopId/staff', () =>
+    HttpResponse.json([]),
+  ),
+
+  http.post('/api/brands/:slug/staff', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'staff-new',
+        email: body.email,
+        displayName: body.displayName,
+        roleId: 'role-new',
+        role: body.role,
+        shopId: body.shopId ?? null,
+        shopName: null,
+        createdAt: '2024-06-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.post('/api/brands/:slug/staff/:roleId/deactivate', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  // ── Shops (/api/brands/:slug/shops) ─────────────────────────────────────
+
+  http.get('/api/brands/:slug/shops', () =>
+    HttpResponse.json([
+      {
+        id: 'shop-1',
+        name: 'Gent Centrum',
+        slug: 'gent-centrum',
+        address: {
+          street: 'Veldstraat',
+          number: '1',
+          city: 'Gent',
+          postalCode: '9000',
+          country: 'BE',
+        },
+        contactEmail: 'gent@frietjes.be',
+        contactPhone: null,
+        isActive: true,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    ]),
+  ),
+
+  http.get('/api/brands/:slug/shops/:shopId', ({ params }) =>
+    HttpResponse.json({
+      id: params.shopId,
+      name: 'Gent Centrum',
+      slug: 'gent-centrum',
+      address: {
+        street: 'Veldstraat',
+        number: '1',
+        city: 'Gent',
+        postalCode: '9000',
+        country: 'BE',
+      },
+      contactEmail: 'gent@frietjes.be',
+      contactPhone: null,
+      isActive: true,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }),
+  ),
+
+  http.post('/api/brands/:slug/shops', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'shop-new',
+        name: body.name,
+        slug: body.slug,
+        address: body.address,
+        contactEmail: body.contactEmail,
+        contactPhone: body.contactPhone ?? null,
+        isActive: true,
+        createdAt: '2024-06-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.put('/api/brands/:slug/shops/:shopId', async ({ params, request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: params.shopId,
+      name: body.name,
+      slug: 'gent-centrum',
+      address: body.address,
+      contactEmail: body.contactEmail,
+      contactPhone: body.contactPhone ?? null,
+      isActive: true,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  http.post('/api/brands/:slug/shops/:shopId/deactivate', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  http.post('/api/brands/:slug/shops/:shopId/activate', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  // ── Opening Hours (/api/brands/:slug/shops/:shopId/opening-hours) ────────
+
+  http.get('/api/brands/:slug/shops/:shopId/opening-hours', () =>
+    HttpResponse.json({
+      timeBlocks: [
+        { id: 'tb-1', dayOfWeek: 1, openTime: '09:00', closeTime: '18:00' },
+      ],
+    }),
+  ),
+
+  http.put('/api/brands/:slug/shops/:shopId/opening-hours', async ({ request }) => {
+    const body = await request.json() as { timeBlocks: unknown[] };
+    return HttpResponse.json({
+      timeBlocks: body.timeBlocks.map((tb, i) => ({ id: `tb-${i}`, ...tb as object })),
+    });
+  }),
+
+  http.get('/api/brands/:slug/shops/:shopId/status', () =>
+    HttpResponse.json({
+      isOpen: true,
+      nextOpeningTime: null,
+      timeZoneId: 'Europe/Brussels',
+    }),
+  ),
+
+  // ── Order Lifecycle (/api/brands/:slug/shops/:shopId/order-lifecycle) ────
+
+  http.get('/api/brands/:slug/shops/:shopId/order-lifecycle', ({ params }) =>
+    HttpResponse.json({
+      shopId: params.shopId,
+      statuses: [
+        {
+          id: 'status-1',
+          name: 'New',
+          systemKey: 'new',
+          sortOrder: 1,
+          isEnabled: true,
+          isTerminal: false,
+          colorHex: '#3b82f6',
+        },
+      ],
+      transitions: [],
+    }),
+  ),
+
+  http.put('/api/brands/:slug/shops/:shopId/order-lifecycle', async ({ params, request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      shopId: params.shopId,
+      statuses: body.statuses,
+      transitions: body.transitions,
+    });
+  }),
+
+  http.post('/api/brands/:slug/shops/:shopId/order-lifecycle/reset', ({ params }) =>
+    HttpResponse.json({
+      shopId: params.shopId,
+      statuses: [],
+      transitions: [],
+    }),
+  ),
+
+  // ── Menu Categories (/api/brands/:slug/menu-categories) ─────────────────
+
+  http.get('/api/brands/:slug/menu-categories', () =>
+    HttpResponse.json([
+      {
+        id: 'cat-1',
+        name: 'Frietjes',
+        sortOrder: 1,
+        imageUrl: null,
+        productCount: 3,
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]),
+  ),
+
+  http.get('/api/brands/:slug/menu-categories/:id', ({ params }) =>
+    HttpResponse.json({
+      id: params.id,
+      sortOrder: 1,
+      imageUrl: null,
+      productCount: 3,
+      translations: [{ languageCode: 'nl', name: 'Frietjes' }],
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }),
+  ),
+
+  http.post('/api/brands/:slug/menu-categories', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'cat-new',
+        sortOrder: body.sortOrder,
+        imageUrl: body.imageUrl ?? null,
+        productCount: 0,
+        translations: body.translations,
+        createdAt: '2024-06-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.put('/api/brands/:slug/menu-categories/:id', async ({ params, request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: params.id,
+      sortOrder: body.sortOrder,
+      imageUrl: body.imageUrl ?? null,
+      productCount: 3,
+      translations: body.translations,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  http.delete('/api/brands/:slug/menu-categories/:id', () =>
+    new HttpResponse(null, { status: 204 }),
+  ),
+
+  http.patch('/api/brands/:slug/menu-categories/:id/sort-order', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  http.post('/api/brands/:slug/menu-categories/assign-product', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  http.get('/api/brands/:slug/menu-categories/:id/products', () =>
+    HttpResponse.json([]),
+  ),
+
+  http.put('/api/brands/:slug/menu-categories/:id/products/order', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  // ── Modifier Groups (/api/brands/:slug/modifier-groups) ──────────────────
+
+  http.get('/api/brands/:slug/modifier-groups', () =>
+    HttpResponse.json([
+      {
+        id: 'mg-1',
+        name: 'Sauzen',
+        modifierCount: 3,
+        productCount: 5,
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]),
+  ),
+
+  http.get('/api/brands/:slug/modifier-groups/:id', ({ params }) =>
+    HttpResponse.json({
+      id: params.id,
+      translations: [{ languageCode: 'nl', name: 'Sauzen' }],
+      modifiers: [
+        {
+          id: 'mod-1',
+          priceAdjustment: 0,
+          sortOrder: 1,
+          translations: [{ languageCode: 'nl', name: 'Mayonaise' }],
+        },
+      ],
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }),
+  ),
+
+  http.post('/api/brands/:slug/modifier-groups', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'mg-new',
+        translations: body.translations,
+        modifiers: body.modifiers,
+        createdAt: '2024-06-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.put('/api/brands/:slug/modifier-groups/:id', async ({ params, request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: params.id,
+      translations: body.translations,
+      modifiers: body.modifiers,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  http.delete('/api/brands/:slug/modifier-groups/:id', () =>
+    new HttpResponse(null, { status: 204 }),
+  ),
+
+  http.get('/api/brands/:slug/products/:productId/modifier-groups', () =>
+    HttpResponse.json([
+      {
+        modifierGroupId: 'mg-1',
+        name: 'Sauzen',
+        sortOrder: 1,
+        modifiers: [],
+      },
+    ]),
+  ),
+
+  http.put('/api/brands/:slug/products/:productId/modifier-groups', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  // ── Products (/api/brands/:slug/products) ────────────────────────────────
+
+  http.get('/api/brands/:slug/products', () =>
+    HttpResponse.json([
+      {
+        id: 'prod-1',
+        productType: 'Simple',
+        name: 'Kleine friet',
+        basePrice: { amount: 3.5, currency: 'EUR' },
+        imageUrl: null,
+        menuCategoryId: 'cat-1',
+        sortOrderInCategory: 1,
+        allergens: [],
+        dietaryTags: [],
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]),
+  ),
+
+  http.get('/api/brands/:slug/products/:id', ({ params }) =>
+    HttpResponse.json({
+      id: params.id,
+      productType: 'Simple',
+      basePrice: { amount: 3.5, currency: 'EUR' },
+      imageUrl: null,
+      menuCategoryId: 'cat-1',
+      sortOrderInCategory: 1,
+      translations: [{ languageCode: 'nl', name: 'Kleine friet', description: null }],
+      allergens: [],
+      dietaryTags: [],
+      comboItems: null,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }),
+  ),
+
+  http.post('/api/brands/:slug/products', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'prod-new',
+        productType: 'Simple',
+        basePrice: { amount: body.basePrice, currency: 'EUR' },
+        imageUrl: body.imageUrl ?? null,
+        menuCategoryId: null,
+        sortOrderInCategory: 0,
+        translations: body.translations,
+        allergens: body.allergens ?? [],
+        dietaryTags: body.dietaryTags ?? [],
+        comboItems: null,
+        createdAt: '2024-06-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.put('/api/brands/:slug/products/:id', async ({ params, request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: params.id,
+      productType: 'Simple',
+      basePrice: { amount: body.basePrice, currency: 'EUR' },
+      imageUrl: body.imageUrl ?? null,
+      menuCategoryId: null,
+      sortOrderInCategory: 0,
+      translations: body.translations,
+      allergens: body.allergens ?? [],
+      dietaryTags: body.dietaryTags ?? [],
+      comboItems: null,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  http.delete('/api/brands/:slug/products/:id', () =>
+    new HttpResponse(null, { status: 204 }),
+  ),
+
+  http.post('/api/brands/:slug/combo-products', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'combo-new',
+        productType: 'Combo',
+        basePrice: { amount: body.basePrice, currency: 'EUR' },
+        imageUrl: body.imageUrl ?? null,
+        menuCategoryId: null,
+        sortOrderInCategory: 0,
+        translations: body.translations,
+        allergens: [],
+        dietaryTags: [],
+        comboItems: (body.componentProductIds as string[]).map((id, i) => ({
+          componentProductId: id,
+          name: `Product ${i + 1}`,
+          sortOrder: i,
+        })),
+        createdAt: '2024-06-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.put('/api/brands/:slug/combo-products/:id', async ({ params, request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: params.id,
+      productType: 'Combo',
+      basePrice: { amount: body.basePrice, currency: 'EUR' },
+      imageUrl: body.imageUrl ?? null,
+      menuCategoryId: null,
+      sortOrderInCategory: 0,
+      translations: body.translations,
+      allergens: [],
+      dietaryTags: [],
+      comboItems: (body.componentProductIds as string[]).map((id, i) => ({
+        componentProductId: id,
+        name: `Product ${i + 1}`,
+        sortOrder: i,
+      })),
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  // ── Platform Admins (/api/platform-admins) ────────────────────────────────
+
+  http.get('/api/platform-admins', () =>
+    HttpResponse.json([
+      {
+        id: 'pa-1',
+        email: 'admin@platform.dev',
+        displayName: 'Platform Admin',
+        isPlatformAdmin: true,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    ]),
+  ),
+
+  http.post('/api/platform-admins', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        id: 'pa-new',
+        email: body.email,
+        displayName: body.displayName,
+        isPlatformAdmin: true,
+        createdAt: '2024-06-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.post('/api/platform-admins/:id/deactivate', () =>
+    new HttpResponse(null, { status: 200 }),
+  ),
+
+  // ── Tax Configuration (/api/brands/:slug/tax-configuration) ─────────────
+
+  http.get('/api/brands/:slug/tax-configuration', () =>
+    HttpResponse.json({
+      id: 'tax-1',
+      vatRates: [
+        { consumptionMode: 'Takeaway', ratePercentage: 6 },
+        { consumptionMode: 'EatIn', ratePercentage: 21 },
+      ],
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }),
+  ),
+
+  http.put('/api/brands/:slug/tax-configuration', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      id: 'tax-1',
+      vatRates: body.vatRates,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    });
+  }),
+
+  http.post('/api/brands/:slug/tax-configuration/calculate', async ({ request }) => {
+    const body = await request.json() as { grossAmount: number; consumptionMode: string };
+    const rate = body.consumptionMode === 'Takeaway' ? 6 : 21;
+    const vatAmount = parseFloat(((body.grossAmount * rate) / (100 + rate)).toFixed(2));
+    return HttpResponse.json({
+      netAmount: parseFloat((body.grossAmount - vatAmount).toFixed(2)),
+      vatAmount,
+      grossAmount: body.grossAmount,
+      vatRatePercentage: rate,
+    });
+  }),
+];

--- a/src/frontend/src/test/msw/server.ts
+++ b/src/frontend/src/test/msw/server.ts
@@ -1,0 +1,8 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+/**
+ * MSW server instance for Vitest (Node environment).
+ * Started/reset/stopped via the global setup in src/test/setup.ts.
+ */
+export const server = setupServer(...handlers);

--- a/src/frontend/src/test/setup.ts
+++ b/src/frontend/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { server } from './msw/server';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/src/frontend/src/test/testUtils.tsx
+++ b/src/frontend/src/test/testUtils.tsx
@@ -1,0 +1,48 @@
+import { type ReactNode } from 'react';
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+import { MemoryRouter, type MemoryRouterProps } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * Creates a fresh QueryClient with retries disabled (suitable for testing).
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+interface RenderWithProvidersOptions extends RenderOptions {
+  /** Initial URL entries for MemoryRouter. Defaults to ['/']. */
+  initialEntries?: MemoryRouterProps['initialEntries'];
+  /** Pre-configured QueryClient. A fresh one is created per call if omitted. */
+  queryClient?: QueryClient;
+}
+
+/**
+ * Wraps the given UI with a fresh QueryClientProvider and MemoryRouter.
+ * Use this for any component that relies on TanStack Query or React Router.
+ *
+ * @example
+ * const { getByText } = renderWithProviders(<MyComponent />);
+ */
+export function renderWithProviders(
+  ui: ReactNode,
+  {
+    initialEntries = ['/'],
+    queryClient,
+    ...renderOptions
+  }: RenderWithProvidersOptions = {},
+): RenderResult {
+  const client = queryClient ?? createTestQueryClient();
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+    renderOptions,
+  );
+}


### PR DESCRIPTION
## Summary

Wave 1 slice 4 of 4 — lays the shared **frontend test infrastructure** that Wave 2 (component/page tests) will depend on, and ships the first round of unit tests for the API client and auth modules.

### What landed

- **MSW v2 bootstrap** — `src/test/msw/{server,handlers}.ts` with default handlers for every `/api/*` and `/bff/*` route touched by `src/api/*`. `src/test/setup.ts` now starts / resets / stops the server around tests; existing `App.test.tsx` is untouched.
- **Shared `testUtils.tsx`** — `renderWithProviders` for `QueryClientProvider` + `MemoryRouter`.
- **13 API client test suites** (under `src/api/__tests__/`) — happy-path + 401 → `auth:session-expired` event dispatch for `auth`, `brands`, `brandSettings`, `brandStaff`, `client`, `menuCategories`, `modifierGroups`, `openingHours`, `orderLifecycle`, `platformAdmins`, `products`, `shops`, `taxConfiguration`.
- **6 auth module test suites** (under `src/auth/__tests__/`) — `useAuth`, `MockAuthProvider`, `BffAuthProvider`, `AuthProviderSwitch`, `RequireAuth`, `useSessionKeepalive`.
- `msw@^2.13.4` added to devDependencies.

### Deliberately deferred

- `signalr.ts`, `useOrderUpdates.ts`, `useSignalR.ts` — WebSocket code needs a dedicated harness; slated for **Wave 2**.

### Pre-existing failures on `main` (not caused by this PR)

- `src/App.test.tsx` — cannot resolve `../i18n/config` (Vite transform error). Exists on main with zero Slice 4 changes.
- `src/api/useOrderUpdates.ts` and `src/features/admin/pages/ShopOpeningHours.tsx` — `exactOptionalPropertyTypes` strictness errors from `tsc`. Also present on main.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm test` — **117/117** new tests pass (only the pre-existing `App.test.tsx` suite fails)
- [ ] CI green once merged
- [ ] Wave 2 PRs use the MSW server + handlers landed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)