### PR TITLE
feat(storefront): order tracking page with real-time stepper (US-FP-063)

### DIFF
--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -96,7 +96,7 @@ Once brands + shops exist, these streams are **independent of each other**.
 |--------|-------|-------------|------------|
 | ✅ | **US-FP-046** | Apply Belgian VAT rates | 022 |
 | ✅ | **US-FP-068** | Real-time updates (SignalR/SSE) | — (infra, can start in L1) |
-| ⬜ | **US-FP-016** | Place an online order | 005, 006, 007, 014, 022, 046 |
+| ✅ | **US-FP-016** | Place an online order | 005, 006, 007, 014, 022, 046 |
 | ⬜ | **US-FP-058** | Complete payment flow (mocked) | 016 |
 | ⬜ | **US-FP-017** | Place an order as a guest | 016 |
 | ⬜ | **US-FP-018** | Place an in-store order (POS) | 016 |
@@ -209,7 +209,7 @@ L0: [069✅] → [061✅] → [001✅] → [070✅] → [004✅] → [002✅]
 
 L1: [A: Products✅]  [B: Auth/Staff🚧]  [C: Shop Config🚧]  [D: Branding✅]  ← 4 parallel
          │                │                  │
-L2: [046✅ VAT] [068✅ Realtime] → [016 Ordering] → [058/017/018]             ← ordering core
+L2: [046✅ VAT] [068✅ Realtime] → [016✅ Ordering] → [058/017/018]            ← ordering core
                                         │
 L3: [E: Kitchen] [F: Customer] [G: Shop Mgmt] [H: Loyalty] [I: Reports]      ← 5 parallel
          │            │

--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -120,7 +120,7 @@ Once ordering works, these streams are **all independent**.
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| ⬜ | **US-FP-063** | Track current order status | 022, 068 |
+| ✅ | **US-FP-063** | Track current order status | 022, 068 |
 | ⬜ | **US-FP-062** | View order history | 016, 037 |
 | ⬜ | **US-FP-024** | Eat-in ordering with table number | 016, 066 |
 | ⬜ | **US-FP-025** | QR code table ordering | 024, 065 |

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
@@ -1,0 +1,107 @@
+using FastEndpoints;
+using FluentValidation;
+using FluentValidation.Results;
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record OrderItemApiInput(Guid ProductId, int Quantity, List<Guid>? SelectedModifierIds);
+
+public sealed record CreateOrderApiRequest(
+    [property: RouteParam] string BrandSlug,
+    [property: RouteParam] Guid ShopId,
+    string OrderType,
+    string? CustomerName,
+    List<OrderItemApiInput> Items);
+
+public sealed class CreateOrderRequestValidator : Validator<CreateOrderApiRequest>
+{
+    public CreateOrderRequestValidator()
+    {
+        RuleFor(x => x.OrderType)
+            .NotEmpty().WithMessage("OrderType is required.")
+            .Must(v => Enum.TryParse<OrderType>(v, out var parsed) && Enum.IsDefined(parsed))
+            .WithMessage($"OrderType must be one of: {string.Join(", ", Enum.GetNames<OrderType>())}.");
+
+        RuleFor(x => x.Items)
+            .NotEmpty().WithMessage("At least one item is required.");
+
+        RuleForEach(x => x.Items).ChildRules(item =>
+        {
+            item.RuleFor(i => i.ProductId)
+                .NotEmpty().WithMessage("ProductId is required.");
+
+            item.RuleFor(i => i.Quantity)
+                .GreaterThan(0).WithMessage("Quantity must be greater than zero.")
+                .LessThanOrEqualTo(99).WithMessage("Quantity cannot exceed 99.");
+        });
+
+        RuleFor(x => x.CustomerName)
+            .MaximumLength(200)
+            .When(x => x.CustomerName is not null);
+    }
+}
+
+public sealed class CreateOrderEndpoint(IOrderService orderService)
+    : Endpoint<CreateOrderApiRequest, OrderResponse>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders";
+
+    public override void Configure()
+    {
+        Post(Route);
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<CreateOrderApiRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Place a new order";
+            s.Description =
+                "Creates a new order for the specified shop. " +
+                "Server resolves current product prices — client-submitted prices are ignored. " +
+                "VAT is applied at 6% for Pickup/Delivery and 21% for EatIn.";
+            s.Response<OrderResponse>(201, "Order placed successfully.");
+            s.Response(400, "Validation error or unknown product/modifier.");
+            s.Response(404, "Shop or brand not found.");
+        });
+    }
+
+    public override async Task HandleAsync(CreateOrderApiRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var appRequest = new CreateOrderRequest(
+                req.ShopId,
+                req.BrandSlug,
+                req.OrderType,
+                req.CustomerName,
+                req.Items
+                    .Select(i => new OrderItemInput(
+                        i.ProductId,
+                        i.Quantity,
+                        (i.SelectedModifierIds ?? []).AsReadOnly()))
+                    .ToList()
+                    .AsReadOnly());
+
+            var response = await orderService.CreateOrderAsync(appRequest, ct);
+
+            await HttpContext.Response.SendAsync(response, statusCode: 201, cancellation: ct);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            var failures = new List<ValidationFailure> { new("items", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+        catch (ArgumentException ex)
+        {
+            var failures = new List<ValidationFailure> { new("request", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            var failures = new List<ValidationFailure> { new("request", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderByNumberEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderByNumberEndpoint.cs
@@ -1,0 +1,60 @@
+using FastEndpoints;
+using TheMillionthFoodOrderApp.Application.OrderLifecycle;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record GetOrderByNumberRequest(
+    [property: RouteParam] string BrandSlug,
+    [property: RouteParam] Guid ShopId,
+    [property: RouteParam] string OrderNumber);
+
+/// <summary>
+/// Retrieves order tracking details by human-readable order number, enriched with
+/// the shop's configured lifecycle. Supports guest lookup where only the order
+/// confirmation slip (with the order number) is available.
+/// </summary>
+public sealed class GetOrderByNumberEndpoint(IOrderRepository orderRepository, IOrderLifecycleService lifecycleService)
+    : Endpoint<GetOrderByNumberRequest, OrderTrackingResponse>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders/number/{orderNumber}";
+
+    public override void Configure()
+    {
+        Get(Route);
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<GetOrderByNumberRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Get order tracking details by order number";
+            s.Description =
+                "Returns the full order detail and the shop's order lifecycle configuration. " +
+                "Allows guest lookup using only the human-readable order number printed on the receipt. " +
+                "Returns 404 if the order does not exist or belongs to a different shop.";
+            s.Response<OrderTrackingResponse>(200, "Order tracking details retrieved successfully.");
+            s.Response(404, "Order not found.");
+        });
+    }
+
+    public override async Task HandleAsync(GetOrderByNumberRequest req, CancellationToken ct)
+    {
+        var order = await orderRepository.GetByOrderNumberAsync(req.ShopId, req.OrderNumber, ct);
+
+        // Return 404 when not found — shopId is already scoped in the query so a mismatch
+        // simply returns null. Never reveal existence via a 403.
+        if (order is null)
+        {
+            await HttpContext.Response.SendNotFoundAsync(ct);
+            return;
+        }
+
+        var lifecycle = await lifecycleService.GetLifecycleAsync(req.ShopId, ct);
+
+        var response = new OrderTrackingResponse(
+            OrderTrackingMapper.MapOrder(order),
+            lifecycle);
+
+        await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderEndpoint.cs
@@ -1,0 +1,59 @@
+using FastEndpoints;
+using TheMillionthFoodOrderApp.Application.OrderLifecycle;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record GetOrderRequest(
+    [property: RouteParam] string BrandSlug,
+    [property: RouteParam] Guid ShopId,
+    [property: RouteParam] Guid OrderId);
+
+/// <summary>
+/// Retrieves order tracking details by Order UUID, enriched with the shop's
+/// configured lifecycle so the customer can see their order's progression
+/// without a second round-trip.
+/// </summary>
+public sealed class GetOrderEndpoint(IOrderRepository orderRepository, IOrderLifecycleService lifecycleService)
+    : Endpoint<GetOrderRequest, OrderTrackingResponse>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}";
+
+    public override void Configure()
+    {
+        Get(Route);
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<GetOrderRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Get order tracking details by ID";
+            s.Description =
+                "Returns the full order detail and the shop's order lifecycle configuration. " +
+                "Returns 404 if the order does not exist or belongs to a different shop.";
+            s.Response<OrderTrackingResponse>(200, "Order tracking details retrieved successfully.");
+            s.Response(404, "Order not found.");
+        });
+    }
+
+    public override async Task HandleAsync(GetOrderRequest req, CancellationToken ct)
+    {
+        var order = await orderRepository.GetByIdAsync(req.OrderId, ct);
+
+        // Return 404 when not found OR when the order belongs to a different shop —
+        // never reveal existence via a 403.
+        if (order is null || order.ShopId != req.ShopId)
+        {
+            await HttpContext.Response.SendNotFoundAsync(ct);
+            return;
+        }
+
+        var lifecycle = await lifecycleService.GetLifecycleAsync(req.ShopId, ct);
+
+        var response = new OrderTrackingResponse(
+            OrderTrackingMapper.MapOrder(order),
+            lifecycle);
+
+        await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
@@ -1,0 +1,44 @@
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+/// <summary>
+/// Maps <see cref="Order"/> aggregates to <see cref="OrderResponse"/> DTOs for the
+/// order-tracking endpoints. Duplicating the private helper from OrderService here
+/// keeps the endpoint layer self-contained and avoids coupling the API layer to
+/// the Application service's internal mapping concern.
+/// </summary>
+internal static class OrderTrackingMapper
+{
+    internal static OrderResponse MapOrder(Order order) =>
+        new(
+            order.Id,
+            order.OrderNumber,
+            order.ShopId,
+            order.BrandSlug,
+            order.OrderType.ToString(),
+            order.StatusName,
+            order.CustomerName,
+            order.Items
+                .Select(i => new OrderItemResponse(
+                    i.ProductId,
+                    i.ProductName,
+                    i.Quantity,
+                    i.UnitGrossPrice,
+                    i.UnitNetPrice,
+                    i.UnitVatAmount,
+                    i.LineTotal,
+                    i.SelectedModifiers
+                        .Select(m => new SelectedModifierResponse(m.ModifierId, m.ModifierName, m.PriceAdjustment))
+                        .ToList()
+                        .AsReadOnly()))
+                .ToList()
+                .AsReadOnly(),
+            order.VatRatePercent,
+            order.SubtotalGross,
+            order.TotalVatAmount,
+            order.TotalNet,
+            order.TotalGross,
+            order.CreatedAt);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/DependencyInjection.cs
@@ -5,6 +5,7 @@ using TheMillionthFoodOrderApp.Application.Identity;
 using TheMillionthFoodOrderApp.Application.MenuCategories;
 using TheMillionthFoodOrderApp.Application.ModifierGroups;
 using TheMillionthFoodOrderApp.Application.OrderLifecycle;
+using TheMillionthFoodOrderApp.Application.Orders;
 using TheMillionthFoodOrderApp.Application.Products;
 using TheMillionthFoodOrderApp.Application.Shops;
 using TheMillionthFoodOrderApp.Application.TaxConfiguration;
@@ -27,6 +28,7 @@ public static class DependencyInjection
         services.AddScoped<IOpeningHoursService, OpeningHoursService>();
         services.AddScoped<IOrderLifecycleService, OrderLifecycleService>();
         services.AddScoped<ITaxConfigurationService, TaxConfigurationService>();
+        services.AddScoped<IOrderService, OrderService>();
 
         return services;
     }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs
@@ -1,0 +1,11 @@
+namespace TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+/// <summary>
+/// Application-layer DTO for placing a new order.
+/// </summary>
+public sealed record CreateOrderRequest(
+    Guid ShopId,
+    string BrandSlug,
+    string OrderType,
+    string? CustomerName,
+    IReadOnlyList<OrderItemInput> Items);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderItemInput.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderItemInput.cs
@@ -1,0 +1,9 @@
+namespace TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+/// <summary>
+/// Represents a single product line in a create-order request.
+/// </summary>
+public sealed record OrderItemInput(
+    Guid ProductId,
+    int Quantity,
+    IReadOnlyList<Guid> SelectedModifierIds);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
@@ -1,0 +1,35 @@
+namespace TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+/// <summary>Response DTO for a selected modifier on an order item.</summary>
+public sealed record SelectedModifierResponse(
+    Guid ModifierId,
+    string ModifierName,
+    decimal PriceAdjustment);
+
+/// <summary>Response DTO for a single order line item.</summary>
+public sealed record OrderItemResponse(
+    Guid ProductId,
+    string ProductName,
+    int Quantity,
+    decimal UnitGrossPrice,
+    decimal UnitNetPrice,
+    decimal UnitVatAmount,
+    decimal LineTotal,
+    IReadOnlyList<SelectedModifierResponse> SelectedModifiers);
+
+/// <summary>Full response DTO returned when an order is created or retrieved.</summary>
+public sealed record OrderResponse(
+    Guid Id,
+    string OrderNumber,
+    Guid ShopId,
+    string BrandSlug,
+    string OrderType,
+    string StatusName,
+    string? CustomerName,
+    IReadOnlyList<OrderItemResponse> Items,
+    decimal VatRatePercent,
+    decimal SubtotalGross,
+    decimal TotalVatAmount,
+    decimal TotalNet,
+    decimal TotalGross,
+    DateTimeOffset CreatedAt);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderTrackingResponse.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderTrackingResponse.cs
@@ -1,0 +1,12 @@
+using TheMillionthFoodOrderApp.Application.OrderLifecycle;
+
+namespace TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+/// <summary>
+/// Combined response DTO returned by the order-tracking endpoints.
+/// Bundles the full order detail with the shop's configured lifecycle so the
+/// frontend can render the status progression without a second round-trip.
+/// </summary>
+public record OrderTrackingResponse(
+    OrderResponse Order,
+    OrderLifecycleResponse Lifecycle);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderService.cs
@@ -1,0 +1,21 @@
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+namespace TheMillionthFoodOrderApp.Application.Orders;
+
+/// <summary>
+/// Application service for placing and managing orders.
+/// </summary>
+public interface IOrderService
+{
+    /// <summary>
+    /// Places a new order for the specified shop, resolving prices from the database
+    /// and applying the correct Belgian VAT rate based on order type.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when a referenced product ID does not exist.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the order type is invalid or items list is empty.
+    /// </exception>
+    Task<OrderResponse> CreateOrderAsync(CreateOrderRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -1,0 +1,244 @@
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Domain.Common;
+using TheMillionthFoodOrderApp.Domain.ModifierGroups;
+using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
+using TheMillionthFoodOrderApp.Domain.Orders;
+using TheMillionthFoodOrderApp.Domain.Products;
+using TheMillionthFoodOrderApp.Domain.Shops;
+using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+
+namespace TheMillionthFoodOrderApp.Application.Orders;
+
+/// <summary>
+/// Application service for placing orders.
+/// Resolves prices and modifier details from the database,
+/// applies the correct Belgian VAT rate based on order type,
+/// and persists the order aggregate.
+/// </summary>
+public sealed class OrderService(
+    IOrderRepository orderRepository,
+    IProductRepository productRepository,
+    IModifierGroupRepository modifierGroupRepository,
+    ITaxConfigurationRepository taxConfigurationRepository,
+    IOrderLifecycleConfigRepository orderLifecycleConfigRepository,
+    IShopRepository shopRepository) : IOrderService
+{
+    public async Task<OrderResponse> CreateOrderAsync(
+        CreateOrderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Parse and validate order type
+        if (!Enum.TryParse<OrderType>(request.OrderType, out var orderType) || !Enum.IsDefined(orderType))
+            throw new ArgumentException(
+                $"Invalid order type: '{request.OrderType}'. Valid values: {string.Join(", ", Enum.GetNames<OrderType>())}.");
+
+        if (request.Items.Count == 0)
+            throw new ArgumentException("An order must contain at least one item.");
+
+        // 2. Determine consumption mode for VAT calculation
+        var consumptionMode = orderType == OrderType.EatIn
+            ? ConsumptionMode.EatIn
+            : ConsumptionMode.Takeaway;
+
+        // 3. Load tax configuration and resolve VAT rate
+        var taxConfig = await taxConfigurationRepository.GetAsync(cancellationToken)
+            ?? throw new InvalidOperationException("No tax configuration has been set up for this brand.");
+
+        var vatRate = taxConfig.GetRateForMode(consumptionMode);
+
+        // 4. Validate that the shop exists in this brand's database
+        var shop = await shopRepository.GetByIdAsync(request.ShopId, cancellationToken);
+        if (shop is null)
+            throw new KeyNotFoundException($"Shop with id '{request.ShopId}' was not found.");
+
+        // 5. Load order lifecycle config to determine opening status (lazy-init default if missing)
+        var lifecycleConfig = await orderLifecycleConfigRepository.GetByShopIdAsync(request.ShopId, cancellationToken);
+        if (lifecycleConfig is null)
+        {
+            lifecycleConfig = OrderLifecycleConfig.CreateDefault(request.ShopId);
+            await orderLifecycleConfigRepository.AddAsync(lifecycleConfig, cancellationToken);
+            await orderLifecycleConfigRepository.SaveChangesAsync(cancellationToken);
+        }
+
+        var openingStatus = GetOpeningStatus(lifecycleConfig);
+
+        // 6. Resolve products from DB (never trust client-submitted prices)
+        var productIds = request.Items.Select(i => i.ProductId).Distinct().ToList();
+        var products = await productRepository.GetByIdsAsync(productIds, cancellationToken);
+
+        if (products.Count != productIds.Count)
+        {
+            var missingIds = productIds.Except(products.Select(p => p.Id));
+            throw new KeyNotFoundException(
+                $"Product(s) not found: {string.Join(", ", missingIds)}.");
+        }
+
+        var productLookup = products.ToDictionary(p => p.Id);
+
+        // 7. Resolve all requested modifier IDs
+        var allModifierIds = request.Items
+            .SelectMany(i => i.SelectedModifierIds)
+            .Distinct()
+            .ToList();
+
+        var modifierLookup = new Dictionary<Guid, Modifier>();
+        if (allModifierIds.Count > 0)
+        {
+            // Load all modifier groups and build a flat modifier lookup
+            // (Modifiers belong to groups; we query by modifier ID across all groups)
+            var allGroups = await modifierGroupRepository.GetAllAsync(cancellationToken);
+            modifierLookup = allGroups
+                .SelectMany(g => g.Modifiers)
+                .Where(m => allModifierIds.Contains(m.Id))
+                .GroupBy(m => m.Id)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            var missingModifierIds = allModifierIds.Except(modifierLookup.Keys).ToList();
+            if (missingModifierIds.Count > 0)
+                throw new KeyNotFoundException(
+                    $"Modifier(s) not found: {string.Join(", ", missingModifierIds)}.");
+        }
+
+        // 8. Build order items with denormalised prices and modifiers
+        // Pre-generate the order ID so item FKs and the order aggregate share the same value.
+        var orderId = Guid.CreateVersion7();
+        var orderItems = new List<OrderItem>();
+
+        foreach (var itemInput in request.Items)
+        {
+            var product = productLookup[itemInput.ProductId];
+
+            // Build the selected modifier list first so we can sum their price adjustments
+            var selectedModifiers = itemInput.SelectedModifierIds
+                .Select(mid =>
+                {
+                    var mod = modifierLookup[mid];
+                    var name = mod.Translations.FirstOrDefault()?.Name ?? "(unnamed)";
+                    return SelectedModifier.Create(mid, name, mod.PriceAdjustment);
+                })
+                .ToList();
+
+            // Combined unit gross = base price + sum of all modifier adjustments.
+            // VAT is applied to the combined amount so the tax decomposition is accurate.
+            var modifierTotal = selectedModifiers.Sum(m => m.PriceAdjustment);
+            var combinedGrossPrice = product.BasePrice.Amount + modifierTotal;
+            var taxBreakdown = TaxCalculator.CalculateFromGross(combinedGrossPrice, vatRate);
+
+            var productName = product.Translations.FirstOrDefault()?.Name ?? "(unnamed)";
+
+            var orderItem = OrderItem.Create(
+                orderId,
+                product.Id,
+                productName,
+                itemInput.Quantity,
+                taxBreakdown.GrossAmount,
+                taxBreakdown.NetAmount,
+                taxBreakdown.VatAmount,
+                selectedModifiers);
+
+            orderItems.Add(orderItem);
+        }
+
+        // 9. Generate a unique order number and persist, retrying on the rare race condition
+        //    where two concurrent requests pass the exists-check simultaneously and one
+        //    hits the UX_Orders_ShopId_OrderNumber unique index on INSERT.
+        //    OrderRepository.SaveChangesAsync detects the SQL unique-constraint error (2601/2627)
+        //    and throws InvalidOperationException("ORDER_NUMBER_CONFLICT") so we can retry here
+        //    without coupling the Application layer to EF Core.
+        const int maxSaveAttempts = 5;
+        Order? order = null;
+
+        for (var saveAttempt = 0; saveAttempt < maxSaveAttempts; saveAttempt++)
+        {
+            var orderNumber = await GenerateUniqueOrderNumberAsync(request.ShopId, cancellationToken);
+
+            // 10. Create the order aggregate with the candidate number
+            order = Order.Create(
+                orderId,
+                request.ShopId,
+                request.BrandSlug,
+                orderNumber,
+                orderType,
+                openingStatus.Name,
+                request.CustomerName,
+                vatRate,
+                orderItems);
+
+            try
+            {
+                await orderRepository.AddAsync(order, cancellationToken);
+                await orderRepository.SaveChangesAsync(cancellationToken);
+                break; // success — exit retry loop
+            }
+            catch (InvalidOperationException ex) when (ex.Message == "ORDER_NUMBER_CONFLICT")
+            {
+                // The unique index was hit by a concurrent request. The repository has already
+                // detached the failed entity. Re-generate a fresh ID and order number on next loop.
+                orderId = Guid.CreateVersion7();
+                if (saveAttempt == maxSaveAttempts - 1)
+                    throw new InvalidOperationException(
+                        "Failed to generate a unique order number after multiple retries. Please try again.", ex);
+            }
+        }
+
+        return MapToResponse(order!);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private static Domain.OrderLifecycle.OrderStatus GetOpeningStatus(OrderLifecycleConfig config)
+    {
+        // Opening status = lowest SortOrder; fall back to "placed" SystemKey if tied
+        return config.Statuses
+            .OrderBy(s => s.SortOrder)
+            .First();
+    }
+
+    private async Task<string> GenerateUniqueOrderNumberAsync(
+        Guid shopId,
+        CancellationToken cancellationToken)
+    {
+        // Simple 8-char alphanumeric prefix from a UUIDv7 — retry on collision (rare)
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            var candidate = Guid.CreateVersion7().ToString("N")[..8].ToUpperInvariant();
+            var exists = await orderRepository.OrderNumberExistsAsync(shopId, candidate, cancellationToken);
+            if (!exists)
+                return candidate;
+        }
+
+        // Fallback: use full guid to guarantee uniqueness
+        return Guid.CreateVersion7().ToString("N")[..16].ToUpperInvariant();
+    }
+
+    private static OrderResponse MapToResponse(Order order) =>
+        new(
+            order.Id,
+            order.OrderNumber,
+            order.ShopId,
+            order.BrandSlug,
+            order.OrderType.ToString(),
+            order.StatusName,
+            order.CustomerName,
+            order.Items
+                .Select(i => new OrderItemResponse(
+                    i.ProductId,
+                    i.ProductName,
+                    i.Quantity,
+                    i.UnitGrossPrice,
+                    i.UnitNetPrice,
+                    i.UnitVatAmount,
+                    i.LineTotal,
+                    i.SelectedModifiers
+                        .Select(m => new SelectedModifierResponse(m.ModifierId, m.ModifierName, m.PriceAdjustment))
+                        .ToList()
+                        .AsReadOnly()))
+                .ToList()
+                .AsReadOnly(),
+            order.VatRatePercent,
+            order.SubtotalGross,
+            order.TotalVatAmount,
+            order.TotalNet,
+            order.TotalGross,
+            order.CreatedAt);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
@@ -1,0 +1,23 @@
+namespace TheMillionthFoodOrderApp.Domain.Orders;
+
+/// <summary>
+/// Repository for persisting and retrieving <see cref="Order"/> aggregates.
+/// Implementations live in the Infrastructure layer.
+/// </summary>
+public interface IOrderRepository
+{
+    /// <summary>Returns the order with all items (including selected modifiers), or null.</summary>
+    Task<Order?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>Stages the order for insert. Call <see cref="SaveChangesAsync"/> to persist.</summary>
+    Task AddAsync(Order order, CancellationToken cancellationToken = default);
+
+    /// <summary>Persists all pending changes and dispatches domain events via Wolverine.</summary>
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns true if an order with this number already exists for the given shop.
+    /// Used to guard against race-condition duplicate order numbers.
+    /// </summary>
+    Task<bool> OrderNumberExistsAsync(Guid shopId, string orderNumber, CancellationToken cancellationToken = default);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
@@ -16,6 +16,12 @@ public interface IOrderRepository
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the order with all items (including selected modifiers) matching the
+    /// given order number for the specified shop, or null if not found.
+    /// </summary>
+    Task<Order?> GetByOrderNumberAsync(Guid shopId, string orderNumber, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns true if an order with this number already exists for the given shop.
     /// Used to guard against race-condition duplicate order numbers.
     /// </summary>

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
@@ -1,0 +1,110 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+
+namespace TheMillionthFoodOrderApp.Domain.Orders;
+
+/// <summary>
+/// The Order aggregate root. Represents a customer's food order placed at a shop.
+/// Persisted in the brand database (database-per-brand isolation).
+/// </summary>
+public sealed class Order : AggregateRoot<Guid>, IAuditable
+{
+    public Guid ShopId { get; private set; }
+    public string BrandSlug { get; private set; } = string.Empty;
+
+    /// <summary>Short, human-readable order identifier (unique within a shop).</summary>
+    public string OrderNumber { get; private set; } = string.Empty;
+
+    public OrderType OrderType { get; private set; }
+
+    /// <summary>Name of the status the order was placed in (opening lifecycle status).</summary>
+    public string StatusName { get; private set; } = string.Empty;
+
+    /// <summary>Optional customer name for display on kitchen displays and receipts.</summary>
+    public string? CustomerName { get; private set; }
+
+    /// <summary>VAT rate applied to this order (6 for Pickup/Delivery, 21 for EatIn).</summary>
+    public decimal VatRatePercent { get; private set; }
+
+    /// <summary>Sum of all line totals (gross, VAT-inclusive).</summary>
+    public decimal SubtotalGross { get; private set; }
+
+    /// <summary>Total VAT amount across all items.</summary>
+    public decimal TotalVatAmount { get; private set; }
+
+    /// <summary>SubtotalGross minus TotalVatAmount.</summary>
+    public decimal TotalNet { get; private set; }
+
+    /// <summary>Total gross amount (== SubtotalGross for a simple order).</summary>
+    public decimal TotalGross { get; private set; }
+
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private readonly List<OrderItem> _items = [];
+    public IReadOnlyCollection<OrderItem> Items => _items.AsReadOnly();
+
+    // Required by EF Core
+    private Order() { }
+
+    /// <summary>
+    /// Factory method — the only way to create a valid Order.
+    /// Calculates aggregate totals from the provided items.
+    /// Raises <see cref="OrderCreatedEvent"/> so it propagates via Wolverine/SignalR.
+    /// </summary>
+    /// <param name="orderId">
+    /// Pre-generated order ID. Must be the same Guid used when creating the order items
+    /// via <see cref="OrderItem.Create"/> so that the FK relationship is consistent.
+    /// </param>
+    public static Order Create(
+        Guid orderId,
+        Guid shopId,
+        string brandSlug,
+        string orderNumber,
+        OrderType orderType,
+        string statusName,
+        string? customerName,
+        decimal vatRatePercent,
+        IEnumerable<OrderItem> items)
+    {
+        var itemList = items.ToList();
+        if (itemList.Count == 0)
+            throw new ArgumentException("An order must contain at least one item.", nameof(items));
+
+        var subtotalGross = itemList.Sum(i => i.LineTotal);
+        var totalVatAmount = itemList.Sum(i => i.UnitVatAmount * i.Quantity);
+        var totalNet = subtotalGross - totalVatAmount;
+
+        var now = DateTimeOffset.UtcNow;
+
+        var order = new Order
+        {
+            Id = orderId,
+            ShopId = shopId,
+            BrandSlug = brandSlug,
+            OrderNumber = orderNumber,
+            OrderType = orderType,
+            StatusName = statusName,
+            CustomerName = customerName,
+            VatRatePercent = vatRatePercent,
+            SubtotalGross = Math.Round(subtotalGross, 2, MidpointRounding.AwayFromZero),
+            TotalVatAmount = Math.Round(totalVatAmount, 2, MidpointRounding.AwayFromZero),
+            TotalNet = Math.Round(totalNet, 2, MidpointRounding.AwayFromZero),
+            TotalGross = Math.Round(subtotalGross, 2, MidpointRounding.AwayFromZero),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        // Items reference the order's Id — must be set after the order is created
+        order._items.AddRange(itemList);
+
+        order.AddDomainEvent(new OrderCreatedEvent(
+            order.Id,
+            shopId,
+            brandSlug,
+            orderNumber,
+            statusName,
+            customerName));
+
+        return order;
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderCreatedEvent.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderCreatedEvent.cs
@@ -1,0 +1,19 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+
+namespace TheMillionthFoodOrderApp.Domain.Orders;
+
+/// <summary>
+/// Raised when a new order is successfully placed.
+/// Consumed by SignalR notification infrastructure to push real-time updates
+/// to kitchen displays, POS interfaces, and other connected clients.
+/// </summary>
+public sealed record OrderCreatedEvent(
+    Guid OrderId,
+    Guid ShopId,
+    string BrandSlug,
+    string OrderNumber,
+    string StatusName,
+    string? CustomerName) : IDomainEvent
+{
+    public DateTimeOffset OccurredOn { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderItem.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderItem.cs
@@ -1,0 +1,76 @@
+using TheMillionthFoodOrderApp.Domain.Common;
+
+namespace TheMillionthFoodOrderApp.Domain.Orders;
+
+/// <summary>
+/// A line item in an order, representing one product (possibly with modifier selections).
+/// Prices are denormalised at creation time so they remain accurate if the product changes later.
+/// </summary>
+public sealed class OrderItem : Entity<Guid>
+{
+    public Guid OrderId { get; private set; }
+    public Guid ProductId { get; private set; }
+
+    /// <summary>Denormalised product name captured at order time.</summary>
+    public string ProductName { get; private set; } = string.Empty;
+
+    public int Quantity { get; private set; }
+
+    /// <summary>Gross (VAT-inclusive) unit price at order time (base product price + modifier adjustments).</summary>
+    public decimal UnitGrossPrice { get; private set; }
+
+    /// <summary>Net (excl. VAT) unit price derived from UnitGrossPrice at order time.</summary>
+    public decimal UnitNetPrice { get; private set; }
+
+    /// <summary>VAT amount per unit.</summary>
+    public decimal UnitVatAmount { get; private set; }
+
+    /// <summary>Total line gross = UnitGrossPrice * Quantity (including modifier price adjustments).</summary>
+    public decimal LineTotal { get; private set; }
+
+    private readonly List<SelectedModifier> _selectedModifiers = [];
+    public IReadOnlyCollection<SelectedModifier> SelectedModifiers => _selectedModifiers.AsReadOnly();
+
+    // Required by EF Core
+    private OrderItem() { }
+
+    /// <summary>
+    /// Factory method. Calculates line total from the provided gross breakdown.
+    /// <para>
+    /// <paramref name="unitGrossPrice"/> must already include all modifier price adjustments
+    /// (combined gross = base price + sum of modifier PriceAdjustments). VAT decomposition
+    /// (net/vat) is derived from this combined amount by the caller before invoking Create.
+    /// </para>
+    /// </summary>
+    public static OrderItem Create(
+        Guid orderId,
+        Guid productId,
+        string productName,
+        int quantity,
+        decimal unitGrossPrice,
+        decimal unitNetPrice,
+        decimal unitVatAmount,
+        IEnumerable<SelectedModifier> selectedModifiers)
+    {
+        var modifierList = selectedModifiers.ToList();
+
+        var item = new OrderItem
+        {
+            Id = Guid.CreateVersion7(),
+            OrderId = orderId,
+            ProductId = productId,
+            ProductName = productName,
+            Quantity = quantity,
+            UnitGrossPrice = unitGrossPrice,
+            UnitNetPrice = unitNetPrice,
+            UnitVatAmount = unitVatAmount,
+            // LineTotal = combined unit gross (base + modifiers) × quantity.
+            // unitGrossPrice already incorporates modifier adjustments, so no further addition needed.
+            LineTotal = unitGrossPrice * quantity,
+        };
+
+        item._selectedModifiers.AddRange(modifierList);
+
+        return item;
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderType.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderType.cs
@@ -1,0 +1,16 @@
+namespace TheMillionthFoodOrderApp.Domain.Orders;
+
+/// <summary>
+/// Describes how an order will be fulfilled.
+/// </summary>
+public enum OrderType
+{
+    /// <summary>The customer picks up their order at the counter.</summary>
+    Pickup = 0,
+
+    /// <summary>The customer eats their order on the premises.</summary>
+    EatIn = 1,
+
+    /// <summary>The order is delivered to the customer's address.</summary>
+    Delivery = 2,
+}

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/SelectedModifier.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/SelectedModifier.cs
@@ -1,0 +1,28 @@
+namespace TheMillionthFoodOrderApp.Domain.Orders;
+
+/// <summary>
+/// Denormalised snapshot of a modifier selection captured at order time.
+/// Stored as a value object inside OrderItem — modifier name and price adjustment
+/// are copied at creation so they remain accurate even if the modifier is later changed.
+/// </summary>
+public sealed class SelectedModifier
+{
+    public Guid ModifierId { get; private set; }
+
+    /// <summary>Denormalised modifier name at the time of ordering.</summary>
+    public string ModifierName { get; private set; } = string.Empty;
+
+    /// <summary>Price delta applied by this modifier (can be negative or zero).</summary>
+    public decimal PriceAdjustment { get; private set; }
+
+    // Required by EF Core
+    private SelectedModifier() { }
+
+    public static SelectedModifier Create(Guid modifierId, string modifierName, decimal priceAdjustment) =>
+        new()
+        {
+            ModifierId = modifierId,
+            ModifierName = modifierName,
+            PriceAdjustment = priceAdjustment,
+        };
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using TheMillionthFoodOrderApp.Application.BrandSettings;
 using TheMillionthFoodOrderApp.Application.Multitenancy;
 using TheMillionthFoodOrderApp.Application.Orders;
 using TheMillionthFoodOrderApp.Domain.Brands;
+using TheMillionthFoodOrderApp.Domain.Orders;
 using TheMillionthFoodOrderApp.Domain.BrandSettings;
 using TheMillionthFoodOrderApp.Domain.Identity;
 using TheMillionthFoodOrderApp.Domain.MenuCategories;
@@ -24,6 +25,7 @@ using TheMillionthFoodOrderApp.Infrastructure.TaxConfiguration;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence.Interceptors;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence.Seeding;
+using TheMillionthFoodOrderApp.Infrastructure.Orders;
 using TheMillionthFoodOrderApp.Infrastructure.Products;
 using TheMillionthFoodOrderApp.Infrastructure.Shops;
 
@@ -67,6 +69,7 @@ public static class DependencyInjection
         services.AddScoped<IModifierGroupRepository, ModifierGroupRepository>();
         services.AddScoped<IOrderLifecycleConfigRepository, OrderLifecycleConfigRepository>();
         services.AddScoped<ITaxConfigurationRepository, TaxConfigurationRepository>();
+        services.AddScoped<IOrderRepository, OrderRepository>();
 
         // Seeders (scoped — they depend on scoped DbContext)
         services.AddScoped<PlatformDbSeeder>();

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderCreatedHandler.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Notifications/OrderCreatedHandler.cs
@@ -1,0 +1,30 @@
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Notifications;
+
+/// <summary>
+/// Wolverine message handler that bridges <see cref="OrderCreatedEvent"/> to SignalR.
+/// When a new order is placed, connected kitchen displays and POS clients receive
+/// a real-time notification via the shop group.
+///
+/// Wolverine discovers this handler by convention: HandleAsync(OrderCreatedEvent).
+/// </summary>
+public sealed class OrderCreatedHandler(IOrderNotificationService notificationService)
+{
+    public async Task HandleAsync(OrderCreatedEvent @event, CancellationToken cancellationToken)
+    {
+        // Notify all clients monitoring this shop that a new order has arrived.
+        // We reuse the status-changed pipeline: a new order appears as a transition
+        // from "(none)" to the opening status so the kitchen display can render it.
+        await notificationService.NotifyOrderStatusChangedAsync(
+            @event.OrderId,
+            @event.ShopId,
+            @event.BrandSlug,
+            previousStatus: string.Empty,
+            newStatus: @event.StatusName,
+            @event.CustomerName,
+            @event.OccurredOn,
+            cancellationToken);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Orders;
+
+public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
+{
+    public void Configure(EntityTypeBuilder<Order> builder)
+    {
+        builder.ToTable("Orders");
+
+        builder.HasKey(o => o.Id);
+
+        builder.Property(o => o.ShopId)
+            .IsRequired();
+
+        builder.Property(o => o.BrandSlug)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(o => o.OrderNumber)
+            .IsRequired()
+            .HasMaxLength(50);
+
+        builder.Property(o => o.OrderType)
+            .IsRequired();
+
+        builder.Property(o => o.StatusName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(o => o.CustomerName)
+            .HasMaxLength(200);
+
+        builder.Property(o => o.VatRatePercent)
+            .HasColumnType("decimal(5,2)")
+            .IsRequired();
+
+        builder.Property(o => o.SubtotalGross)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(o => o.TotalVatAmount)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(o => o.TotalNet)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(o => o.TotalGross)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(o => o.CreatedAt)
+            .IsRequired();
+
+        builder.Property(o => o.UpdatedAt)
+            .IsRequired();
+
+        // Unique order number per shop
+        builder.HasIndex(o => new { o.ShopId, o.OrderNumber })
+            .IsUnique()
+            .HasDatabaseName("UX_Orders_ShopId_OrderNumber");
+
+        // Index for querying orders by shop
+        builder.HasIndex(o => o.ShopId)
+            .HasDatabaseName("IX_Orders_ShopId");
+
+        builder.HasMany(o => o.Items)
+            .WithOne()
+            .HasForeignKey(i => i.OrderId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(o => o.Items)
+            .HasField("_items")
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        // Domain events are transient — never persisted
+        builder.Ignore(o => o.DomainEvents);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderItemConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderItemConfiguration.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Orders;
+
+public sealed class OrderItemConfiguration : IEntityTypeConfiguration<OrderItem>
+{
+    public void Configure(EntityTypeBuilder<OrderItem> builder)
+    {
+        builder.ToTable("OrderItems");
+
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.OrderId)
+            .IsRequired();
+
+        builder.Property(i => i.ProductId)
+            .IsRequired();
+
+        builder.Property(i => i.ProductName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(i => i.Quantity)
+            .IsRequired();
+
+        builder.Property(i => i.UnitGrossPrice)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(i => i.UnitNetPrice)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(i => i.UnitVatAmount)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(i => i.LineTotal)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        // SelectedModifiers stored as an owned entity collection in a separate table.
+        builder.OwnsMany(i => i.SelectedModifiers, sm =>
+        {
+            sm.ToTable("OrderItemSelectedModifiers");
+
+            sm.WithOwner()
+                .HasForeignKey("OrderItemId");
+
+            sm.Property<Guid>("OrderItemId")
+                .IsRequired();
+
+            sm.HasKey("OrderItemId", nameof(SelectedModifier.ModifierId));
+
+            sm.Property(m => m.ModifierId)
+                .IsRequired();
+
+            sm.Property(m => m.ModifierName)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            sm.Property(m => m.PriceAdjustment)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+        });
+
+        builder.Navigation(i => i.SelectedModifiers)
+            .HasField("_selectedModifiers")
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        // Domain events are transient — never persisted
+        builder.Ignore(i => i.DomainEvents);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using TheMillionthFoodOrderApp.Domain.Orders;
+using TheMillionthFoodOrderApp.Infrastructure.Persistence;
+using Wolverine;
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Orders;
+
+/// <summary>
+/// Brand-scoped order repository. Injects <see cref="BrandDbContext"/> directly
+/// (registered as scoped via factory delegate in DI).
+/// </summary>
+public sealed class OrderRepository(BrandDbContext dbContext, IMessageBus messageBus) : IOrderRepository
+{
+    /// <summary>
+    /// Marker message used when <see cref="SaveChangesAsync"/> detects a duplicate
+    /// OrderNumber unique-index violation. The Application layer catches this to
+    /// retry with a freshly generated number — keeping EF Core out of the Application layer.
+    /// </summary>
+    internal const string OrderNumberConflictMessage = "ORDER_NUMBER_CONFLICT";
+
+    /// <inheritdoc/>
+    public async Task<Order?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        => await dbContext.Orders
+            .Include(o => o.Items)
+            .ThenInclude(i => i.SelectedModifiers)
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task AddAsync(Order order, CancellationToken cancellationToken = default)
+        => await dbContext.Orders.AddAsync(order, cancellationToken);
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// If the INSERT fails because of a duplicate on <c>UX_Orders_ShopId_OrderNumber</c>
+    /// (SQL Server error 2601 or 2627), the failed entity is detached from the change tracker
+    /// and an <see cref="InvalidOperationException"/> with message
+    /// <see cref="OrderNumberConflictMessage"/> is thrown so the Application service can
+    /// regenerate the order number and retry. All other exceptions propagate as-is.
+    /// </remarks>
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var events = DomainEventDispatcher.CollectAndClear(dbContext);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (
+            ex.InnerException is Microsoft.Data.SqlClient.SqlException { Number: 2601 or 2627 } sqlEx
+            && sqlEx.Message.Contains("UX_Orders_ShopId_OrderNumber", StringComparison.OrdinalIgnoreCase))
+        {
+            // Detach all Added entries so the context is clean for a retry
+            foreach (var entry in dbContext.ChangeTracker.Entries().Where(e => e.State == EntityState.Added).ToList())
+                entry.State = EntityState.Detached;
+
+            throw new InvalidOperationException(OrderNumberConflictMessage, ex);
+        }
+
+        await DomainEventDispatcher.PublishAsync(events, messageBus);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> OrderNumberExistsAsync(
+        Guid shopId,
+        string orderNumber,
+        CancellationToken cancellationToken = default)
+        => await dbContext.Orders
+            .AnyAsync(o => o.ShopId == shopId && o.OrderNumber == orderNumber, cancellationToken);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
@@ -60,6 +60,16 @@ public sealed class OrderRepository(BrandDbContext dbContext, IMessageBus messag
     }
 
     /// <inheritdoc/>
+    public async Task<Order?> GetByOrderNumberAsync(
+        Guid shopId,
+        string orderNumber,
+        CancellationToken cancellationToken = default)
+        => await dbContext.Orders
+            .Include(o => o.Items)
+            .ThenInclude(i => i.SelectedModifiers)
+            .SingleOrDefaultAsync(o => o.ShopId == shopId && o.OrderNumber == orderNumber, cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<bool> OrderNumberExistsAsync(
         Guid shopId,
         string orderNumber,

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/BrandDbContext.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/BrandDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using TheMillionthFoodOrderApp.Domain.MenuCategories;
 using TheMillionthFoodOrderApp.Domain.ModifierGroups;
 using TheMillionthFoodOrderApp.Domain.OrderLifecycle;
+using TheMillionthFoodOrderApp.Domain.Orders;
 using TheMillionthFoodOrderApp.Domain.Products;
 using TheMillionthFoodOrderApp.Domain.Shops;
 using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
@@ -9,6 +10,7 @@ using TheMillionthFoodOrderApp.Infrastructure.BrandSettings;
 using TheMillionthFoodOrderApp.Infrastructure.MenuCategories;
 using TheMillionthFoodOrderApp.Infrastructure.ModifierGroups;
 using TheMillionthFoodOrderApp.Infrastructure.OrderLifecycle;
+using TheMillionthFoodOrderApp.Infrastructure.Orders;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence.Conventions;
 using TheMillionthFoodOrderApp.Infrastructure.Products;
 using TheMillionthFoodOrderApp.Infrastructure.Shops;
@@ -40,6 +42,8 @@ public sealed class BrandDbContext(DbContextOptions<BrandDbContext> options) : D
     public DbSet<ComboItem> ComboItems => Set<ComboItem>();
     public DbSet<Domain.TaxConfiguration.TaxConfiguration> TaxConfigurations => Set<Domain.TaxConfiguration.TaxConfiguration>();
     public DbSet<VatRate> VatRates => Set<VatRate>();
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<OrderItem> OrderItems => Set<OrderItem>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -64,6 +68,8 @@ public sealed class BrandDbContext(DbContextOptions<BrandDbContext> options) : D
         modelBuilder.ApplyConfiguration(new ComboItemConfiguration());
         modelBuilder.ApplyConfiguration(new TaxConfigurationConfiguration());
         modelBuilder.ApplyConfiguration(new VatRateConfiguration());
+        modelBuilder.ApplyConfiguration(new OrderConfiguration());
+        modelBuilder.ApplyConfiguration(new OrderItemConfiguration());
 
         // Global query filter: soft-deleted entities are excluded by default
         modelBuilder.Entity<Product>().HasQueryFilter(p => !p.IsDeleted);

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260504131405_AddOrders.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260504131405_AddOrders.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504131405_AddOrders")]
+    partial class AddOrders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260504131405_AddOrders.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260504131405_AddOrders.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddOrders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ShopId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    BrandSlug = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    OrderNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    OrderType = table.Column<int>(type: "int", nullable: false),
+                    StatusName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    CustomerName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    VatRatePercent = table.Column<decimal>(type: "decimal(5,2)", nullable: false),
+                    SubtotalGross = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    TotalVatAmount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    TotalNet = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    TotalGross = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OrderItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OrderId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ProductId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ProductName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Quantity = table.Column<int>(type: "int", nullable: false),
+                    UnitGrossPrice = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    UnitNetPrice = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    UnitVatAmount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    LineTotal = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrderItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrderItems_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OrderItemSelectedModifiers",
+                columns: table => new
+                {
+                    ModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OrderItemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ModifierName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    PriceAdjustment = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrderItemSelectedModifiers", x => new { x.OrderItemId, x.ModifierId });
+                    table.ForeignKey(
+                        name: "FK_OrderItemSelectedModifiers_OrderItems_OrderItemId",
+                        column: x => x.OrderItemId,
+                        principalTable: "OrderItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_OrderId",
+                table: "OrderItems",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_ShopId",
+                table: "Orders",
+                column: "ShopId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Orders_ShopId_OrderNumber",
+                table: "Orders",
+                columns: new[] { "ShopId", "OrderNumber" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrderItemSelectedModifiers");
+
+            migrationBuilder.DropTable(
+                name: "OrderItems");
+
+            migrationBuilder.DropTable(
+                name: "Orders");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetOrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetOrderTests.cs
@@ -1,0 +1,278 @@
+using System.Net;
+using System.Net.Http.Json;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Application.Products;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Orders;
+
+/// <summary>
+/// Integration tests for the order-tracking endpoints:
+///   GET /api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}
+///   GET /api/brands/{brandSlug}/shops/{shopId}/orders/number/{orderNumber}
+///
+/// Each test places a real order via POST and then retrieves it, verifying
+/// the OrderTrackingResponse shape and lifecycle data.
+/// Runs against a real SQL Server via Testcontainers.
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class GetOrderTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string OrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders";
+
+    private static string GetOrderByIdUrl(string brandSlug, Guid shopId, Guid orderId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}";
+
+    private static string GetOrderByNumberUrl(string brandSlug, Guid shopId, string orderNumber) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders/number/{orderNumber}";
+
+    private static string TaxConfigUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/tax-configuration";
+
+    private static string ShopsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/shops";
+
+    private static string ProductsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/products";
+
+    private static string OrderLifecycleUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+
+    // ── Setup helpers ─────────────────────────────────────────────────────────
+
+    private async Task SeedTaxConfigAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 21m },
+            }
+        };
+        var response = await client.PutAsJsonAsync(TaxConfigUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            Name = $"Tracking Shop {Guid.NewGuid().ToString("N")[..8]}",
+            Slug = $"track-{Guid.NewGuid().ToString("N")[..8]}",
+            Address = new
+            {
+                Street = "Frietstraat",
+                Number = "42",
+                City = "Gent",
+                PostalCode = "9000",
+                Country = "BE"
+            },
+            ContactEmail = "track@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var response = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var shop = await response.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+
+        // Trigger default lifecycle creation (lazy-initialised on first GET)
+        await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
+
+        return shop.Id;
+    }
+
+    private async Task<Guid> CreateProductAsync(HttpClient client, string brandSlug, decimal price = 3.50m, string name = "Test Product")
+    {
+        var request = new
+        {
+            BasePrice = price,
+            Translations = new[] { new { LanguageCode = "nl", Name = name, Description = (string?)null } }
+        };
+
+        var response = await client.PostAsJsonAsync(ProductsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var product = await response.Content.ReadFromJsonAsync<ProductResponse>();
+        await Assert.That(product).IsNotNull();
+        return product!.Id;
+    }
+
+    private async Task<OrderResponse> PlaceOrderAsync(HttpClient client, string brandSlug, Guid shopId, Guid productId)
+    {
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = "Tracking Tester",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brandSlug, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        return order!;
+    }
+
+    // ── Test 1: GET by ID — happy path ────────────────────────────────────────
+
+    [Test]
+    public async Task GetOrderById_ExistingOrder_Returns200WithOrderTrackingResponse()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 4.00m, name: "Tracking Frietje");
+        var placed = await PlaceOrderAsync(client, brand, shopId, productId);
+
+        var response = await client.GetAsync(GetOrderByIdUrl(brand, shopId, placed.Id));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var tracking = await response.Content.ReadFromJsonAsync<OrderTrackingResponse>();
+        await Assert.That(tracking).IsNotNull();
+
+        // Order detail is correct
+        await Assert.That(tracking!.Order.Id).IsEqualTo(placed.Id);
+        await Assert.That(tracking.Order.OrderNumber).IsEqualTo(placed.OrderNumber);
+        await Assert.That(tracking.Order.ShopId).IsEqualTo(shopId);
+        await Assert.That(tracking.Order.BrandSlug).IsEqualTo(brand);
+        await Assert.That(tracking.Order.StatusName).IsNotEmpty();
+        await Assert.That(tracking.Order.Items.Count).IsEqualTo(1);
+
+        // Lifecycle is populated
+        await Assert.That(tracking.Lifecycle).IsNotNull();
+        await Assert.That(tracking.Lifecycle.ShopId).IsEqualTo(shopId);
+        await Assert.That(tracking.Lifecycle.Statuses.Count).IsGreaterThan(0);
+    }
+
+    // ── Test 2: GET by ID — not found ─────────────────────────────────────────
+
+    [Test]
+    public async Task GetOrderById_NonExistentId_Returns404()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+
+        var randomId = Guid.NewGuid();
+        var response = await client.GetAsync(GetOrderByIdUrl(brand, shopId, randomId));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    // ── Test 3: GET by order number — happy path ──────────────────────────────
+
+    [Test]
+    public async Task GetOrderByNumber_ExistingOrder_Returns200WithOrderTrackingResponse()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 2.50m, name: "Tracking Saus");
+        var placed = await PlaceOrderAsync(client, brand, shopId, productId);
+
+        var response = await client.GetAsync(GetOrderByNumberUrl(brand, shopId, placed.OrderNumber));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var tracking = await response.Content.ReadFromJsonAsync<OrderTrackingResponse>();
+        await Assert.That(tracking).IsNotNull();
+
+        // Order detail matches the placed order
+        await Assert.That(tracking!.Order.Id).IsEqualTo(placed.Id);
+        await Assert.That(tracking.Order.OrderNumber).IsEqualTo(placed.OrderNumber);
+        await Assert.That(tracking.Order.ShopId).IsEqualTo(shopId);
+        await Assert.That(tracking.Order.CustomerName).IsEqualTo("Tracking Tester");
+        await Assert.That(tracking.Order.Items.Count).IsEqualTo(1);
+
+        // Lifecycle is populated
+        await Assert.That(tracking.Lifecycle).IsNotNull();
+        await Assert.That(tracking.Lifecycle.ShopId).IsEqualTo(shopId);
+        await Assert.That(tracking.Lifecycle.Statuses.Count).IsGreaterThan(0);
+    }
+
+    // ── Test 4: GET by order number — not found ───────────────────────────────
+
+    [Test]
+    public async Task GetOrderByNumber_BogusOrderNumber_Returns404()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+
+        var response = await client.GetAsync(GetOrderByNumberUrl(brand, shopId, "DOESNTEXIST"));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    // ── Bonus Test 5: GET by ID — shopId mismatch returns 404 ────────────────
+
+    [Test]
+    public async Task GetOrderById_WrongShopId_Returns404()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var wrongShopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 1.80m, name: "Shop Mismatch Product");
+        var placed = await PlaceOrderAsync(client, brand, shopId, productId);
+
+        // Request order from the correct brand but a different shop
+        var response = await client.GetAsync(GetOrderByIdUrl(brand, wrongShopId, placed.Id));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    // ── Bonus Test 6: Lifecycle statuses are ordered by SortOrder ────────────
+
+    [Test]
+    public async Task GetOrderById_LifecycleStatusesAreOrderedBySortOrder()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 3.00m, name: "Lifecycle Check");
+        var placed = await PlaceOrderAsync(client, brand, shopId, productId);
+
+        var response = await client.GetAsync(GetOrderByIdUrl(brand, shopId, placed.Id));
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var tracking = await response.Content.ReadFromJsonAsync<OrderTrackingResponse>();
+        await Assert.That(tracking).IsNotNull();
+
+        var statuses = tracking!.Lifecycle.Statuses;
+        await Assert.That(statuses.Count).IsGreaterThan(0);
+
+        // Verify statuses are sorted by SortOrder (ascending)
+        var sortOrders = statuses.Select(s => s.SortOrder).ToList();
+        var expected = sortOrders.OrderBy(x => x).ToList();
+        await Assert.That(sortOrders).IsEquivalentTo(expected);
+
+        // Order's current StatusName must be one of the lifecycle status names
+        var statusNames = statuses.Select(s => s.Name).ToList();
+        await Assert.That(statusNames).Contains(tracking.Order.StatusName);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
@@ -1,0 +1,585 @@
+using System.Net;
+using System.Net.Http.Json;
+using TheMillionthFoodOrderApp.Application.ModifierGroups;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Application.Products;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Orders;
+
+/// <summary>
+/// Integration tests for POST /api/brands/{brandSlug}/shops/{shopId}/orders.
+/// Covers happy paths (both VAT modes), error cases, and denormalisation checks.
+/// Runs against a real SQL Server via Testcontainers.
+///
+/// Prerequisites seeded in each test:
+///   - Tax configuration (PUT /tax-configuration)
+///   - Shop (POST /shops) → order lifecycle auto-created on first GET
+///   - Products (POST /products)
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class PlaceOrderTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string OrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders";
+
+    private static string TaxConfigUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/tax-configuration";
+
+    private static string ShopsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/shops";
+
+    private static string ProductsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/products";
+
+    private static string OrderLifecycleUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+
+    // ── Setup helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>Seeds Belgian VAT defaults (6% Takeaway, 21% EatIn) for the brand.</summary>
+    private async Task SeedTaxConfigAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            VatRates = new[]
+            {
+                new { ConsumptionMode = "Takeaway", RatePercentage = 6m },
+                new { ConsumptionMode = "EatIn",    RatePercentage = 21m },
+            }
+        };
+
+        var response = await client.PutAsJsonAsync(TaxConfigUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    /// <summary>Creates a shop and triggers order lifecycle initialisation.</summary>
+    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            Name = $"Test Shop {Guid.NewGuid().ToString("N")[..8]}",
+            Slug = $"shop-{Guid.NewGuid().ToString("N")[..8]}",
+            Address = new
+            {
+                Street = "Frietstraat",
+                Number = "1",
+                City = "Brussel",
+                PostalCode = "1000",
+                Country = "BE"
+            },
+            ContactEmail = "shop@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var response = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var shop = await response.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+
+        // Trigger default lifecycle creation (lazy-initialised on first GET)
+        await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
+
+        return shop.Id;
+    }
+
+    /// <summary>Creates a simple product and returns its ID and gross price.</summary>
+    private async Task<(Guid Id, decimal GrossPrice)> CreateProductAsync(
+        HttpClient client,
+        string brandSlug,
+        decimal price = 3.50m,
+        string name = "Test Product")
+    {
+        var request = new
+        {
+            BasePrice = price,
+            Translations = new[] { new { LanguageCode = "nl", Name = name, Description = (string?)null } }
+        };
+
+        var response = await client.PostAsJsonAsync(ProductsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var product = await response.Content.ReadFromJsonAsync<ProductResponse>();
+        await Assert.That(product).IsNotNull();
+        return (product!.Id, product.BasePrice.Amount);
+    }
+
+    // ── Happy path — Pickup (6% VAT) ─────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_Pickup_Returns201WithCorrect6PercentVat()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, grossPrice) = await CreateProductAsync(client, brand, price: 3.50m, name: "Frietje Klein");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = "Jan Janssen",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 2, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.Id).IsNotEqualTo(Guid.Empty);
+        await Assert.That(order.OrderNumber).IsNotEmpty();
+        await Assert.That(order.ShopId).IsEqualTo(shopId);
+        await Assert.That(order.BrandSlug).IsEqualTo(brand);
+        await Assert.That(order.OrderType).IsEqualTo("Pickup");
+        await Assert.That(order.CustomerName).IsEqualTo("Jan Janssen");
+        await Assert.That(order.StatusName).IsNotEmpty();
+        await Assert.That(order.VatRatePercent).IsEqualTo(6m);
+
+        // VAT calculation for 3.50 gross @ 6%:
+        // net  = Round(3.50 / 1.06, 2, AwayFromZero) = 3.30
+        // vat  = 3.50 - 3.30 = 0.20
+        await Assert.That(order.Items.Count).IsEqualTo(1);
+        var item = order.Items[0];
+        await Assert.That(item.ProductId).IsEqualTo(productId);
+        await Assert.That(item.ProductName).IsEqualTo("Frietje Klein");
+        await Assert.That(item.Quantity).IsEqualTo(2);
+        await Assert.That(item.UnitGrossPrice).IsEqualTo(3.50m);
+        await Assert.That(item.UnitNetPrice).IsEqualTo(3.30m);
+        await Assert.That(item.UnitVatAmount).IsEqualTo(0.20m);
+        await Assert.That(item.LineTotal).IsEqualTo(7.00m); // 3.50 * 2
+
+        // Order totals
+        await Assert.That(order.SubtotalGross).IsEqualTo(7.00m);
+        await Assert.That(order.TotalVatAmount).IsEqualTo(0.40m); // 0.20 * 2
+        await Assert.That(order.TotalNet).IsEqualTo(6.60m);       // 7.00 - 0.40
+        await Assert.That(order.TotalGross).IsEqualTo(7.00m);
+    }
+
+    [Test]
+    public async Task PlaceOrder_Delivery_Uses6PercentVat()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 5.00m, name: "Frietje Speciaal");
+
+        var request = new
+        {
+            OrderType = "Delivery",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.VatRatePercent).IsEqualTo(6m);
+
+        // 5.00 @ 6% → net = Round(5.00/1.06, 2) = 4.72; vat = 0.28
+        await Assert.That(order.Items[0].UnitNetPrice).IsEqualTo(4.72m);
+        await Assert.That(order.Items[0].UnitVatAmount).IsEqualTo(0.28m);
+    }
+
+    // ── Happy path — EatIn (21% VAT) ─────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_EatIn_Returns201WithCorrect21PercentVat()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 3.50m, name: "Frietje Groot");
+
+        var request = new
+        {
+            OrderType = "EatIn",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.VatRatePercent).IsEqualTo(21m);
+
+        // VAT calculation for 3.50 gross @ 21%:
+        // net  = Round(3.50 / 1.21, 2, AwayFromZero) = 2.89
+        // vat  = 3.50 - 2.89 = 0.61
+        var item = order.Items[0];
+        await Assert.That(item.UnitGrossPrice).IsEqualTo(3.50m);
+        await Assert.That(item.UnitNetPrice).IsEqualTo(2.89m);
+        await Assert.That(item.UnitVatAmount).IsEqualTo(0.61m);
+        await Assert.That(item.LineTotal).IsEqualTo(3.50m);
+
+        await Assert.That(order.SubtotalGross).IsEqualTo(3.50m);
+        await Assert.That(order.TotalVatAmount).IsEqualTo(0.61m);
+        await Assert.That(order.TotalNet).IsEqualTo(2.89m);
+    }
+
+    // ── Happy path — multiple items ───────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_MultipleItems_AggregatesCorrectly()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId1, _) = await CreateProductAsync(client, brand, price: 3.50m, name: "Frietje");
+        var (productId2, _) = await CreateProductAsync(client, brand, price: 1.20m, name: "Saus");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId1, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() },
+                new { ProductId = productId2, Quantity = 2, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.Items.Count).IsEqualTo(2);
+
+        // Total = 3.50 * 1 + 1.20 * 2 = 5.90
+        await Assert.That(order.SubtotalGross).IsEqualTo(5.90m);
+        await Assert.That(order.TotalGross).IsEqualTo(5.90m);
+    }
+
+    // ── OrderNumber uniqueness ────────────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_TwoOrders_HaveDifferentOrderNumbers()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.00m, name: "Knakworst");
+
+        var requestBody = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response1 = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), requestBody);
+        var response2 = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), requestBody);
+
+        await Assert.That(response1.StatusCode).IsEqualTo(HttpStatusCode.Created);
+        await Assert.That(response2.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order1 = await response1.Content.ReadFromJsonAsync<OrderResponse>();
+        var order2 = await response2.Content.ReadFromJsonAsync<OrderResponse>();
+
+        await Assert.That(order1).IsNotNull();
+        await Assert.That(order2).IsNotNull();
+        await Assert.That(order1!.OrderNumber).IsNotEqualTo(order2!.OrderNumber);
+        await Assert.That(order1.Id).IsNotEqualTo(order2.Id);
+    }
+
+    // ── Error cases ───────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_UnknownProductId_Returns400()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = Guid.NewGuid(), Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task PlaceOrder_EmptyItems_Returns400()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = Array.Empty<object>()
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task PlaceOrder_InvalidOrderType_Returns400()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.00m, name: "Wafels");
+
+        var request = new
+        {
+            OrderType = "DineIn",  // Not a valid OrderType value
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task PlaceOrder_ZeroQuantity_Returns400()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.00m, name: "Kroket");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 0, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task PlaceOrder_NonExistentBrand_Returns404()
+    {
+        var client = CreateClient();
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = Guid.NewGuid(), Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        // BrandContextMiddleware returns 404 for unknown brands
+        var response = await client.PostAsJsonAsync(
+            $"/api/brands/non-existent-brand/shops/{Guid.NewGuid()}/orders",
+            request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    // ── Denormalisation check ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_DenormalisesProductNameAtOrderTime()
+    {
+        // Verifies that the product name is captured on the order item at creation time.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.50m, name: "Oorspronkelijke Naam");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.Items[0].ProductName).IsEqualTo("Oorspronkelijke Naam");
+    }
+
+    // ── Opening lifecycle status ──────────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_StatusIsOpeningLifecycleStatus()
+    {
+        // The order should be in the "Placed" status (opening status = lowest SortOrder).
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.00m, name: "Bitterballen");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        // Default lifecycle's opening status is "Placed" (SortOrder = 0)
+        await Assert.That(order!.StatusName).IsEqualTo("Placed");
+    }
+
+    // ── VAT on modifier price adjustments ────────────────────────────────────
+
+    /// <summary>
+    /// Creates a modifier group with a single modifier and returns its modifier ID.
+    /// </summary>
+    private async Task<Guid> CreateModifierWithPriceAsync(
+        HttpClient client,
+        string brandSlug,
+        decimal priceAdjustment,
+        string modifierName = "Extra saus")
+    {
+        var request = new
+        {
+            Translations = new[] { new { LanguageCode = "nl", Name = "Extras" } },
+            Modifiers = new[]
+            {
+                new
+                {
+                    PriceAdjustment = priceAdjustment,
+                    SortOrder = 0,
+                    Translations = new[] { new { LanguageCode = "nl", Name = modifierName } }
+                }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/brands/{brandSlug}/modifier-groups", request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var group = await response.Content.ReadFromJsonAsync<ModifierGroupResponse>();
+        await Assert.That(group).IsNotNull();
+        return group!.Modifiers[0].Id;
+    }
+
+    [Test]
+    public async Task PlaceOrder_WithModifier_VatAppliedToCombinedPrice()
+    {
+        // Verifies that modifier price adjustments are included in the VAT decomposition.
+        // Product base price = 3.00, modifier price adjustment = 0.50, combined gross = 3.50.
+        // At 6% VAT (Pickup): net = Round(3.50 / 1.06, 2) = 3.30, vat = 0.20.
+        // The UnitGrossPrice stored on the item must be 3.50, NOT 3.00.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 3.00m, name: "Frietje");
+        var modifierId = await CreateModifierWithPriceAsync(client, brand, priceAdjustment: 0.50m, modifierName: "Extra groot");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            CustomerName = (string?)null,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 2, SelectedModifierIds = new[] { modifierId } }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.VatRatePercent).IsEqualTo(6m);
+
+        var item = order.Items[0];
+        await Assert.That(item.SelectedModifiers.Count).IsEqualTo(1);
+
+        // Combined gross = 3.00 (base) + 0.50 (modifier) = 3.50
+        await Assert.That(item.UnitGrossPrice).IsEqualTo(3.50m);
+
+        // Net = Round(3.50 / 1.06, 2, AwayFromZero) = 3.30, VAT = 3.50 - 3.30 = 0.20
+        await Assert.That(item.UnitNetPrice).IsEqualTo(3.30m);
+        await Assert.That(item.UnitVatAmount).IsEqualTo(0.20m);
+
+        // LineTotal = combined unit gross × quantity = 3.50 × 2 = 7.00
+        await Assert.That(item.LineTotal).IsEqualTo(7.00m);
+
+        // Order totals
+        await Assert.That(order.SubtotalGross).IsEqualTo(7.00m);
+        await Assert.That(order.TotalVatAmount).IsEqualTo(0.40m); // 0.20 * 2
+        await Assert.That(order.TotalNet).IsEqualTo(6.60m);       // 7.00 - 0.40
+        await Assert.That(order.TotalGross).IsEqualTo(7.00m);
+
+        // Modifier PriceAdjustment is still recorded individually for display
+        await Assert.That(item.SelectedModifiers[0].PriceAdjustment).IsEqualTo(0.50m);
+    }
+}

--- a/src/frontend/CLAUDE.md
+++ b/src/frontend/CLAUDE.md
@@ -66,8 +66,10 @@ Brand CRUD (list/create/edit), brand theming, shop CRUD (list/create/edit), shop
 
 ## Storefront
 
-- Components: `LanguageSelector` (NL/FR/DE switcher with locale persistence), `ThemeProvider` (brand theming), `ShopStatusBadge`
-- Pages: Home
+- Components: `LanguageSelector` (NL/FR/DE switcher with locale persistence), `ThemeProvider` (brand theming), `ShopStatusBadge`, `OrderStatusStepper` (lifecycle step indicator, brand-coloured, SignalR-driven)
+- Pages: Home, MenuPage (`shops/:shopId/menu`), CheckoutPage (`checkout`), OrderConfirmationPage (`order/:orderId`), OrderTrackingPage (`order/:orderId/track`)
+- Real-time pattern: `useOrderUpdates({ orderId, onStatusChange })` subscribes to SignalR `OrderStatusChanged` events — used on both confirmation and tracking pages
+- `ordersApi.getById` extracts `.order` from `OrderTrackingResponse` internally to preserve its `Promise<OrderResponse>` contract; use `ordersApi.getTracking` when you need the full lifecycle too
 
 ## POS
 

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -57,6 +57,37 @@ export interface OrderResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Order tracking response types (US-FP-063)
+// ---------------------------------------------------------------------------
+
+export interface OrderStatusResponse {
+  id: string;
+  name: string;
+  systemKey: string | null;
+  sortOrder: number;
+  isEnabled: boolean;
+  isTerminal: boolean;
+  colorHex: string | null;
+}
+
+export interface OrderStatusTransitionResponse {
+  id: string;
+  fromStatusId: string;
+  toStatusId: string;
+}
+
+export interface OrderLifecycleResponse {
+  shopId: string;
+  statuses: OrderStatusResponse[];
+  transitions: OrderStatusTransitionResponse[];
+}
+
+export interface OrderTrackingResponse {
+  order: OrderResponse;
+  lifecycle: OrderLifecycleResponse;
+}
+
+// ---------------------------------------------------------------------------
 // API module
 // ---------------------------------------------------------------------------
 
@@ -80,6 +111,28 @@ export const ordersApi = {
     orderId: string,
   ): Promise<OrderResponse> =>
     apiClient
-      .get<OrderResponse>(`/brands/${brandSlug}/shops/${shopId}/orders/${orderId}`)
+      .get<OrderTrackingResponse>(`/brands/${brandSlug}/shops/${shopId}/orders/${orderId}`)
+      .then((r) => r.data.order),
+
+  /** Fetch full tracking response (order + lifecycle) for the tracking page. */
+  getTracking: (
+    brandSlug: string,
+    shopId: string,
+    orderId: string,
+  ): Promise<OrderTrackingResponse> =>
+    apiClient
+      .get<OrderTrackingResponse>(`/brands/${brandSlug}/shops/${shopId}/orders/${orderId}`)
+      .then((r) => r.data),
+
+  /** Look up an order by its human-readable order number. */
+  getByNumber: (
+    brandSlug: string,
+    shopId: string,
+    orderNumber: string,
+  ): Promise<OrderTrackingResponse> =>
+    apiClient
+      .get<OrderTrackingResponse>(
+        `/brands/${brandSlug}/shops/${shopId}/orders/number/${orderNumber}`,
+      )
       .then((r) => r.data),
 };

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -1,0 +1,85 @@
+import { apiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+export type OrderType = 'Pickup' | 'EatIn' | 'Delivery';
+
+export interface OrderItemRequest {
+  productId: string;
+  quantity: number;
+  selectedModifierIds: string[];
+}
+
+export interface CreateOrderRequest {
+  orderType: OrderType;
+  customerName?: string | null;
+  items: OrderItemRequest[];
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+export interface OrderModifierResponse {
+  modifierId: string;
+  modifierName: string;
+  priceAdjustment: number;
+}
+
+export interface OrderItemResponse {
+  productId: string;
+  productName: string;
+  quantity: number;
+  unitGrossPrice: number;
+  unitNetPrice: number;
+  unitVatAmount: number;
+  lineTotal: number;
+  selectedModifiers: OrderModifierResponse[];
+}
+
+export interface OrderResponse {
+  id: string;
+  orderNumber: string;
+  shopId: string;
+  brandSlug: string;
+  orderType: OrderType;
+  statusName: string;
+  customerName: string | null;
+  items: OrderItemResponse[];
+  vatRatePercent: number;
+  subtotalGross: number;
+  totalVatAmount: number;
+  totalNet: number;
+  totalGross: number;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// API module
+// ---------------------------------------------------------------------------
+
+/**
+ * API functions for orders (customer storefront).
+ * Routes are brand + shop scoped: /brands/{brandSlug}/shops/{shopId}/orders/...
+ */
+export const ordersApi = {
+  create: (
+    brandSlug: string,
+    shopId: string,
+    data: CreateOrderRequest,
+  ): Promise<OrderResponse> =>
+    apiClient
+      .post<OrderResponse>(`/brands/${brandSlug}/shops/${shopId}/orders`, data)
+      .then((r) => r.data),
+
+  getById: (
+    brandSlug: string,
+    shopId: string,
+    orderId: string,
+  ): Promise<OrderResponse> =>
+    apiClient
+      .get<OrderResponse>(`/brands/${brandSlug}/shops/${shopId}/orders/${orderId}`)
+      .then((r) => r.data),
+};

--- a/src/frontend/src/features/storefront/components/CartDrawer.tsx
+++ b/src/frontend/src/features/storefront/components/CartDrawer.tsx
@@ -1,0 +1,265 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCart, type CartItem } from '../context/CartContext';
+
+interface CartDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Fixed-position right-side panel showing the current cart contents.
+ * Provides quantity +/- controls and line totals, with a "Go to Checkout" button.
+ */
+export function CartDrawer({ isOpen, onClose }: CartDrawerProps) {
+  const { t } = useTranslation('common');
+  const { brandSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
+  const navigate = useNavigate();
+  const { state, updateQuantity, removeItem, cartTotal, cartItemCount, getModifierKey } = useCart();
+
+  function handleGoToCheckout() {
+    onClose();
+    void navigate(`/${brandSlug}/${lang}/checkout`);
+  }
+
+  function formatCurrency(amount: number): string {
+    return new Intl.NumberFormat('nl-BE', { style: 'currency', currency: 'EUR' }).format(amount);
+  }
+
+  function getLineTotal(item: CartItem): number {
+    const modifierTotal = item.selectedModifiers.reduce((s, m) => s + m.priceAdjustment, 0);
+    return item.quantity * (item.unitGrossPrice + modifierTotal);
+  }
+
+  return (
+    <>
+      {/* Backdrop — only when open */}
+      {isOpen && (
+        <div
+          onClick={onClose}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.3)',
+            zIndex: 90,
+          }}
+        />
+      )}
+
+      {/* Drawer panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('storefront.cart.title')}
+        style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: 'min(24rem, 100vw)',
+          background: '#fff',
+          boxShadow: '-4px 0 24px rgba(0,0,0,0.15)',
+          zIndex: 91,
+          transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
+          transition: 'transform 0.25s ease',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '1.25rem 1.5rem',
+            borderBottom: '1px solid #e5e7eb',
+          }}
+        >
+          <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 700, color: '#111827' }}>
+            {t('storefront.cart.title')}
+            {cartItemCount > 0 && (
+              <span
+                style={{
+                  marginLeft: '0.5rem',
+                  background: 'var(--brand-color-primary, #111827)',
+                  color: '#fff',
+                  borderRadius: '9999px',
+                  fontSize: '0.75rem',
+                  fontWeight: 700,
+                  padding: '0.125rem 0.5rem',
+                }}
+              >
+                {cartItemCount}
+              </span>
+            )}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('storefront.cart.close')}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: '#6b7280',
+              fontSize: '1.5rem',
+              lineHeight: 1,
+            }}
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Item list */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '1rem 1.5rem' }}>
+          {state.items.length === 0 ? (
+            <p style={{ color: '#6b7280', fontSize: '0.9375rem', textAlign: 'center', marginTop: '2rem' }}>
+              {t('storefront.cart.empty')}
+            </p>
+          ) : (
+            state.items.map((item) => {
+              const key = `${item.productId}-${getModifierKey(item.selectedModifiers)}`;
+              const lineTotal = getLineTotal(item);
+
+              return (
+                <div
+                  key={key}
+                  style={{
+                    paddingBottom: '1rem',
+                    marginBottom: '1rem',
+                    borderBottom: '1px solid #f3f4f6',
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.5rem' }}>
+                    <span style={{ fontWeight: 600, fontSize: '0.9375rem', color: '#111827', flex: 1 }}>
+                      {item.productName}
+                    </span>
+                    <span style={{ fontWeight: 600, fontSize: '0.9375rem', color: '#111827', whiteSpace: 'nowrap' }}>
+                      {formatCurrency(lineTotal)}
+                    </span>
+                  </div>
+
+                  {item.selectedModifiers.length > 0 && (
+                    <p style={{ margin: '0.25rem 0 0', fontSize: '0.8125rem', color: '#6b7280' }}>
+                      {item.selectedModifiers.map((m) => m.modifierName).join(', ')}
+                    </p>
+                  )}
+
+                  {/* Quantity controls */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        updateQuantity(item.productId, item.selectedModifiers, item.quantity - 1)
+                      }
+                      aria-label={t('storefront.cart.decreaseQuantity')}
+                      style={{
+                        width: '2rem',
+                        height: '2rem',
+                        borderRadius: '50%',
+                        border: '1px solid #d1d5db',
+                        background: '#fff',
+                        cursor: 'pointer',
+                        fontSize: '1.125rem',
+                        lineHeight: 1,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: '#374151',
+                      }}
+                    >
+                      &minus;
+                    </button>
+                    <span style={{ fontWeight: 600, minWidth: '1.5rem', textAlign: 'center', fontSize: '0.9375rem' }}>
+                      {item.quantity}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        updateQuantity(item.productId, item.selectedModifiers, item.quantity + 1)
+                      }
+                      aria-label={t('storefront.cart.increaseQuantity')}
+                      style={{
+                        width: '2rem',
+                        height: '2rem',
+                        borderRadius: '50%',
+                        border: '1px solid #d1d5db',
+                        background: '#fff',
+                        cursor: 'pointer',
+                        fontSize: '1.125rem',
+                        lineHeight: 1,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: '#374151',
+                      }}
+                    >
+                      +
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeItem(item.productId, item.selectedModifiers)}
+                      aria-label={t('storefront.cart.remove')}
+                      style={{
+                        marginLeft: 'auto',
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: '#ef4444',
+                        fontSize: '0.8125rem',
+                        fontWeight: 600,
+                      }}
+                    >
+                      {t('storefront.cart.remove')}
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer */}
+        {state.items.length > 0 && (
+          <div
+            style={{
+              padding: '1rem 1.5rem',
+              borderTop: '1px solid #e5e7eb',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginBottom: '1rem',
+                fontWeight: 700,
+                fontSize: '1rem',
+              }}
+            >
+              <span>{t('storefront.cart.subtotal')}</span>
+              <span>{formatCurrency(cartTotal)}</span>
+            </div>
+            <button
+              type="button"
+              onClick={handleGoToCheckout}
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                borderRadius: '0.5rem',
+                border: 'none',
+                background: 'var(--brand-color-primary, #111827)',
+                color: '#fff',
+                fontWeight: 700,
+                fontSize: '1rem',
+                cursor: 'pointer',
+              }}
+            >
+              {t('storefront.cart.goToCheckout')}
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/frontend/src/features/storefront/components/ModifierModal.tsx
+++ b/src/frontend/src/features/storefront/components/ModifierModal.tsx
@@ -1,0 +1,254 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ProductListItem, ModifierResponse } from '@/types/common';
+import type { CartModifier } from '../context/CartContext';
+import { useProductModifierGroups } from '../hooks/useStorefrontMenu';
+
+interface ModifierModalProps {
+  brandSlug: string;
+  product: ProductListItem;
+  onConfirm: (selectedModifiers: CartModifier[]) => void;
+  onClose: () => void;
+}
+
+/**
+ * Modal for selecting modifier options before adding a product to the cart.
+ * Fetches modifier groups for the product and renders them as a list of checkboxes.
+ *
+ * Each modifier group allows multiple selections (no single-choice enforcement in MVP).
+ */
+export function ModifierModal({ brandSlug, product, onConfirm, onClose }: ModifierModalProps) {
+  const { t } = useTranslation('common');
+  const { data: modifierGroups, isLoading } = useProductModifierGroups(brandSlug, product.id);
+  const [selectedModifierIds, setSelectedModifierIds] = useState<Set<string>>(new Set());
+
+  function toggleModifier(modifier: ModifierResponse) {
+    setSelectedModifierIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(modifier.id)) {
+        next.delete(modifier.id);
+      } else {
+        next.add(modifier.id);
+      }
+      return next;
+    });
+  }
+
+  function handleConfirm() {
+    if (!modifierGroups) {
+      onConfirm([]);
+      return;
+    }
+
+    const selected: CartModifier[] = [];
+    for (const group of modifierGroups) {
+      for (const modifier of group.modifiers) {
+        if (selectedModifierIds.has(modifier.id)) {
+          const modifierName = modifier.translations[0]?.name ?? '';
+          selected.push({
+            modifierId: modifier.id,
+            modifierName,
+            priceAdjustment: modifier.priceAdjustment,
+          });
+        }
+      }
+    }
+    onConfirm(selected);
+  }
+
+  const formattedBasePrice = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: product.basePrice.currency || 'EUR',
+  }).format(product.basePrice.amount);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.4)',
+          zIndex: 100,
+        }}
+      />
+
+      {/* Modal panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('storefront.menu.customise')}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          margin: 'auto',
+          width: 'min(28rem, calc(100vw - 2rem))',
+          maxHeight: 'calc(100vh - 4rem)',
+          background: '#fff',
+          borderRadius: '0.75rem',
+          boxShadow: '0 20px 60px rgba(0,0,0,0.25)',
+          zIndex: 101,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: '1.25rem 1.5rem',
+            borderBottom: '1px solid #e5e7eb',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+          }}
+        >
+          <div>
+            <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 700, color: '#111827' }}>
+              {product.name}
+            </h2>
+            <p style={{ margin: '0.25rem 0 0', fontSize: '0.875rem', color: '#6b7280' }}>
+              {formattedBasePrice}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('storefront.menu.closeModal')}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: '#6b7280',
+              fontSize: '1.5rem',
+              lineHeight: 1,
+              padding: '0.25rem',
+            }}
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '1rem 1.5rem' }}>
+          {isLoading && (
+            <p style={{ color: '#6b7280', fontSize: '0.875rem' }}>
+              {t('storefront.menu.loadingModifiers')}
+            </p>
+          )}
+
+          {!isLoading && modifierGroups && modifierGroups.length === 0 && (
+            <p style={{ color: '#6b7280', fontSize: '0.875rem' }}>
+              {t('storefront.menu.noModifiers')}
+            </p>
+          )}
+
+          {!isLoading &&
+            modifierGroups?.map((group) => {
+              return (
+                <div key={group.modifierGroupId} style={{ marginBottom: '1.25rem' }}>
+                  <h3
+                    style={{
+                      margin: '0 0 0.5rem',
+                      fontSize: '0.9375rem',
+                      fontWeight: 600,
+                      color: '#374151',
+                    }}
+                  >
+                    {group.name}
+                  </h3>
+                  {group.modifiers.map((modifier) => {
+                    const modifierName = modifier.translations[0]?.name ?? '';
+                    const isChecked = selectedModifierIds.has(modifier.id);
+                    const adjustmentLabel =
+                      modifier.priceAdjustment !== 0
+                        ? ` (+${new Intl.NumberFormat('nl-BE', {
+                            style: 'currency',
+                            currency: 'EUR',
+                          }).format(modifier.priceAdjustment)})`
+                        : '';
+
+                    return (
+                      <label
+                        key={modifier.id}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '0.75rem',
+                          padding: '0.5rem 0',
+                          cursor: 'pointer',
+                          fontSize: '0.9375rem',
+                          color: '#111827',
+                          borderBottom: '1px solid #f3f4f6',
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          onChange={() => toggleModifier(modifier)}
+                          style={{ width: '1.125rem', height: '1.125rem', cursor: 'pointer' }}
+                        />
+                        <span style={{ flex: 1 }}>{modifierName}</span>
+                        {adjustmentLabel && (
+                          <span style={{ color: '#6b7280', fontSize: '0.875rem' }}>
+                            {adjustmentLabel}
+                          </span>
+                        )}
+                      </label>
+                    );
+                  })}
+                </div>
+              );
+            })}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: '1rem 1.5rem',
+            borderTop: '1px solid #e5e7eb',
+            display: 'flex',
+            gap: '0.75rem',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: '0.625rem 1.25rem',
+              borderRadius: '0.375rem',
+              border: '1px solid #d1d5db',
+              background: '#fff',
+              color: '#374151',
+              fontWeight: 600,
+              fontSize: '0.875rem',
+              cursor: 'pointer',
+            }}
+          >
+            {t('storefront.menu.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isLoading}
+            style={{
+              padding: '0.625rem 1.25rem',
+              borderRadius: '0.375rem',
+              border: 'none',
+              background: 'var(--brand-color-primary, #111827)',
+              color: '#fff',
+              fontWeight: 600,
+              fontSize: '0.875rem',
+              cursor: isLoading ? 'not-allowed' : 'pointer',
+              opacity: isLoading ? 0.6 : 1,
+            }}
+          >
+            {t('storefront.menu.addToCart')}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/frontend/src/features/storefront/components/OrderStatusStepper.tsx
+++ b/src/frontend/src/features/storefront/components/OrderStatusStepper.tsx
@@ -1,0 +1,154 @@
+// Presentational stepper component — renders the shop's configured order
+// lifecycle as a horizontal step progression for customer-facing tracking.
+
+import type { OrderStatusResponse } from '@api/orders';
+
+interface Props {
+  /** Statuses from the lifecycle, ordered by sortOrder. */
+  statuses: OrderStatusResponse[];
+  /** The current status name of the order. */
+  currentStatusName: string;
+}
+
+/**
+ * Renders the order lifecycle as a visual step indicator.
+ * Completed steps are filled; the current step is highlighted with the brand
+ * colour (or the status colorHex); upcoming steps are greyed out.
+ */
+export function OrderStatusStepper({ statuses, currentStatusName }: Props) {
+  const enabled = statuses.filter((s) => s.isEnabled).sort((a, b) => a.sortOrder - b.sortOrder);
+
+  const currentIndex = enabled.findIndex(
+    (s) => s.name.toLowerCase() === currentStatusName.toLowerCase(),
+  );
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        overflowX: 'auto',
+        padding: '0.5rem 0 1rem',
+        gap: 0,
+      }}
+      role="list"
+      aria-label="Order status progression"
+    >
+      {enabled.map((status, idx) => {
+        const isCompleted = idx < currentIndex;
+        const isCurrent = idx === currentIndex;
+        const isPending = idx > currentIndex;
+
+        const brandColor = status.colorHex ?? 'var(--brand-color-primary, #111827)';
+        const stepColor = isCurrent || isCompleted ? brandColor : '#d1d5db';
+        const textColor = isCurrent ? brandColor : isCompleted ? '#374151' : '#9ca3af';
+        const fontWeight = isCurrent ? 700 : 400;
+
+        return (
+          <div
+            key={status.id}
+            role="listitem"
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              flex: '1 0 5rem',
+              minWidth: '4rem',
+              position: 'relative',
+            }}
+          >
+            {/* Connector line before this step */}
+            {idx > 0 && (
+              <div
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  top: '0.875rem',
+                  right: '50%',
+                  left: '-50%',
+                  height: '2px',
+                  background: isCompleted || isCurrent ? brandColor : '#e5e7eb',
+                  zIndex: 0,
+                }}
+              />
+            )}
+
+            {/* Step circle */}
+            <div
+              aria-hidden="true"
+              style={{
+                position: 'relative',
+                zIndex: 1,
+                width: '1.75rem',
+                height: '1.75rem',
+                borderRadius: '50%',
+                border: `2px solid ${stepColor}`,
+                background: isCompleted || isCurrent ? stepColor : '#fff',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+                transition: 'background 0.2s, border-color 0.2s',
+              }}
+            >
+              {isCompleted && (
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M2 6l3 3 5-5"
+                    stroke="#fff"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+              {isCurrent && (
+                <div
+                  style={{
+                    width: '0.5rem',
+                    height: '0.5rem',
+                    borderRadius: '50%',
+                    background: '#fff',
+                  }}
+                />
+              )}
+              {isPending && (
+                <div
+                  style={{
+                    width: '0.375rem',
+                    height: '0.375rem',
+                    borderRadius: '50%',
+                    background: '#d1d5db',
+                  }}
+                />
+              )}
+            </div>
+
+            {/* Status label */}
+            <span
+              style={{
+                marginTop: '0.375rem',
+                fontSize: '0.6875rem',
+                fontWeight,
+                color: textColor,
+                textAlign: 'center',
+                lineHeight: 1.3,
+                wordBreak: 'break-word',
+                maxWidth: '5rem',
+                transition: 'color 0.2s',
+              }}
+            >
+              {status.name}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/frontend/src/features/storefront/components/ProductCard.tsx
+++ b/src/frontend/src/features/storefront/components/ProductCard.tsx
@@ -1,0 +1,96 @@
+import { useTranslation } from 'react-i18next';
+import type { ProductListItem } from '@/types/common';
+
+interface ProductCardProps {
+  product: ProductListItem;
+  onAdd: (product: ProductListItem) => void;
+}
+
+/**
+ * Displays a single product in the storefront menu.
+ * Shows the product name, formatted price, and an "Add" button.
+ *
+ * For products with modifier groups, the parent (MenuPage) opens a ModifierModal
+ * when the add button is clicked.
+ */
+export function ProductCard({ product, onAdd }: ProductCardProps) {
+  const { t } = useTranslation('common');
+
+  const formattedPrice = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: product.basePrice.currency || 'EUR',
+  }).format(product.basePrice.amount);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '1rem',
+        padding: '1rem',
+        borderRadius: '0.5rem',
+        border: '1px solid #e5e7eb',
+        background: '#fff',
+        marginBottom: '0.75rem',
+      }}
+    >
+      {product.imageUrl && (
+        <img
+          src={product.imageUrl}
+          alt={product.name}
+          style={{
+            width: '4.5rem',
+            height: '4.5rem',
+            objectFit: 'cover',
+            borderRadius: '0.375rem',
+            flexShrink: 0,
+          }}
+        />
+      )}
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            fontSize: '0.9375rem',
+            color: '#111827',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {product.name}
+        </p>
+        <p
+          style={{
+            margin: '0.25rem 0 0',
+            fontSize: '0.875rem',
+            color: '#6b7280',
+          }}
+        >
+          {formattedPrice}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onAdd(product)}
+        aria-label={t('storefront.menu.addItem', { name: product.name })}
+        style={{
+          flexShrink: 0,
+          padding: '0.5rem 1rem',
+          borderRadius: '0.375rem',
+          border: 'none',
+          background: 'var(--brand-color-primary, #111827)',
+          color: '#fff',
+          fontWeight: 600,
+          fontSize: '0.875rem',
+          cursor: 'pointer',
+        }}
+      >
+        {t('storefront.menu.add')}
+      </button>
+    </div>
+  );
+}

--- a/src/frontend/src/features/storefront/context/CartContext.tsx
+++ b/src/frontend/src/features/storefront/context/CartContext.tsx
@@ -1,0 +1,284 @@
+import {
+  createContext,
+  useContext,
+  useReducer,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CartModifier {
+  modifierId: string;
+  modifierName: string;
+  priceAdjustment: number;
+}
+
+export interface CartItem {
+  productId: string;
+  productName: string;
+  quantity: number;
+  unitGrossPrice: number;
+  selectedModifiers: CartModifier[];
+}
+
+export interface CartState {
+  brandSlug: string;
+  shopId: string;
+  items: CartItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+type CartAction =
+  | { type: 'ADD_ITEM'; payload: CartItem }
+  | { type: 'REMOVE_ITEM'; payload: { productId: string; modifierKey: string } }
+  | { type: 'UPDATE_QUANTITY'; payload: { productId: string; modifierKey: string; quantity: number } }
+  | { type: 'CLEAR_CART' }
+  | { type: 'LOAD_CART'; payload: CartState };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a stable key for a cart item based on productId + selected modifiers.
+ * This allows the same product with different modifier selections to be separate
+ * line items.
+ */
+function modifierKey(selectedModifiers: CartModifier[]): string {
+  return selectedModifiers
+    .map((m) => m.modifierId)
+    .sort()
+    .join(',');
+}
+
+function storageKey(brandSlug: string, shopId: string): string {
+  return `cart:${brandSlug}:${shopId}`;
+}
+
+function loadFromStorage(brandSlug: string, shopId: string): CartState | null {
+  try {
+    const raw = localStorage.getItem(storageKey(brandSlug, shopId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CartState;
+    // Validate that the stored state matches the current shop
+    if (parsed.brandSlug !== brandSlug || parsed.shopId !== shopId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function saveToStorage(state: CartState): void {
+  try {
+    localStorage.setItem(storageKey(state.brandSlug, state.shopId), JSON.stringify(state));
+  } catch {
+    // Storage quota exceeded — degrade gracefully
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function cartReducer(state: CartState, action: CartAction): CartState {
+  switch (action.type) {
+    case 'LOAD_CART':
+      return action.payload;
+
+    case 'ADD_ITEM': {
+      const newItemKey = modifierKey(action.payload.selectedModifiers);
+      const existingIndex = state.items.findIndex(
+        (item) =>
+          item.productId === action.payload.productId &&
+          modifierKey(item.selectedModifiers) === newItemKey,
+      );
+
+      if (existingIndex >= 0) {
+        // Increment quantity of existing line item
+        const updatedItems = state.items.map((item, idx) =>
+          idx === existingIndex
+            ? { ...item, quantity: item.quantity + action.payload.quantity }
+            : item,
+        );
+        return { ...state, items: updatedItems };
+      }
+
+      return { ...state, items: [...state.items, action.payload] };
+    }
+
+    case 'REMOVE_ITEM': {
+      return {
+        ...state,
+        items: state.items.filter(
+          (item) =>
+            !(
+              item.productId === action.payload.productId &&
+              modifierKey(item.selectedModifiers) === action.payload.modifierKey
+            ),
+        ),
+      };
+    }
+
+    case 'UPDATE_QUANTITY': {
+      if (action.payload.quantity <= 0) {
+        // Remove item when quantity drops to 0
+        return {
+          ...state,
+          items: state.items.filter(
+            (item) =>
+              !(
+                item.productId === action.payload.productId &&
+                modifierKey(item.selectedModifiers) === action.payload.modifierKey
+              ),
+          ),
+        };
+      }
+
+      return {
+        ...state,
+        items: state.items.map((item) =>
+          item.productId === action.payload.productId &&
+          modifierKey(item.selectedModifiers) === action.payload.modifierKey
+            ? { ...item, quantity: action.payload.quantity }
+            : item,
+        ),
+      };
+    }
+
+    case 'CLEAR_CART':
+      return { ...state, items: [] };
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface CartContextValue {
+  state: CartState;
+  addItem: (item: CartItem) => void;
+  removeItem: (productId: string, modifiers: CartModifier[]) => void;
+  updateQuantity: (productId: string, modifiers: CartModifier[], quantity: number) => void;
+  clearCart: () => void;
+  cartTotal: number;
+  cartItemCount: number;
+  getModifierKey: (modifiers: CartModifier[]) => string;
+}
+
+const CartContext = createContext<CartContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface CartProviderProps {
+  brandSlug: string;
+  shopId: string;
+  children: ReactNode;
+}
+
+export function CartProvider({ brandSlug, shopId, children }: CartProviderProps) {
+  const initialState: CartState = {
+    brandSlug,
+    shopId,
+    items: [],
+  };
+
+  const [state, dispatch] = useReducer(cartReducer, initialState, () => {
+    // Eagerly load from localStorage on mount
+    const stored = loadFromStorage(brandSlug, shopId);
+    return stored ?? initialState;
+  });
+
+  // When shopId changes (user navigates to a different shop), load that shop's cart
+  useEffect(() => {
+    const stored = loadFromStorage(brandSlug, shopId);
+    if (stored) {
+      dispatch({ type: 'LOAD_CART', payload: stored });
+    } else {
+      dispatch({
+        type: 'LOAD_CART',
+        payload: { brandSlug, shopId, items: [] },
+      });
+    }
+  }, [brandSlug, shopId]);
+
+  // Persist to localStorage on every change
+  useEffect(() => {
+    // Only persist if this state belongs to the current shop
+    if (state.brandSlug === brandSlug && state.shopId === shopId) {
+      saveToStorage(state);
+    }
+  }, [state, brandSlug, shopId]);
+
+  const addItem = useCallback((item: CartItem) => {
+    dispatch({ type: 'ADD_ITEM', payload: item });
+  }, []);
+
+  const removeItem = useCallback((productId: string, modifiers: CartModifier[]) => {
+    dispatch({
+      type: 'REMOVE_ITEM',
+      payload: { productId, modifierKey: modifierKey(modifiers) },
+    });
+  }, []);
+
+  const updateQuantity = useCallback(
+    (productId: string, modifiers: CartModifier[], quantity: number) => {
+      dispatch({
+        type: 'UPDATE_QUANTITY',
+        payload: { productId, modifierKey: modifierKey(modifiers), quantity },
+      });
+    },
+    [],
+  );
+
+  const clearCart = useCallback(() => {
+    dispatch({ type: 'CLEAR_CART' });
+  }, []);
+
+  const cartTotal = state.items.reduce(
+    (sum, item) =>
+      sum +
+      item.quantity *
+        (item.unitGrossPrice +
+          item.selectedModifiers.reduce((mSum, m) => mSum + m.priceAdjustment, 0)),
+    0,
+  );
+
+  const cartItemCount = state.items.reduce((sum, item) => sum + item.quantity, 0);
+
+  const value: CartContextValue = {
+    state,
+    addItem,
+    removeItem,
+    updateQuantity,
+    clearCart,
+    cartTotal,
+    cartItemCount,
+    getModifierKey: modifierKey,
+  };
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCart(): CartContextValue {
+  const ctx = useContext(CartContext);
+  if (ctx === null) {
+    throw new Error('useCart must be used within a CartProvider.');
+  }
+  return ctx;
+}

--- a/src/frontend/src/features/storefront/hooks/useCreateOrder.ts
+++ b/src/frontend/src/features/storefront/hooks/useCreateOrder.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { ordersApi } from '@api/orders';
+import type { CreateOrderRequest, OrderResponse } from '@api/orders';
+
+/**
+ * TanStack Query mutation hook for creating an order.
+ * Called from CheckoutPage after form validation.
+ *
+ * On success, the caller should navigate to /order/:orderId using the returned id.
+ */
+export function useCreateOrder(brandSlug: string, shopId: string) {
+  return useMutation<OrderResponse, Error, CreateOrderRequest>({
+    mutationFn: (data: CreateOrderRequest) => ordersApi.create(brandSlug, shopId, data),
+  });
+}

--- a/src/frontend/src/features/storefront/hooks/useStorefrontMenu.ts
+++ b/src/frontend/src/features/storefront/hooks/useStorefrontMenu.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import { menuCategoriesApi } from '@api/menuCategories';
+import { modifierGroupsApi } from '@api/modifierGroups';
+import type { MenuCategoryListItem, ProductListItem, ProductModifierGroupResponse } from '@/types/common';
+
+// ---------------------------------------------------------------------------
+// Query key factories — storefront-scoped, separate from admin keys
+// ---------------------------------------------------------------------------
+
+export const storefrontMenuKeys = {
+  categories: (brandSlug: string) => ['storefront', 'menuCategories', brandSlug] as const,
+  categoryProducts: (brandSlug: string, categoryId: string) =>
+    ['storefront', 'menuCategories', brandSlug, categoryId, 'products'] as const,
+  productModifiers: (brandSlug: string, productId: string) =>
+    ['storefront', 'productModifiers', brandSlug, productId] as const,
+};
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all menu categories for a brand, sorted by sortOrder.
+ * Used by the storefront menu page to render category sections.
+ */
+export function useStorefrontCategories(brandSlug: string) {
+  return useQuery<MenuCategoryListItem[]>({
+    queryKey: storefrontMenuKeys.categories(brandSlug),
+    queryFn: async () => {
+      const categories = await menuCategoriesApi.list(brandSlug);
+      return [...categories].sort((a, b) => a.sortOrder - b.sortOrder);
+    },
+    enabled: brandSlug.length > 0,
+    staleTime: 2 * 60 * 1000, // 2 minutes
+  });
+}
+
+/**
+ * Fetches all products for a menu category, sorted by sortOrderInCategory.
+ * Used by the storefront menu page to render product cards within each section.
+ */
+export function useStorefrontCategoryProducts(brandSlug: string, categoryId: string) {
+  return useQuery<ProductListItem[]>({
+    queryKey: storefrontMenuKeys.categoryProducts(brandSlug, categoryId),
+    queryFn: async () => {
+      const products = await menuCategoriesApi.listProducts(brandSlug, categoryId);
+      return [...products].sort((a, b) => a.sortOrderInCategory - b.sortOrderInCategory);
+    },
+    enabled: brandSlug.length > 0 && categoryId.length > 0,
+    staleTime: 2 * 60 * 1000,
+  });
+}
+
+/**
+ * Fetches modifier groups assigned to a product.
+ * Used by the ModifierModal to display customisation options before adding to cart.
+ */
+export function useProductModifierGroups(brandSlug: string, productId: string) {
+  return useQuery<ProductModifierGroupResponse[]>({
+    queryKey: storefrontMenuKeys.productModifiers(brandSlug, productId),
+    queryFn: () => modifierGroupsApi.getProductModifierGroups(brandSlug, productId),
+    enabled: brandSlug.length > 0 && productId.length > 0,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
+++ b/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
@@ -1,0 +1,422 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useAuth } from '@/auth/useAuth';
+import { CartProvider, useCart } from '../context/CartContext';
+import { useCreateOrder } from '../hooks/useCreateOrder';
+import type { OrderType } from '@api/orders';
+
+// ---------------------------------------------------------------------------
+// Zod schema
+// ---------------------------------------------------------------------------
+
+const checkoutSchema = z.object({
+  orderType: z.enum(['Pickup', 'EatIn', 'Delivery']),
+  customerName: z.string().trim().optional(),
+});
+
+type CheckoutFormValues = z.infer<typeof checkoutSchema>;
+
+// ---------------------------------------------------------------------------
+// Checkout form inner component (needs CartProvider to be above)
+// ---------------------------------------------------------------------------
+
+interface CheckoutFormProps {
+  brandSlug: string;
+  shopId: string;
+}
+
+function CheckoutForm({ brandSlug, shopId }: CheckoutFormProps) {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const { brandSlug: paramSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
+  const { user } = useAuth();
+  const { state, clearCart } = useCart();
+  const createOrder = useCreateOrder(brandSlug, shopId);
+
+  // Redirect to menu if cart is empty
+  useEffect(() => {
+    if (state.items.length === 0) {
+      void navigate(`/${paramSlug}/${lang}/shops/${shopId}/menu`, { replace: true });
+    }
+  }, [state.items.length, navigate, paramSlug, lang, shopId]);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    control,
+    formState: { errors, isSubmitting },
+  } = useForm<CheckoutFormValues>({
+    resolver: zodResolver(checkoutSchema),
+    defaultValues: {
+      customerName: user?.displayName ?? '',
+    },
+  });
+
+  const orderType = watch('orderType');
+
+  const vatNotice =
+    orderType === 'EatIn'
+      ? t('storefront.checkout.vatEatIn')
+      : orderType
+        ? t('storefront.checkout.vatTakeaway')
+        : null;
+
+  const paymentNotice =
+    orderType === 'EatIn'
+      ? t('storefront.checkout.paymentAtCounter')
+      : orderType === 'Pickup'
+        ? t('storefront.checkout.paymentAtPickup')
+        : orderType === 'Delivery'
+          ? t('storefront.checkout.paymentOnline')
+          : null;
+
+  function formatCurrency(amount: number): string {
+    return new Intl.NumberFormat('nl-BE', { style: 'currency', currency: 'EUR' }).format(amount);
+  }
+
+  const cartSubtotal = state.items.reduce((sum, item) => {
+    const modTotal = item.selectedModifiers.reduce((s, m) => s + m.priceAdjustment, 0);
+    return sum + item.quantity * (item.unitGrossPrice + modTotal);
+  }, 0);
+
+  async function onSubmit(values: CheckoutFormValues) {
+    const orderItems = state.items.map((item) => ({
+      productId: item.productId,
+      quantity: item.quantity,
+      selectedModifierIds: item.selectedModifiers.map((m) => m.modifierId),
+    }));
+
+    const result = await createOrder.mutateAsync({
+      orderType: values.orderType as OrderType,
+      customerName: values.customerName ?? null,
+      items: orderItems,
+    });
+
+    // Save the shopId mapping so OrderConfirmationPage can reconstruct the API route
+    sessionStorage.setItem(`order-shop:${brandSlug}:${result.id}`, result.shopId);
+    clearCart();
+    void navigate(`/${paramSlug}/${lang}/order/${result.id}`);
+  }
+
+  if (state.items.length === 0) {
+    return null; // Redirecting
+  }
+
+  return (
+    <main style={{ maxWidth: '36rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      <h1 style={{ fontSize: '1.75rem', fontWeight: 800, color: '#111827', marginBottom: '1.5rem' }}>
+        {t('storefront.checkout.title')}
+      </h1>
+
+      <form onSubmit={(e) => { void handleSubmit(onSubmit)(e); }} noValidate>
+        {/* Order type selection */}
+        <fieldset
+          style={{
+            border: 'none',
+            padding: 0,
+            margin: '0 0 1.5rem',
+          }}
+        >
+          <legend
+            style={{
+              fontSize: '1rem',
+              fontWeight: 700,
+              color: '#111827',
+              marginBottom: '0.75rem',
+            }}
+          >
+            {t('storefront.checkout.orderTypeLabel')}
+            <span style={{ color: '#ef4444', marginLeft: '0.25rem' }}>*</span>
+          </legend>
+
+          {errors.orderType && (
+            <p style={{ color: '#ef4444', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
+              {errors.orderType.message}
+            </p>
+          )}
+
+          <Controller
+            name="orderType"
+            control={control}
+            render={({ field }) => (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                {(['Pickup', 'EatIn', 'Delivery'] as const).map((type) => (
+                  <label
+                    key={type}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.75rem',
+                      padding: '0.875rem 1rem',
+                      borderRadius: '0.5rem',
+                      border: `2px solid ${field.value === type ? 'var(--brand-color-primary, #111827)' : '#e5e7eb'}`,
+                      background: field.value === type ? '#f9fafb' : '#fff',
+                      cursor: 'pointer',
+                      fontSize: '0.9375rem',
+                      fontWeight: field.value === type ? 600 : 400,
+                      color: '#111827',
+                    }}
+                  >
+                    <input
+                      type="radio"
+                      value={type}
+                      checked={field.value === type}
+                      onChange={() => field.onChange(type)}
+                      style={{ width: '1.125rem', height: '1.125rem', cursor: 'pointer' }}
+                    />
+                    {t(`storefront.checkout.orderType.${type}`)}
+                  </label>
+                ))}
+              </div>
+            )}
+          />
+        </fieldset>
+
+        {/* VAT notice */}
+        {vatNotice && (
+          <div
+            style={{
+              padding: '0.75rem 1rem',
+              borderRadius: '0.375rem',
+              background: '#eff6ff',
+              border: '1px solid #bfdbfe',
+              color: '#1e40af',
+              fontSize: '0.875rem',
+              marginBottom: '1.5rem',
+            }}
+          >
+            {vatNotice}
+          </div>
+        )}
+
+        {/* Customer name */}
+        <div style={{ marginBottom: '1.5rem' }}>
+          <label
+            htmlFor="customerName"
+            style={{
+              display: 'block',
+              fontSize: '0.9375rem',
+              fontWeight: 600,
+              color: '#374151',
+              marginBottom: '0.375rem',
+            }}
+          >
+            {t('storefront.checkout.customerNameLabel')}
+            <span style={{ fontWeight: 400, color: '#6b7280', marginLeft: '0.25rem' }}>
+              ({t('storefront.checkout.optional')})
+            </span>
+          </label>
+          <input
+            id="customerName"
+            type="text"
+            {...register('customerName')}
+            placeholder={t('storefront.checkout.customerNamePlaceholder')}
+            style={{
+              width: '100%',
+              padding: '0.625rem 0.875rem',
+              borderRadius: '0.375rem',
+              border: '1px solid #d1d5db',
+              fontSize: '0.9375rem',
+              color: '#111827',
+              boxSizing: 'border-box',
+            }}
+          />
+        </div>
+
+        {/* Cart summary */}
+        <div
+          style={{
+            border: '1px solid #e5e7eb',
+            borderRadius: '0.5rem',
+            overflow: 'hidden',
+            marginBottom: '1.5rem',
+          }}
+        >
+          <div
+            style={{
+              padding: '0.75rem 1rem',
+              background: '#f9fafb',
+              borderBottom: '1px solid #e5e7eb',
+              fontWeight: 700,
+              fontSize: '0.9375rem',
+              color: '#111827',
+            }}
+          >
+            {t('storefront.checkout.orderSummary')}
+          </div>
+          <div style={{ padding: '0.75rem 1rem' }}>
+            {state.items.map((item) => {
+              const modTotal = item.selectedModifiers.reduce((s, m) => s + m.priceAdjustment, 0);
+              const lineTotal = item.quantity * (item.unitGrossPrice + modTotal);
+              const key = `${item.productId}-${item.selectedModifiers.map((m) => m.modifierId).join(',')}`;
+              return (
+                <div
+                  key={key}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: '1rem',
+                    padding: '0.375rem 0',
+                    fontSize: '0.9375rem',
+                    color: '#374151',
+                  }}
+                >
+                  <span>
+                    {item.quantity}&times; {item.productName}
+                    {item.selectedModifiers.length > 0 && (
+                      <span style={{ fontSize: '0.8125rem', color: '#6b7280', display: 'block' }}>
+                        {item.selectedModifiers.map((m) => m.modifierName).join(', ')}
+                      </span>
+                    )}
+                  </span>
+                  <span style={{ whiteSpace: 'nowrap', fontWeight: 600 }}>
+                    {formatCurrency(lineTotal)}
+                  </span>
+                </div>
+              );
+            })}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginTop: '0.75rem',
+                paddingTop: '0.75rem',
+                borderTop: '1px solid #e5e7eb',
+                fontWeight: 700,
+                fontSize: '1rem',
+              }}
+            >
+              <span>{t('storefront.checkout.subtotal')}</span>
+              <span>{formatCurrency(cartSubtotal)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Payment placeholder */}
+        {paymentNotice && (
+          <div
+            style={{
+              padding: '0.875rem 1rem',
+              borderRadius: '0.375rem',
+              background: '#f0fdf4',
+              border: '1px solid #bbf7d0',
+              color: '#166534',
+              fontSize: '0.875rem',
+              fontWeight: 600,
+              marginBottom: '1.5rem',
+            }}
+          >
+            {paymentNotice}
+          </div>
+        )}
+
+        {/* Error */}
+        {createOrder.isError && (
+          <div
+            style={{
+              padding: '0.75rem 1rem',
+              borderRadius: '0.375rem',
+              background: '#fef2f2',
+              border: '1px solid #fecaca',
+              color: '#991b1b',
+              fontSize: '0.875rem',
+              marginBottom: '1rem',
+            }}
+          >
+            {t('storefront.checkout.submitError')}
+          </div>
+        )}
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={isSubmitting || createOrder.isPending}
+          style={{
+            width: '100%',
+            padding: '0.875rem',
+            borderRadius: '0.5rem',
+            border: 'none',
+            background: 'var(--brand-color-primary, #111827)',
+            color: '#fff',
+            fontWeight: 700,
+            fontSize: '1rem',
+            cursor: isSubmitting || createOrder.isPending ? 'not-allowed' : 'pointer',
+            opacity: isSubmitting || createOrder.isPending ? 0.7 : 1,
+          }}
+        >
+          {isSubmitting || createOrder.isPending
+            ? t('storefront.checkout.placing')
+            : t('storefront.checkout.placeOrder')}
+        </button>
+      </form>
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CheckoutPage — wraps form in CartProvider
+// ---------------------------------------------------------------------------
+
+export function CheckoutPage() {
+  const { brandSlug } = useParams<{ brandSlug: string }>();
+  const resolvedBrandSlug = brandSlug ?? '';
+
+  return <CheckoutPageInner brandSlug={resolvedBrandSlug} />;
+}
+
+/**
+ * Inner component that creates a CartProvider by reading the shopId from localStorage
+ * directly (before CartContext is available). This avoids a chicken-and-egg problem.
+ */
+function CheckoutPageInner({ brandSlug }: { brandSlug: string }) {
+  const { t } = useTranslation('common');
+
+  // Find the first cart key in localStorage for this brand
+  const shopId = findActiveShopId(brandSlug);
+
+  if (!shopId) {
+    return (
+      <main style={{ maxWidth: '36rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <h1 style={{ fontSize: '1.75rem', fontWeight: 800, color: '#111827', marginBottom: '1rem' }}>
+          {t('storefront.checkout.title')}
+        </h1>
+        <p style={{ color: '#6b7280' }}>{t('storefront.checkout.cartEmpty')}</p>
+      </main>
+    );
+  }
+
+  return (
+    <CartProvider brandSlug={brandSlug} shopId={shopId}>
+      <CheckoutForm brandSlug={brandSlug} shopId={shopId} />
+    </CartProvider>
+  );
+}
+
+/**
+ * Scans localStorage for a cart belonging to the given brandSlug.
+ * Returns the first shopId found, or null if no cart exists.
+ */
+function findActiveShopId(brandSlug: string): string | null {
+  const prefix = `cart:${brandSlug}:`;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(prefix)) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (!raw) continue;
+        const parsed = JSON.parse(raw) as { shopId?: string; items?: unknown[] };
+        if (parsed.shopId && Array.isArray(parsed.items) && parsed.items.length > 0) {
+          return parsed.shopId;
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}

--- a/src/frontend/src/features/storefront/pages/MenuPage.tsx
+++ b/src/frontend/src/features/storefront/pages/MenuPage.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import type { ProductListItem } from '@/types/common';
+import { CartProvider, useCart, type CartModifier } from '../context/CartContext';
+import { ProductCard } from '../components/ProductCard';
+import { ModifierModal } from '../components/ModifierModal';
+import { CartDrawer } from '../components/CartDrawer';
+import { useStorefrontCategories, useStorefrontCategoryProducts } from '../hooks/useStorefrontMenu';
+import { modifierGroupsApi } from '@api/modifierGroups';
+
+// ---------------------------------------------------------------------------
+// Category section — fetches its own products
+// ---------------------------------------------------------------------------
+
+interface CategorySectionProps {
+  brandSlug: string;
+  categoryId: string;
+  categoryName: string;
+  onAddProduct: (product: ProductListItem) => void;
+}
+
+function CategorySection({
+  brandSlug,
+  categoryId,
+  categoryName,
+  onAddProduct,
+}: CategorySectionProps) {
+  const { t } = useTranslation('common');
+  const { data: products, isLoading, isError } = useStorefrontCategoryProducts(brandSlug, categoryId);
+
+  if (isLoading) {
+    return (
+      <section style={{ marginBottom: '2rem' }}>
+        <h2 style={{ fontSize: '1.25rem', fontWeight: 700, color: '#111827', marginBottom: '0.75rem' }}>
+          {categoryName}
+        </h2>
+        <p style={{ color: '#6b7280' }}>{t('loading')}</p>
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section style={{ marginBottom: '2rem' }}>
+        <h2 style={{ fontSize: '1.25rem', fontWeight: 700, color: '#111827', marginBottom: '0.75rem' }}>
+          {categoryName}
+        </h2>
+        <p style={{ color: '#ef4444', fontSize: '0.875rem' }}>{t('error')}</p>
+      </section>
+    );
+  }
+
+  if (!products || products.length === 0) return null;
+
+  return (
+    <section style={{ marginBottom: '2.5rem' }}>
+      <h2
+        style={{
+          fontSize: '1.25rem',
+          fontWeight: 700,
+          color: '#111827',
+          marginBottom: '0.75rem',
+          paddingBottom: '0.5rem',
+          borderBottom: '2px solid var(--brand-color-primary, #111827)',
+        }}
+      >
+        {categoryName}
+      </h2>
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} onAdd={onAddProduct} />
+      ))}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Menu content (inner — needs cart context and brandSlug)
+// ---------------------------------------------------------------------------
+
+interface MenuContentProps {
+  brandSlug: string;
+}
+
+function MenuContent({ brandSlug }: MenuContentProps) {
+  const { t } = useTranslation('common');
+  const { addItem, cartItemCount } = useCart();
+
+  const [cartOpen, setCartOpen] = useState(false);
+  const [modifierProduct, setModifierProduct] = useState<ProductListItem | null>(null);
+
+  const { data: categories, isLoading, isError } = useStorefrontCategories(brandSlug);
+
+  // Pre-fetch modifier groups for all visible products' modifier count check
+  // (We check whether a product has modifier groups by fetching once the user clicks Add)
+
+  async function checkProductHasModifiers(product: ProductListItem): Promise<boolean> {
+    try {
+      const groups = await modifierGroupsApi.getProductModifierGroups(brandSlug, product.id);
+      return groups.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async function handleAddProduct(product: ProductListItem) {
+    const hasModifiers = await checkProductHasModifiers(product);
+    if (hasModifiers) {
+      setModifierProduct(product);
+    } else {
+      addItem({
+        productId: product.id,
+        productName: product.name,
+        quantity: 1,
+        unitGrossPrice: product.basePrice.amount,
+        selectedModifiers: [],
+      });
+    }
+  }
+
+  function handleModifierConfirm(selectedModifiers: CartModifier[]) {
+    if (!modifierProduct) return;
+    addItem({
+      productId: modifierProduct.id,
+      productName: modifierProduct.name,
+      quantity: 1,
+      unitGrossPrice: modifierProduct.basePrice.amount,
+      selectedModifiers,
+    });
+    setModifierProduct(null);
+  }
+
+  return (
+    <main style={{ maxWidth: '48rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      {/* Sticky cart button */}
+      <div
+        style={{
+          position: 'sticky',
+          top: '1rem',
+          zIndex: 50,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setCartOpen(true)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            padding: '0.625rem 1.25rem',
+            borderRadius: '9999px',
+            border: 'none',
+            background: 'var(--brand-color-primary, #111827)',
+            color: '#fff',
+            fontWeight: 700,
+            fontSize: '0.9375rem',
+            cursor: 'pointer',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+          }}
+        >
+          <span>{t('storefront.cart.title')}</span>
+          {cartItemCount > 0 && (
+            <span
+              style={{
+                background: 'var(--brand-color-accent, #2563eb)',
+                color: '#fff',
+                borderRadius: '9999px',
+                fontSize: '0.75rem',
+                fontWeight: 700,
+                padding: '0.125rem 0.5rem',
+              }}
+            >
+              {cartItemCount}
+            </span>
+          )}
+        </button>
+      </div>
+
+      <h1 style={{ fontSize: '1.75rem', fontWeight: 800, color: '#111827', marginBottom: '1.5rem' }}>
+        {t('storefront.menu.title')}
+      </h1>
+
+      {isLoading && <p style={{ color: '#6b7280' }}>{t('loading')}</p>}
+      {isError && <p style={{ color: '#ef4444' }}>{t('error')}</p>}
+
+      {categories && categories.length === 0 && (
+        <p style={{ color: '#6b7280' }}>{t('storefront.menu.noCategories')}</p>
+      )}
+
+      {categories?.map((category) => (
+        <CategorySection
+          key={category.id}
+          brandSlug={brandSlug}
+          categoryId={category.id}
+          categoryName={category.name}
+          onAddProduct={(product) => { void handleAddProduct(product); }}
+        />
+      ))}
+
+      {/* Modifier modal */}
+      {modifierProduct && (
+        <ModifierModal
+          brandSlug={brandSlug}
+          product={modifierProduct}
+          onConfirm={handleModifierConfirm}
+          onClose={() => setModifierProduct(null)}
+        />
+      )}
+
+      {/* Cart drawer */}
+      <CartDrawer isOpen={cartOpen} onClose={() => setCartOpen(false)} />
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MenuPage — wraps content in CartProvider
+// ---------------------------------------------------------------------------
+
+export function MenuPage() {
+  const { brandSlug, shopId } = useParams<{ brandSlug: string; shopId: string }>();
+
+  if (!brandSlug || !shopId) {
+    return <p>Invalid route: brandSlug and shopId are required.</p>;
+  }
+
+  return (
+    <CartProvider brandSlug={brandSlug} shopId={shopId}>
+      <MenuContent brandSlug={brandSlug} />
+    </CartProvider>
+  );
+}

--- a/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
@@ -1,0 +1,339 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { ordersApi } from '@api/orders';
+import type { OrderResponse } from '@api/orders';
+import { useOrderUpdates } from '@api/useOrderUpdates';
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+function useOrderDetails(brandSlug: string, shopId: string, orderId: string) {
+  return useQuery<OrderResponse>({
+    queryKey: ['order', brandSlug, shopId, orderId],
+    queryFn: () => ordersApi.getById(brandSlug, shopId, orderId),
+    enabled: brandSlug.length > 0 && shopId.length > 0 && orderId.length > 0,
+    staleTime: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Order confirmation page
+// ---------------------------------------------------------------------------
+
+export function OrderConfirmationPage() {
+  const { t } = useTranslation('common');
+  const { brandSlug, lang, orderId } = useParams<{
+    brandSlug: string;
+    lang: string;
+    orderId: string;
+  }>();
+
+  const resolvedBrandSlug = brandSlug ?? '';
+  const resolvedOrderId = orderId ?? '';
+
+  // We need shopId for the API call — attempt to recover it from orderId query if possible.
+  // Since the backend returns the order at GET /brands/{brandSlug}/shops/{shopId}/orders/{orderId}
+  // and we don't have shopId in this route, we use the ordersApi.getByOrderId approach which
+  // is scoped differently. For now, we store shopId in localStorage after checkout or use
+  // a separate route. Per the contract, we'll use a simpler approach: retrieve from
+  // the session storage key we save at checkout.
+  const shopId = recoverShopId(resolvedBrandSlug, resolvedOrderId);
+
+  const { data: order, isLoading, isError } = useOrderDetails(
+    resolvedBrandSlug,
+    shopId ?? '',
+    resolvedOrderId,
+  );
+
+  // Live status tracking via SignalR
+  const [liveStatus, setLiveStatus] = useState<string | null>(null);
+
+  const { status: signalRStatus } = useOrderUpdates({
+    orderId: resolvedOrderId,
+    onStatusChange: (update) => {
+      setLiveStatus(update.newStatus);
+    },
+  });
+
+  const displayStatus = liveStatus ?? order?.statusName;
+
+  function formatCurrency(amount: number): string {
+    return new Intl.NumberFormat('nl-BE', { style: 'currency', currency: 'EUR' }).format(amount);
+  }
+
+  if (isLoading) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#6b7280' }}>{t('loading')}</p>
+      </main>
+    );
+  }
+
+  if (isError || !order) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#ef4444' }}>{t('error')}</p>
+        <Link
+          to={`/${resolvedBrandSlug}/${lang}`}
+          style={{ color: 'var(--brand-color-primary, #111827)', fontWeight: 600 }}
+        >
+          {t('storefront.order.backToHome')}
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      {/* Thank you header */}
+      <div
+        style={{
+          textAlign: 'center',
+          padding: '2rem 1rem',
+          marginBottom: '2rem',
+          background: '#f0fdf4',
+          borderRadius: '0.75rem',
+          border: '1px solid #bbf7d0',
+        }}
+      >
+        <p style={{ fontSize: '2rem', margin: '0 0 0.5rem' }}>&#10003;</p>
+        <h1
+          style={{ fontSize: '1.5rem', fontWeight: 800, color: '#166534', margin: '0 0 0.5rem' }}
+        >
+          {t('storefront.order.confirmed')}
+        </h1>
+        <p style={{ color: '#166534', margin: 0, fontSize: '0.9375rem' }}>
+          {t('storefront.order.preparing')}
+        </p>
+      </div>
+
+      {/* Order meta */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: '0.75rem',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <InfoCard label={t('storefront.order.orderNumber')} value={`#${order.orderNumber}`} />
+        <InfoCard label={t('storefront.order.orderType')} value={order.orderType} />
+        {order.customerName && (
+          <InfoCard label={t('storefront.order.customerName')} value={order.customerName} />
+        )}
+        <InfoCard
+          label={t('storefront.order.status')}
+          value={displayStatus ?? ''}
+          highlight
+          signalRStatus={signalRStatus}
+        />
+      </div>
+
+      {/* Items */}
+      <div
+        style={{
+          border: '1px solid #e5e7eb',
+          borderRadius: '0.5rem',
+          overflow: 'hidden',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <div
+          style={{
+            padding: '0.75rem 1rem',
+            background: '#f9fafb',
+            borderBottom: '1px solid #e5e7eb',
+            fontWeight: 700,
+            fontSize: '0.9375rem',
+            color: '#111827',
+          }}
+        >
+          {t('storefront.order.items')}
+        </div>
+        <div style={{ padding: '0.75rem 1rem' }}>
+          {order.items.map((item, idx) => (
+            <div
+              key={`${item.productId}-${idx}`}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: '1rem',
+                padding: '0.5rem 0',
+                borderBottom: idx < order.items.length - 1 ? '1px solid #f3f4f6' : 'none',
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <p style={{ margin: 0, fontSize: '0.9375rem', color: '#111827', fontWeight: 600 }}>
+                  {item.quantity}&times; {item.productName}
+                </p>
+                {item.selectedModifiers.length > 0 && (
+                  <p style={{ margin: '0.25rem 0 0', fontSize: '0.8125rem', color: '#6b7280' }}>
+                    {item.selectedModifiers.map((m) => m.modifierName).join(', ')}
+                  </p>
+                )}
+                <p style={{ margin: '0.125rem 0 0', fontSize: '0.8125rem', color: '#6b7280' }}>
+                  {formatCurrency(item.unitGrossPrice)} {t('storefront.order.each')}
+                </p>
+              </div>
+              <span
+                style={{
+                  fontWeight: 700,
+                  fontSize: '0.9375rem',
+                  color: '#111827',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {formatCurrency(item.lineTotal)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Totals */}
+      <div
+        style={{
+          border: '1px solid #e5e7eb',
+          borderRadius: '0.5rem',
+          padding: '1rem',
+          marginBottom: '2rem',
+        }}
+      >
+        <TotalRow label={t('storefront.order.subtotal')} value={formatCurrency(order.subtotalGross)} />
+        <TotalRow
+          label={t('storefront.order.vat', { rate: order.vatRatePercent })}
+          value={formatCurrency(order.totalVatAmount)}
+        />
+        <TotalRow
+          label={t('storefront.order.total')}
+          value={formatCurrency(order.totalGross)}
+          bold
+        />
+      </div>
+
+      {/* Back to home */}
+      <div style={{ textAlign: 'center' }}>
+        <Link
+          to={`/${resolvedBrandSlug}/${lang}`}
+          style={{
+            color: 'var(--brand-color-primary, #111827)',
+            fontWeight: 700,
+            fontSize: '0.9375rem',
+          }}
+        >
+          {t('storefront.order.backToHome')}
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small reusable sub-components
+// ---------------------------------------------------------------------------
+
+interface InfoCardProps {
+  label: string;
+  value: string;
+  highlight?: boolean;
+  signalRStatus?: string;
+}
+
+function InfoCard({ label, value, highlight, signalRStatus }: InfoCardProps) {
+  return (
+    <div
+      style={{
+        padding: '0.875rem 1rem',
+        borderRadius: '0.5rem',
+        border: `1px solid ${highlight ? 'var(--brand-color-primary, #111827)' : '#e5e7eb'}`,
+        background: highlight ? '#f9fafb' : '#fff',
+      }}
+    >
+      <p
+        style={{
+          margin: '0 0 0.25rem',
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          color: '#6b7280',
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+        }}
+      >
+        {label}
+        {highlight && signalRStatus === 'connected' && (
+          <span
+            style={{
+              display: 'inline-block',
+              width: '0.5rem',
+              height: '0.5rem',
+              borderRadius: '50%',
+              background: '#22c55e',
+              marginLeft: '0.375rem',
+              verticalAlign: 'middle',
+            }}
+            title="Live updates active"
+          />
+        )}
+      </p>
+      <p style={{ margin: 0, fontSize: '1rem', fontWeight: 700, color: '#111827' }}>{value}</p>
+    </div>
+  );
+}
+
+interface TotalRowProps {
+  label: string;
+  value: string;
+  bold?: boolean;
+}
+
+function TotalRow({ label, value, bold }: TotalRowProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '0.375rem 0',
+        borderTop: bold ? '1px solid #e5e7eb' : 'none',
+        marginTop: bold ? '0.5rem' : 0,
+        paddingTop: bold ? '0.625rem' : '0.375rem',
+        fontSize: bold ? '1rem' : '0.9375rem',
+        fontWeight: bold ? 700 : 400,
+        color: '#111827',
+      }}
+    >
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — recover shopId from localStorage after checkout
+// ---------------------------------------------------------------------------
+
+/**
+ * After a successful order, the cart is cleared but we may still have the shopId
+ * saved under a separate key in sessionStorage that CheckoutPage wrote before clearing.
+ * Falls back to scanning localStorage cart keys for this brand.
+ */
+function recoverShopId(brandSlug: string, orderId: string): string | null {
+  // Try sessionStorage key first
+  const sessionKey = `order-shop:${brandSlug}:${orderId}`;
+  const fromSession = sessionStorage.getItem(sessionKey);
+  if (fromSession) return fromSession;
+
+  // Fall back to scanning any remaining cart entries for this brand
+  const prefix = `cart:${brandSlug}:`;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(prefix)) {
+      const shopId = key.slice(prefix.length);
+      if (shopId) return shopId;
+    }
+  }
+
+  return null;
+}

--- a/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
@@ -108,6 +108,23 @@ export function OrderConfirmationPage() {
         <p style={{ color: '#166534', margin: 0, fontSize: '0.9375rem' }}>
           {t('storefront.order.preparing')}
         </p>
+        <div style={{ marginTop: '1rem' }}>
+          <Link
+            to="./track"
+            style={{
+              display: 'inline-block',
+              padding: '0.5rem 1.25rem',
+              background: 'var(--brand-color-primary, #111827)',
+              color: '#fff',
+              borderRadius: '0.5rem',
+              fontWeight: 700,
+              fontSize: '0.9375rem',
+              textDecoration: 'none',
+            }}
+          >
+            {t('storefront.tracking.title')}
+          </Link>
+        </div>
       </div>
 
       {/* Order meta */}

--- a/src/frontend/src/features/storefront/pages/OrderTrackingPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderTrackingPage.tsx
@@ -1,0 +1,276 @@
+// Order tracking page — shows the shop's configured lifecycle as a visual
+// stepper and subscribes to real-time status updates via SignalR.
+// Accessible to guests (no RequireAuth) via /:brandSlug/:lang/order/:orderId/track.
+
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { ordersApi } from '@api/orders';
+import type { OrderTrackingResponse } from '@api/orders';
+import { useOrderUpdates } from '@api/useOrderUpdates';
+import { OrderStatusStepper } from '../components/OrderStatusStepper';
+
+// ---------------------------------------------------------------------------
+// Query hook
+// ---------------------------------------------------------------------------
+
+function useOrderTracking(brandSlug: string, shopId: string, orderId: string) {
+  return useQuery<OrderTrackingResponse>({
+    queryKey: ['order-tracking', brandSlug, shopId, orderId],
+    queryFn: () => ordersApi.getTracking(brandSlug, shopId, orderId),
+    enabled: brandSlug.length > 0 && shopId.length > 0 && orderId.length > 0,
+    staleTime: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// OrderTrackingPage
+// ---------------------------------------------------------------------------
+
+export function OrderTrackingPage() {
+  const { t } = useTranslation('common');
+  const { brandSlug, lang, orderId } = useParams<{
+    brandSlug: string;
+    lang: string;
+    orderId: string;
+  }>();
+
+  const resolvedBrandSlug = brandSlug ?? '';
+  const resolvedOrderId = orderId ?? '';
+
+  // Recover shopId from sessionStorage — written by CheckoutPage after order placement.
+  const shopId = recoverShopId(resolvedBrandSlug, resolvedOrderId) ?? '';
+
+  const { data, isLoading, isError } = useOrderTracking(
+    resolvedBrandSlug,
+    shopId,
+    resolvedOrderId,
+  );
+
+  // Seed live status from the initial fetch; updated by SignalR events.
+  const [currentStatusName, setCurrentStatusName] = useState<string | null>(null);
+
+  const { status: signalRStatus } = useOrderUpdates({
+    orderId: resolvedOrderId,
+    onStatusChange: (update) => {
+      setCurrentStatusName(update.newStatus);
+    },
+  });
+
+  const displayStatus = currentStatusName ?? data?.order.statusName ?? '';
+  const isConnected = signalRStatus === 'connected';
+
+  // ---------------------------------------------------------------------------
+  // Loading state
+  // ---------------------------------------------------------------------------
+
+  if (isLoading) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#6b7280' }}>{t('loading')}</p>
+      </main>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error state
+  // ---------------------------------------------------------------------------
+
+  if (isError || !data) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#ef4444' }}>{t('error')}</p>
+        <Link
+          to={`/${resolvedBrandSlug}/${lang}`}
+          style={{ color: 'var(--brand-color-primary, #111827)', fontWeight: 600 }}
+        >
+          {t('storefront.order.backToHome')}
+        </Link>
+      </main>
+    );
+  }
+
+  const { order, lifecycle } = data;
+
+  // Sort lifecycle statuses by sortOrder for the stepper.
+  const sortedStatuses = [...lifecycle.statuses].sort((a, b) => a.sortOrder - b.sortOrder);
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      {/* Page header */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <Link
+          to=".."
+          relative="path"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+            color: 'var(--brand-color-primary, #111827)',
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            textDecoration: 'none',
+            marginBottom: '1rem',
+          }}
+        >
+          &#8592; {t('storefront.tracking.backToConfirmation')}
+        </Link>
+
+        <h1
+          style={{
+            fontSize: '1.5rem',
+            fontWeight: 800,
+            color: '#111827',
+            margin: '0 0 0.25rem',
+          }}
+        >
+          {t('storefront.tracking.title')}
+        </h1>
+
+        <p style={{ margin: 0, fontSize: '0.9375rem', color: '#6b7280' }}>
+          {t('storefront.tracking.orderNumber')}
+          {order.orderNumber}
+        </p>
+      </div>
+
+      {/* SignalR connection indicator + current status */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0.75rem 1rem',
+          background: '#f9fafb',
+          borderRadius: '0.5rem',
+          border: '1px solid #e5e7eb',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <span style={{ fontSize: '0.9375rem', fontWeight: 700, color: '#111827' }}>
+          {displayStatus}
+        </span>
+
+        <span
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.375rem',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            color: isConnected ? '#16a34a' : '#6b7280',
+          }}
+        >
+          {/* Live indicator dot */}
+          <span
+            style={{
+              display: 'inline-block',
+              width: '0.5rem',
+              height: '0.5rem',
+              borderRadius: '50%',
+              background: isConnected ? '#22c55e' : '#9ca3af',
+            }}
+            aria-hidden="true"
+          />
+          {isConnected
+            ? t('storefront.tracking.statusLive')
+            : t('storefront.tracking.connecting')}
+        </span>
+      </div>
+
+      {/* Order lifecycle stepper */}
+      <div
+        style={{
+          border: '1px solid #e5e7eb',
+          borderRadius: '0.75rem',
+          padding: '1.25rem 1rem 0.5rem',
+          marginBottom: '1.5rem',
+          overflowX: 'hidden',
+        }}
+      >
+        <OrderStatusStepper statuses={sortedStatuses} currentStatusName={displayStatus} />
+      </div>
+
+      {/* Order meta */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: '0.75rem',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <MetaCard label={t('storefront.order.orderType')} value={order.orderType} />
+        {order.customerName && (
+          <MetaCard label={t('storefront.order.customerName')} value={order.customerName} />
+        )}
+      </div>
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small reusable sub-component
+// ---------------------------------------------------------------------------
+
+interface MetaCardProps {
+  label: string;
+  value: string;
+}
+
+function MetaCard({ label, value }: MetaCardProps) {
+  return (
+    <div
+      style={{
+        padding: '0.875rem 1rem',
+        borderRadius: '0.5rem',
+        border: '1px solid #e5e7eb',
+        background: '#fff',
+      }}
+    >
+      <p
+        style={{
+          margin: '0 0 0.25rem',
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          color: '#6b7280',
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+        }}
+      >
+        {label}
+      </p>
+      <p style={{ margin: 0, fontSize: '1rem', fontWeight: 700, color: '#111827' }}>{value}</p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — recover shopId from sessionStorage after checkout
+// ---------------------------------------------------------------------------
+
+/**
+ * The CheckoutPage writes `sessionStorage.setItem(\`order-shop:\${brandSlug}:\${orderId}\`, shopId)`
+ * immediately after a successful order submission. We read that key here.
+ */
+function recoverShopId(brandSlug: string, orderId: string): string | null {
+  const sessionKey = `order-shop:${brandSlug}:${orderId}`;
+  const fromSession = sessionStorage.getItem(sessionKey);
+  if (fromSession) return fromSession;
+
+  // Fall back to scanning any remaining cart entries for this brand.
+  const prefix = `cart:${brandSlug}:`;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(prefix)) {
+      const shopId = key.slice(prefix.length);
+      if (shopId) return shopId;
+    }
+  }
+
+  return null;
+}

--- a/src/frontend/src/features/storefront/routes.tsx
+++ b/src/frontend/src/features/storefront/routes.tsx
@@ -18,6 +18,10 @@ const LazyOrderConfirmationPage = lazy(() =>
   import('./pages/OrderConfirmationPage').then((m) => ({ default: m.OrderConfirmationPage })),
 );
 
+const LazyOrderTrackingPage = lazy(() =>
+  import('./pages/OrderTrackingPage').then((m) => ({ default: m.OrderTrackingPage })),
+);
+
 /**
  * Route configuration for the customer-facing storefront.
  * These routes are nested under /:brandSlug/:lang in the main router,
@@ -54,6 +58,15 @@ export const storefrontRoutes: RouteObject[] = [
     element: (
       <SuspenseWrapper>
         <LazyOrderConfirmationPage />
+      </SuspenseWrapper>
+    ),
+  },
+  {
+    // Order tracking page: visual lifecycle stepper with real-time SignalR updates (US-FP-063)
+    path: 'order/:orderId/track',
+    element: (
+      <SuspenseWrapper>
+        <LazyOrderTrackingPage />
       </SuspenseWrapper>
     ),
   },

--- a/src/frontend/src/features/storefront/routes.tsx
+++ b/src/frontend/src/features/storefront/routes.tsx
@@ -1,13 +1,27 @@
-// fallow-ignore-file unused-file
-//
 // Storefront route module. Wired up by US-FP-016 + US-FP-017 (online + guest ordering).
 
+import { lazy } from 'react';
 import type { RouteObject } from 'react-router-dom';
+import { SuspenseWrapper } from '@components/SuspenseWrapper';
 import { Home } from './pages/Home';
+
+// Lazy-load heavy storefront pages for code-splitting
+const LazyMenuPage = lazy(() =>
+  import('./pages/MenuPage').then((m) => ({ default: m.MenuPage })),
+);
+
+const LazyCheckoutPage = lazy(() =>
+  import('./pages/CheckoutPage').then((m) => ({ default: m.CheckoutPage })),
+);
+
+const LazyOrderConfirmationPage = lazy(() =>
+  import('./pages/OrderConfirmationPage').then((m) => ({ default: m.OrderConfirmationPage })),
+);
 
 /**
  * Route configuration for the customer-facing storefront.
- * These routes are nested under /:brandSlug/:lang in the main router.
+ * These routes are nested under /:brandSlug/:lang in the main router,
+ * inside the ThemeProvider layout route.
  *
  * ThemeProvider is applied as a layout route in router.tsx — do NOT wrap again here.
  */
@@ -15,5 +29,32 @@ export const storefrontRoutes: RouteObject[] = [
   {
     index: true,
     element: <Home />,
+  },
+  {
+    // Menu page for a specific shop: browse categories and products, add to cart
+    path: 'shops/:shopId/menu',
+    element: (
+      <SuspenseWrapper>
+        <LazyMenuPage />
+      </SuspenseWrapper>
+    ),
+  },
+  {
+    // Checkout page: review cart, select order type, submit order
+    path: 'checkout',
+    element: (
+      <SuspenseWrapper>
+        <LazyCheckoutPage />
+      </SuspenseWrapper>
+    ),
+  },
+  {
+    // Order confirmation page: show order details and real-time status via SignalR
+    path: 'order/:orderId',
+    element: (
+      <SuspenseWrapper>
+        <LazyOrderConfirmationPage />
+      </SuspenseWrapper>
+    ),
   },
 ];

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -6,6 +6,65 @@
     "description": "Sehen Sie unsere Speisekarte und geben Sie Ihre Bestellung auf.",
     "languageSelector": {
       "ariaLabel": "Sprache wählen"
+    },
+    "menu": {
+      "title": "Menü",
+      "add": "Hinzufügen",
+      "addItem": "{{name}} in den Warenkorb legen",
+      "addToCart": "In den Warenkorb",
+      "customise": "Anpassen",
+      "cancel": "Abbrechen",
+      "closeModal": "Schließen",
+      "noCategories": "Keine Menükategorien verfügbar.",
+      "loadingModifiers": "Optionen werden geladen…",
+      "noModifiers": "Keine Anpassungen verfügbar."
+    },
+    "cart": {
+      "title": "Warenkorb",
+      "empty": "Ihr Warenkorb ist leer.",
+      "close": "Warenkorb schließen",
+      "remove": "Entfernen",
+      "subtotal": "Zwischensumme",
+      "goToCheckout": "Zur Kasse",
+      "increaseQuantity": "Menge erhöhen",
+      "decreaseQuantity": "Menge verringern"
+    },
+    "checkout": {
+      "title": "Bestellung aufgeben",
+      "orderTypeLabel": "Bestellart",
+      "orderType": {
+        "Pickup": "Abholung",
+        "EatIn": "Vor Ort",
+        "Delivery": "Lieferung"
+      },
+      "customerNameLabel": "Name",
+      "customerNamePlaceholder": "Ihr Name (optional)",
+      "optional": "optional",
+      "orderSummary": "Bestellübersicht",
+      "subtotal": "Zwischensumme",
+      "vatEatIn": "21% MwSt. anwendbar (Verzehr vor Ort).",
+      "vatTakeaway": "6% MwSt. anwendbar (Abholung / Lieferung).",
+      "paymentAtCounter": "Zahlung an der Kasse.",
+      "paymentAtPickup": "Zahlung bei Abholung.",
+      "paymentOnline": "Online-Zahlung demnächst verfügbar.",
+      "placeOrder": "Bestellung aufgeben",
+      "placing": "Wird aufgegeben…",
+      "submitError": "Bestellung fehlgeschlagen. Bitte erneut versuchen.",
+      "cartEmpty": "Ihr Warenkorb ist leer."
+    },
+    "order": {
+      "confirmed": "Bestellung bestätigt!",
+      "preparing": "Ihre Bestellung wird vorbereitet.",
+      "orderNumber": "Bestellnummer",
+      "orderType": "Bestellart",
+      "customerName": "Name",
+      "status": "Status",
+      "items": "Artikel",
+      "each": "je",
+      "subtotal": "Zwischensumme",
+      "vat": "MwSt. ({{rate}}%)",
+      "total": "Gesamt",
+      "backToHome": "Zurück zur Startseite"
     }
   },
   "pos": {

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -65,6 +65,13 @@
       "vat": "MwSt. ({{rate}}%)",
       "total": "Gesamt",
       "backToHome": "Zurück zur Startseite"
+    },
+    "tracking": {
+      "title": "Verfolge deine Bestellung",
+      "orderNumber": "Bestellung #",
+      "statusLive": "Live",
+      "backToConfirmation": "Zurück zur Bestätigung",
+      "connecting": "Verbinde..."
     }
   },
   "pos": {

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -6,6 +6,65 @@
     "description": "Consultez notre menu et passez votre commande.",
     "languageSelector": {
       "ariaLabel": "Choisir la langue"
+    },
+    "menu": {
+      "title": "Menu",
+      "add": "Ajouter",
+      "addItem": "Ajouter {{name}} au panier",
+      "addToCart": "Ajouter au panier",
+      "customise": "Personnaliser",
+      "cancel": "Annuler",
+      "closeModal": "Fermer",
+      "noCategories": "Aucune catégorie de menu disponible.",
+      "loadingModifiers": "Chargement des options…",
+      "noModifiers": "Aucune personnalisation disponible."
+    },
+    "cart": {
+      "title": "Panier",
+      "empty": "Votre panier est vide.",
+      "close": "Fermer le panier",
+      "remove": "Supprimer",
+      "subtotal": "Sous-total",
+      "goToCheckout": "Passer à la caisse",
+      "increaseQuantity": "Augmenter la quantité",
+      "decreaseQuantity": "Diminuer la quantité"
+    },
+    "checkout": {
+      "title": "Passer commande",
+      "orderTypeLabel": "Type de commande",
+      "orderType": {
+        "Pickup": "À emporter",
+        "EatIn": "Sur place",
+        "Delivery": "Livraison"
+      },
+      "customerNameLabel": "Nom",
+      "customerNamePlaceholder": "Votre nom (optionnel)",
+      "optional": "optionnel",
+      "orderSummary": "Récapitulatif de commande",
+      "subtotal": "Sous-total",
+      "vatEatIn": "TVA 21% applicable (consommation sur place).",
+      "vatTakeaway": "TVA 6% applicable (emporter / livraison).",
+      "paymentAtCounter": "Paiement au comptoir.",
+      "paymentAtPickup": "Paiement au retrait.",
+      "paymentOnline": "Paiement en ligne bientôt disponible.",
+      "placeOrder": "Passer la commande",
+      "placing": "En cours…",
+      "submitError": "Échec de la commande. Veuillez réessayer.",
+      "cartEmpty": "Votre panier est vide."
+    },
+    "order": {
+      "confirmed": "Commande confirmée !",
+      "preparing": "Votre commande est en cours de préparation.",
+      "orderNumber": "Numéro de commande",
+      "orderType": "Type de commande",
+      "customerName": "Nom",
+      "status": "Statut",
+      "items": "Articles",
+      "each": "chacun",
+      "subtotal": "Sous-total",
+      "vat": "TVA ({{rate}}%)",
+      "total": "Total",
+      "backToHome": "Retour à l'accueil"
     }
   },
   "pos": {

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -65,6 +65,13 @@
       "vat": "TVA ({{rate}}%)",
       "total": "Total",
       "backToHome": "Retour à l'accueil"
+    },
+    "tracking": {
+      "title": "Suivez votre commande",
+      "orderNumber": "Commande #",
+      "statusLive": "Live",
+      "backToConfirmation": "Retour à la confirmation",
+      "connecting": "Connexion..."
     }
   },
   "pos": {

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -6,6 +6,65 @@
     "description": "Bekijk ons menu en plaats uw bestelling.",
     "languageSelector": {
       "ariaLabel": "Taal selecteren"
+    },
+    "menu": {
+      "title": "Menu",
+      "add": "Toevoegen",
+      "addItem": "{{name}} toevoegen aan winkelwagen",
+      "addToCart": "Toevoegen aan winkelwagen",
+      "customise": "Aanpassen",
+      "cancel": "Annuleren",
+      "closeModal": "Sluiten",
+      "noCategories": "Geen menu-categorieën beschikbaar.",
+      "loadingModifiers": "Opties laden…",
+      "noModifiers": "Geen aanpassingen beschikbaar."
+    },
+    "cart": {
+      "title": "Winkelwagen",
+      "empty": "Uw winkelwagen is leeg.",
+      "close": "Winkelwagen sluiten",
+      "remove": "Verwijderen",
+      "subtotal": "Subtotaal",
+      "goToCheckout": "Naar kassa",
+      "increaseQuantity": "Hoeveelheid verhogen",
+      "decreaseQuantity": "Hoeveelheid verlagen"
+    },
+    "checkout": {
+      "title": "Bestelling plaatsen",
+      "orderTypeLabel": "Besteltype",
+      "orderType": {
+        "Pickup": "Afhalen",
+        "EatIn": "Ter plaatse",
+        "Delivery": "Bezorging"
+      },
+      "customerNameLabel": "Naam",
+      "customerNamePlaceholder": "Uw naam (optioneel)",
+      "optional": "optioneel",
+      "orderSummary": "Besteloverzicht",
+      "subtotal": "Subtotaal",
+      "vatEatIn": "21% BTW is van toepassing (ter plaatse eten).",
+      "vatTakeaway": "6% BTW is van toepassing (afhalen / bezorging).",
+      "paymentAtCounter": "Betaling aan de balie.",
+      "paymentAtPickup": "Betaling bij afhaling.",
+      "paymentOnline": "Online betaling volgt binnenkort.",
+      "placeOrder": "Bestelling plaatsen",
+      "placing": "Bezig met plaatsen…",
+      "submitError": "Bestelling plaatsen mislukt. Probeer opnieuw.",
+      "cartEmpty": "Uw winkelwagen is leeg."
+    },
+    "order": {
+      "confirmed": "Bestelling bevestigd!",
+      "preparing": "Uw bestelling wordt bereid.",
+      "orderNumber": "Bestelnummer",
+      "orderType": "Besteltype",
+      "customerName": "Naam",
+      "status": "Status",
+      "items": "Artikelen",
+      "each": "elk",
+      "subtotal": "Subtotaal",
+      "vat": "BTW ({{rate}}%)",
+      "total": "Totaal",
+      "backToHome": "Terug naar beginpagina"
     }
   },
   "pos": {

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -65,6 +65,13 @@
       "vat": "BTW ({{rate}}%)",
       "total": "Totaal",
       "backToHome": "Terug naar beginpagina"
+    },
+    "tracking": {
+      "title": "Volg uw bestelling",
+      "orderNumber": "Bestelling #",
+      "statusLive": "Live",
+      "backToConfirmation": "Terug naar bevestiging",
+      "connecting": "Verbinden..."
     }
   },
   "pos": {

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -7,15 +7,12 @@ import { AppVariantLayout } from '@components/AppVariantLayout';
 import { SuspenseWrapper } from '@components/SuspenseWrapper';
 import { RequireAuth } from '@/auth/RequireAuth';
 import { adminRoutes } from '@features/admin/routes';
+import { storefrontRoutes } from '@features/storefront/routes';
 import { ThemeProvider } from '@features/storefront/components/ThemeProvider';
 
 // ---------------------------------------------------------------------------
 // Lazy-loaded feature pages — split into separate chunks by Vite/Rollup
 // ---------------------------------------------------------------------------
-
-const LazyStorefrontHome = lazy(() =>
-  import('@features/storefront/pages/Home').then((m) => ({ default: m.Home })),
-);
 
 const LazyPosDashboard = lazy(() =>
   import('@features/pos/pages/Dashboard').then((m) => ({ default: m.PosDashboard })),
@@ -61,16 +58,7 @@ export const router = createBrowserRouter([
             // ThemeProvider as layout: fetches brand theme, applies CSS custom properties,
             // then renders child routes via <Outlet />.
             element: <ThemeProvider />,
-            children: [
-              {
-                index: true,
-                element: (
-                  <SuspenseWrapper>
-                    <LazyStorefrontHome />
-                  </SuspenseWrapper>
-                ),
-              },
-            ],
+            children: storefrontRoutes,
           },
         ],
       },


### PR DESCRIPTION
## Summary

- **Backend:** Two new read endpoints — `GET /orders/{id}` and `GET /orders/number/{orderNumber}` — returning `OrderTrackingResponse` (order + full lifecycle config). `GetByOrderNumberAsync` added to `IOrderRepository` for guest lookup by human-readable order number.
- **Frontend:** `OrderTrackingPage` at `/:brandSlug/:lang/order/:orderId/track` with `OrderStatusStepper` showing all configured lifecycle statuses in order, current step highlighted. Real-time status advancement via the existing `useOrderUpdates` SignalR hook.
- **Guest tracking:** Guests can reach the tracking page via the order number endpoint — no UUID required.
- **Link:** `OrderConfirmationPage` gains a "Track order" button navigating to the tracking page.
- **i18n:** Keys added for NL, FR, DE.
- **Tests:** 6 integration tests — happy paths, 404 guards, shop-mismatch guard, lifecycle sort-order assertion.

## Dependencies

- US-FP-022 ✅ Order lifecycle statuses
- US-FP-068 ✅ Real-time updates (SignalR)
- US-FP-016 ✅ Place an online order

## Implementation notes

`ordersApi.getById` now calls the same endpoint but extracts `.order` from `OrderTrackingResponse` internally, preserving its `Promise<OrderResponse>` contract so `OrderConfirmationPage` requires no changes. Use `ordersApi.getTracking` when the full lifecycle is needed.

## Test plan

- [ ] Place an order via the storefront checkout flow
- [ ] Confirm "Track order" button appears on the confirmation page
- [ ] Navigate to the tracking page — stepper shows all lifecycle statuses, current step highlighted
- [ ] Use `GET /bff/dev/simulate-status-change` (dev endpoint) to advance order status — stepper updates in real-time without page refresh
- [ ] Verify guest tracking: open tracking page in incognito with only the order number (`/orders/number/{orderNumber}`)
- [ ] `dotnet build` clean · `pnpm type-check` clean (4 pre-existing errors unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)