### PR TITLE
feat: US-FP-064 — Browse menu with allergen and dietary filters

### DIFF
--- a/.agents/plans/us-fp-064-allergen-dietary-filters.md
+++ b/.agents/plans/us-fp-064-allergen-dietary-filters.md
@@ -1,0 +1,121 @@
+# US-FP-064 — Browse menu with allergen and dietary filters
+
+## Story
+As a Registered Customer, I want to filter the menu by allergens and dietary preferences,
+so that I can quickly find safe food options.
+
+**Acceptance criteria:**
+- Filter UI for **allergens** — selecting an allergen *excludes* products containing it.
+- Filter UI for **dietary tags** — selecting a tag *requires* products to have it.
+- Filters combine (e.g. Vegetarian AND no Nuts).
+- Product cards display allergen icons + dietary tags.
+
+## Scope
+Frontend-only. `ProductListItem` already carries `allergens: number[]` and
+`dietaryTags: number[]` from the API, and i18n entries for every allergen/tag
+already exist (`allergens.{Key}`, `dietaryTags.{Key}`) in NL/FR/DE.
+
+No backend, API, or DB changes. No new dependencies.
+
+## Files
+
+### New
+| Path | Purpose |
+| --- | --- |
+| `src/frontend/src/features/storefront/components/MenuFilters.tsx` | Filter UI: collapsible panel with allergen exclusion chips + dietary tag chips + "Clear all" |
+| `src/frontend/src/features/storefront/utils/menuFilters.ts` | Pure helper `matchesFilters(product, filters)` and `MenuFilterState` type |
+| `src/frontend/src/features/storefront/components/__tests__/MenuFilters.test.tsx` | Component tests (toggling, clear-all) |
+| `src/frontend/src/features/storefront/components/__tests__/ProductCard.test.tsx` | Asserts allergen/dietary chips render |
+| `src/frontend/src/features/storefront/utils/__tests__/menuFilters.test.ts` | Pure-function tests for filter logic (combinations, empty case) |
+
+### Modified
+| Path | Change |
+| --- | --- |
+| `src/frontend/src/features/storefront/pages/MenuPage.tsx` | Hold filter state, render `<MenuFilters>`, pass filters to `CategorySection`, show "no matches" copy when all sections are filtered out |
+| `src/frontend/src/features/storefront/components/ProductCard.tsx` | Render allergen icons + dietary tag chips below the price line |
+| `src/frontend/src/i18n/locales/{nl,fr,de}/common.json` | Add `storefront.menu.filters.*` keys |
+
+## Design notes
+
+**Filter semantics** (matches AC):
+```ts
+function matchesFilters(p: ProductListItem, f: MenuFilterState): boolean {
+  if (p.allergens.some(a => f.excludedAllergens.has(a))) return false;
+  for (const tag of f.requiredDietaryTags) {
+    if (!p.dietaryTags.includes(tag)) return false;
+  }
+  return true;
+}
+```
+
+**State shape** (lifted into `MenuContent`):
+```ts
+interface MenuFilterState {
+  excludedAllergens: Set<number>;     // Allergen enum values
+  requiredDietaryTags: Set<number>;   // DietaryTag enum values
+}
+```
+Create new Sets on every toggle so React re-renders. Filters are session-only.
+
+**MenuFilters UI:**
+- Sticky panel below page title, collapsible via `<details>` (accessible, no extra JS).
+- Two sections: "Exclude allergens" + "Dietary requirements".
+- Each option is a toggle chip (`<button type="button"` with `aria-pressed`).
+- Footer row: "X active" + "Clear all" (hidden when no filters active).
+
+**ProductCard chips:**
+- Below price, render allergen chips then dietary chips.
+- Each chip has `title` + `aria-label` for screen readers.
+- Skip rendering the row when both arrays empty.
+
+**MenuContent / "no matches":**
+- Each `CategorySection` reports its filtered match count back via a callback.
+- `MenuContent` aggregates per-category counts in `useRef`-backed state; if filters are active AND total matches === 0, show `storefront.menu.filters.noMatches`.
+
+## i18n additions
+
+```json
+"filters": {
+  "title": "Filters",
+  "excludeAllergens": "Exclude allergens",
+  "requireDietary": "Dietary requirements",
+  "clearAll": "Clear all",
+  "active": "{{count}} active",
+  "noMatches": "No products match your filters.",
+  "open": "Open filters",
+  "close": "Close filters"
+}
+```
+Translations: NL, FR, DE.
+
+## Tests
+
+**`menuFilters.test.ts`** (pure):
+- Empty filters → all products match.
+- Excluded allergen filters out products containing it.
+- Required dietary tag keeps only products with that tag.
+- Combined (AND) — excludes allergen even when dietary tag matches.
+- Product with no allergens passes any allergen filter.
+
+**`MenuFilters.test.tsx`**:
+- Renders all 14 allergens + 4 dietary tags as buttons.
+- Clicking toggles `aria-pressed` and emits new Set.
+- "Clear all" emits empty Sets and is hidden when no filters active.
+
+**`ProductCard.test.tsx`**:
+- Renders allergen chip with the right i18n label.
+- Renders dietary chip with the right i18n label.
+- No chips row when both arrays empty.
+
+No new MSW handlers needed — filtering is client-side.
+
+## Out of scope
+- Persisting filters across sessions / URL sync — not in AC.
+- Backend-side filtering — catalogs are small and already loaded.
+- "May contain traces" warnings — not in domain model.
+- Combo component-level filtering — combos already carry aggregated allergens.
+
+## Verification
+1. `pnpm --dir src/frontend lint`
+2. `pnpm --dir src/frontend typecheck`
+3. `pnpm --dir src/frontend test`

--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -125,7 +125,7 @@ Once ordering works, these streams are **all independent**.
 | ⬜ | **US-FP-024** | Eat-in ordering with table number | 016, 066 |
 | ⬜ | **US-FP-025** | QR code table ordering | 024, 065 |
 | ⬜ | **US-FP-019** | Select time slot at checkout | 016, 020 |
-| ⬜ | **US-FP-064** | Browse menu with allergen/dietary filters | 008 |
+| ✅ | **US-FP-064** | Browse menu with allergen/dietary filters | 008 |
 | ⬜ | **US-FP-059** | Place a delivery order (POC) | 016 |
 
 ### Stream G: Shop Product Management

--- a/src/frontend/src/features/storefront/components/MenuFilters.tsx
+++ b/src/frontend/src/features/storefront/components/MenuFilters.tsx
@@ -1,0 +1,186 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Allergen,
+  DietaryTag,
+  ALLERGEN_KEYS,
+  DIETARY_TAG_KEYS,
+} from '@/types/common';
+import {
+  EMPTY_FILTERS,
+  activeFilterCount,
+  isFilterActive,
+  toggleInSet,
+  type MenuFilterState,
+} from '../utils/menuFilters';
+
+interface MenuFiltersProps {
+  filters: MenuFilterState;
+  onChange: (next: MenuFilterState) => void;
+}
+
+const containerStyle: React.CSSProperties = {
+  marginBottom: '1.5rem',
+  border: '1px solid #e5e7eb',
+  borderRadius: '0.5rem',
+  background: '#fff',
+};
+
+const summaryStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.5rem',
+  padding: '0.75rem 1rem',
+  fontWeight: 600,
+  fontSize: '0.9375rem',
+  color: '#111827',
+  cursor: 'pointer',
+  listStyle: 'none',
+};
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: '0.8125rem',
+  fontWeight: 700,
+  color: '#374151',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  margin: '0 0 0.5rem',
+};
+
+const chipRowStyle: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.375rem',
+};
+
+function chipStyle(selected: boolean, tone: 'allergen' | 'dietary'): React.CSSProperties {
+  const selectedBg =
+    tone === 'allergen' ? 'var(--brand-color-primary, #111827)' : '#15803d';
+  return {
+    padding: '0.3125rem 0.75rem',
+    borderRadius: '9999px',
+    border: `1px solid ${selected ? selectedBg : '#d1d5db'}`,
+    background: selected ? selectedBg : '#fff',
+    color: selected ? '#fff' : '#374151',
+    fontSize: '0.8125rem',
+    fontWeight: 500,
+    cursor: 'pointer',
+    transition: 'background 0.12s, border-color 0.12s, color 0.12s',
+  };
+}
+
+export function MenuFilters({ filters, onChange }: MenuFiltersProps) {
+  const { t } = useTranslation('common');
+  const active = isFilterActive(filters);
+  const count = activeFilterCount(filters);
+
+  function toggleAllergen(value: number) {
+    onChange({
+      ...filters,
+      excludedAllergens: toggleInSet(filters.excludedAllergens, value),
+    });
+  }
+
+  function toggleDietary(value: number) {
+    onChange({
+      ...filters,
+      requiredDietaryTags: toggleInSet(filters.requiredDietaryTags, value),
+    });
+  }
+
+  function clearAll() {
+    onChange(EMPTY_FILTERS);
+  }
+
+  return (
+    <details style={containerStyle}>
+      <summary style={summaryStyle} aria-label={t('storefront.menu.filters.title')}>
+        <span>{t('storefront.menu.filters.title')}</span>
+        {active && (
+          <span
+            style={{
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: '#fff',
+              background: 'var(--brand-color-accent, #2563eb)',
+              padding: '0.125rem 0.5rem',
+              borderRadius: '9999px',
+            }}
+            aria-live="polite"
+          >
+            {t('storefront.menu.filters.active', { count })}
+          </span>
+        )}
+      </summary>
+
+      <div style={{ padding: '0 1rem 1rem' }}>
+        <section style={{ marginTop: '0.75rem' }}>
+          <p style={sectionTitleStyle}>{t('storefront.menu.filters.excludeAllergens')}</p>
+          <div style={chipRowStyle} role="group" aria-label={t('storefront.menu.filters.excludeAllergens')}>
+            {ALLERGEN_KEYS.map((key) => {
+              const value = Allergen[key];
+              const selected = filters.excludedAllergens.has(value);
+              const label = t(`allergens.${key}`);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => { toggleAllergen(value); }}
+                  style={chipStyle(selected, 'allergen')}
+                >
+                  <span aria-hidden="true" style={{ marginRight: '0.25rem' }}>⚠</span>
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section style={{ marginTop: '1rem' }}>
+          <p style={sectionTitleStyle}>{t('storefront.menu.filters.requireDietary')}</p>
+          <div style={chipRowStyle} role="group" aria-label={t('storefront.menu.filters.requireDietary')}>
+            {DIETARY_TAG_KEYS.map((key) => {
+              const value = DietaryTag[key];
+              const selected = filters.requiredDietaryTags.has(value);
+              const label = t(`dietaryTags.${key}`);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => { toggleDietary(value); }}
+                  style={chipStyle(selected, 'dietary')}
+                >
+                  <span aria-hidden="true" style={{ marginRight: '0.25rem' }}>✓</span>
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {active && (
+          <div style={{ marginTop: '1rem', display: 'flex', justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={clearAll}
+              style={{
+                padding: '0.375rem 0.875rem',
+                borderRadius: '0.375rem',
+                border: '1px solid #d1d5db',
+                background: '#fff',
+                color: '#374151',
+                fontSize: '0.8125rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              {t('storefront.menu.filters.clearAll')}
+            </button>
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/src/frontend/src/features/storefront/components/ProductCard.tsx
+++ b/src/frontend/src/features/storefront/components/ProductCard.tsx
@@ -1,4 +1,10 @@
 import { useTranslation } from 'react-i18next';
+import {
+  Allergen,
+  DietaryTag,
+  ALLERGEN_KEYS,
+  DIETARY_TAG_KEYS,
+} from '@/types/common';
 import type { ProductListItem } from '@/types/common';
 
 interface ProductCardProps {
@@ -6,9 +12,42 @@ interface ProductCardProps {
   onAdd: (product: ProductListItem) => void;
 }
 
+const ALLERGEN_KEY_BY_VALUE = new Map<number, (typeof ALLERGEN_KEYS)[number]>(
+  ALLERGEN_KEYS.map((key) => [Allergen[key], key] as const),
+);
+
+const DIETARY_KEY_BY_VALUE = new Map<number, (typeof DIETARY_TAG_KEYS)[number]>(
+  DIETARY_TAG_KEYS.map((key) => [DietaryTag[key], key] as const),
+);
+
+const chipBase: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.1875rem',
+  padding: '0.125rem 0.5rem',
+  borderRadius: '9999px',
+  fontSize: '0.6875rem',
+  fontWeight: 600,
+  lineHeight: 1.3,
+};
+
+const allergenChipStyle: React.CSSProperties = {
+  ...chipBase,
+  background: '#fef3c7',
+  color: '#92400e',
+  border: '1px solid #fde68a',
+};
+
+const dietaryChipStyle: React.CSSProperties = {
+  ...chipBase,
+  background: '#dcfce7',
+  color: '#166534',
+  border: '1px solid #bbf7d0',
+};
+
 /**
  * Displays a single product in the storefront menu.
- * Shows the product name, formatted price, and an "Add" button.
+ * Shows the product name, formatted price, allergen and dietary chips, and an "Add" button.
  *
  * For products with modifier groups, the parent (MenuPage) opens a ModifierModal
  * when the add button is clicked.
@@ -20,6 +59,8 @@ export function ProductCard({ product, onAdd }: ProductCardProps) {
     style: 'currency',
     currency: product.basePrice.currency || 'EUR',
   }).format(product.basePrice.amount);
+
+  const hasTags = product.allergens.length > 0 || product.dietaryTags.length > 0;
 
   return (
     <div
@@ -71,11 +112,57 @@ export function ProductCard({ product, onAdd }: ProductCardProps) {
         >
           {formattedPrice}
         </p>
+
+        {hasTags && (
+          <div
+            style={{
+              marginTop: '0.375rem',
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '0.25rem',
+            }}
+            data-testid="product-tags"
+          >
+            {product.dietaryTags.map((value) => {
+              const key = DIETARY_KEY_BY_VALUE.get(value);
+              if (!key) return null;
+              const label = t(`dietaryTags.${key}`);
+              return (
+                <span
+                  key={`dietary-${String(value)}`}
+                  style={dietaryChipStyle}
+                  title={label}
+                  aria-label={label}
+                >
+                  <span aria-hidden="true">✓</span>
+                  {label}
+                </span>
+              );
+            })}
+            {product.allergens.map((value) => {
+              const key = ALLERGEN_KEY_BY_VALUE.get(value);
+              if (!key) return null;
+              const label = t(`allergens.${key}`);
+              const containsLabel = t('storefront.menu.contains', { name: label });
+              return (
+                <span
+                  key={`allergen-${String(value)}`}
+                  style={allergenChipStyle}
+                  title={containsLabel}
+                  aria-label={containsLabel}
+                >
+                  <span aria-hidden="true">⚠</span>
+                  {label}
+                </span>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <button
         type="button"
-        onClick={() => onAdd(product)}
+        onClick={() => { onAdd(product); }}
         aria-label={t('storefront.menu.addItem', { name: product.name })}
         style={{
           flexShrink: 0,

--- a/src/frontend/src/features/storefront/components/__tests__/MenuFilters.test.tsx
+++ b/src/frontend/src/features/storefront/components/__tests__/MenuFilters.test.tsx
@@ -1,0 +1,114 @@
+import { beforeAll, describe, it, expect, vi } from 'vitest';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { Allergen, DietaryTag, ALLERGEN_KEYS, DIETARY_TAG_KEYS } from '@/types/common';
+import { MenuFilters } from '../MenuFilters';
+import { EMPTY_FILTERS, type MenuFilterState } from '../../utils/menuFilters';
+import '../../../../i18n/config';
+
+beforeAll(async () => {
+  await i18next.changeLanguage('nl');
+});
+
+function t(key: string): string {
+  return i18next.t(key);
+}
+
+function allergenLabel(key: keyof typeof Allergen): string {
+  return t(`allergens.${key}`);
+}
+function dietaryLabel(key: keyof typeof DietaryTag): string {
+  return t(`dietaryTags.${key}`);
+}
+
+function setup(initial: MenuFilterState = EMPTY_FILTERS) {
+  const onChange = vi.fn<(next: MenuFilterState) => void>();
+  const utils = render(<MenuFilters filters={initial} onChange={onChange} />);
+  return { ...utils, onChange };
+}
+
+describe('MenuFilters', () => {
+  it('renders every allergen and dietary tag as a toggle button', () => {
+    setup();
+    for (const key of ALLERGEN_KEYS) {
+      expect(screen.getByRole('button', { name: allergenLabel(key) })).toBeInTheDocument();
+    }
+    for (const key of DIETARY_TAG_KEYS) {
+      expect(screen.getByRole('button', { name: dietaryLabel(key) })).toBeInTheDocument();
+    }
+  });
+
+  it('emits an updated set when an allergen chip is toggled on', async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup();
+    await user.click(screen.getByRole('button', { name: allergenLabel('Nuts') }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0]?.[0];
+    expect(next?.excludedAllergens.has(Allergen.Nuts)).toBe(true);
+    expect(next?.requiredDietaryTags.size).toBe(0);
+  });
+
+  it('removes an allergen when toggled off', async () => {
+    const user = userEvent.setup();
+    const initial: MenuFilterState = {
+      excludedAllergens: new Set([Allergen.Nuts]),
+      requiredDietaryTags: new Set(),
+    };
+    const { onChange } = setup(initial);
+    await user.click(screen.getByRole('button', { name: allergenLabel('Nuts') }));
+
+    const next = onChange.mock.calls[0]?.[0];
+    expect(next?.excludedAllergens.has(Allergen.Nuts)).toBe(false);
+  });
+
+  it('emits an updated set when a dietary chip is toggled on', async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup();
+    await user.click(screen.getByRole('button', { name: dietaryLabel('Vegan') }));
+
+    const next = onChange.mock.calls[0]?.[0];
+    expect(next?.requiredDietaryTags.has(DietaryTag.Vegan)).toBe(true);
+  });
+
+  it('reflects selection state via aria-pressed', () => {
+    setup({
+      excludedAllergens: new Set([Allergen.Gluten]),
+      requiredDietaryTags: new Set([DietaryTag.Vegan]),
+    });
+    expect(screen.getByRole('button', { name: allergenLabel('Gluten') })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: dietaryLabel('Vegan') })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: dietaryLabel('Halal') })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('hides "Clear all" when no filter is active', () => {
+    setup();
+    const clearLabel = t('storefront.menu.filters.clearAll');
+    expect(screen.queryByRole('button', { name: clearLabel })).toBeNull();
+  });
+
+  it('emits empty filters when "Clear all" is clicked', async () => {
+    const user = userEvent.setup();
+    const initial: MenuFilterState = {
+      excludedAllergens: new Set([Allergen.Nuts]),
+      requiredDietaryTags: new Set([DietaryTag.Vegan]),
+    };
+    const { onChange } = setup(initial);
+    const clearLabel = t('storefront.menu.filters.clearAll');
+    await user.click(screen.getByRole('button', { name: clearLabel }));
+
+    const next = onChange.mock.calls[0]?.[0];
+    expect(next?.excludedAllergens.size).toBe(0);
+    expect(next?.requiredDietaryTags.size).toBe(0);
+  });
+});

--- a/src/frontend/src/features/storefront/components/__tests__/ProductCard.test.tsx
+++ b/src/frontend/src/features/storefront/components/__tests__/ProductCard.test.tsx
@@ -1,0 +1,91 @@
+import { beforeAll, describe, it, expect, vi } from 'vitest';
+import { screen, render, within } from '@testing-library/react';
+import i18next from 'i18next';
+import { Allergen, DietaryTag } from '@/types/common';
+import type { ProductListItem } from '@/types/common';
+import { ProductCard } from '../ProductCard';
+import '../../../../i18n/config';
+
+beforeAll(async () => {
+  await i18next.changeLanguage('nl');
+});
+
+function t(key: string, options?: { name: string }): string {
+  return options ? i18next.t(key, options) : i18next.t(key);
+}
+
+function makeProduct(overrides: Partial<ProductListItem> = {}): ProductListItem {
+  return {
+    id: 'p-1',
+    productType: 'Simple',
+    name: 'Frietjes',
+    basePrice: { amount: 3.5, currency: 'EUR' },
+    imageUrl: null,
+    menuCategoryId: null,
+    sortOrderInCategory: 0,
+    allergens: [],
+    dietaryTags: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ProductCard', () => {
+  it('renders the product name and price', () => {
+    render(<ProductCard product={makeProduct()} onAdd={vi.fn()} />);
+    expect(screen.getByText('Frietjes')).toBeInTheDocument();
+  });
+
+  it('renders no tags section when product has no allergens or dietary tags', () => {
+    render(<ProductCard product={makeProduct()} onAdd={vi.fn()} />);
+    expect(screen.queryByTestId('product-tags')).toBeNull();
+  });
+
+  it('renders an allergen chip with the localised label', () => {
+    render(
+      <ProductCard
+        product={makeProduct({ allergens: [Allergen.Gluten] })}
+        onAdd={vi.fn()}
+      />,
+    );
+    const tags = screen.getByTestId('product-tags');
+    expect(within(tags).getByText(t('allergens.Gluten'))).toBeInTheDocument();
+  });
+
+  it('renders a dietary chip with the localised label', () => {
+    render(
+      <ProductCard
+        product={makeProduct({ dietaryTags: [DietaryTag.Vegan] })}
+        onAdd={vi.fn()}
+      />,
+    );
+    const tags = screen.getByTestId('product-tags');
+    expect(within(tags).getByText(t('dietaryTags.Vegan'))).toBeInTheDocument();
+  });
+
+  it('renders both allergen and dietary chips when both are present', () => {
+    render(
+      <ProductCard
+        product={makeProduct({
+          allergens: [Allergen.Nuts],
+          dietaryTags: [DietaryTag.Vegetarian],
+        })}
+        onAdd={vi.fn()}
+      />,
+    );
+    const tags = screen.getByTestId('product-tags');
+    expect(within(tags).getByText(t('allergens.Nuts'))).toBeInTheDocument();
+    expect(within(tags).getByText(t('dietaryTags.Vegetarian'))).toBeInTheDocument();
+  });
+
+  it('labels allergen chips with "Contains {name}" for screen readers', () => {
+    render(
+      <ProductCard
+        product={makeProduct({ allergens: [Allergen.Milk] })}
+        onAdd={vi.fn()}
+      />,
+    );
+    const containsLabel = t('storefront.menu.contains', { name: t('allergens.Milk') });
+    expect(screen.getByLabelText(containsLabel)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/storefront/pages/MenuPage.tsx
+++ b/src/frontend/src/features/storefront/pages/MenuPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { ProductListItem } from '@/types/common';
@@ -6,28 +6,48 @@ import { CartProvider, useCart, type CartModifier } from '../context/CartContext
 import { ProductCard } from '../components/ProductCard';
 import { ModifierModal } from '../components/ModifierModal';
 import { CartDrawer } from '../components/CartDrawer';
+import { MenuFilters } from '../components/MenuFilters';
 import { useStorefrontCategories, useStorefrontCategoryProducts } from '../hooks/useStorefrontMenu';
+import {
+  EMPTY_FILTERS,
+  isFilterActive,
+  matchesFilters,
+  type MenuFilterState,
+} from '../utils/menuFilters';
 import { modifierGroupsApi } from '@api/modifierGroups';
 
 // ---------------------------------------------------------------------------
-// Category section — fetches its own products
+// Category section — fetches its own products and reports filtered match count
 // ---------------------------------------------------------------------------
 
 interface CategorySectionProps {
   brandSlug: string;
   categoryId: string;
   categoryName: string;
+  filters: MenuFilterState;
   onAddProduct: (product: ProductListItem) => void;
+  onMatchCountChange: (categoryId: string, count: number) => void;
 }
 
 function CategorySection({
   brandSlug,
   categoryId,
   categoryName,
+  filters,
   onAddProduct,
+  onMatchCountChange,
 }: CategorySectionProps) {
   const { t } = useTranslation('common');
   const { data: products, isLoading, isError } = useStorefrontCategoryProducts(brandSlug, categoryId);
+
+  const filteredProducts = useMemo(
+    () => (products ?? []).filter((p) => matchesFilters(p, filters)),
+    [products, filters],
+  );
+
+  useEffect(() => {
+    if (products) onMatchCountChange(categoryId, filteredProducts.length);
+  }, [products, filteredProducts.length, categoryId, onMatchCountChange]);
 
   if (isLoading) {
     return (
@@ -51,7 +71,7 @@ function CategorySection({
     );
   }
 
-  if (!products || products.length === 0) return null;
+  if (filteredProducts.length === 0) return null;
 
   return (
     <section style={{ marginBottom: '2.5rem' }}>
@@ -67,7 +87,7 @@ function CategorySection({
       >
         {categoryName}
       </h2>
-      {products.map((product) => (
+      {filteredProducts.map((product) => (
         <ProductCard key={product.id} product={product} onAdd={onAddProduct} />
       ))}
     </section>
@@ -88,11 +108,14 @@ function MenuContent({ brandSlug }: MenuContentProps) {
 
   const [cartOpen, setCartOpen] = useState(false);
   const [modifierProduct, setModifierProduct] = useState<ProductListItem | null>(null);
+  const [filters, setFilters] = useState<MenuFilterState>(EMPTY_FILTERS);
+  const [matchCounts, setMatchCounts] = useState<Record<string, number>>({});
 
   const { data: categories, isLoading, isError } = useStorefrontCategories(brandSlug);
 
-  // Pre-fetch modifier groups for all visible products' modifier count check
-  // (We check whether a product has modifier groups by fetching once the user clicks Add)
+  const handleMatchCountChange = useCallback((categoryId: string, count: number) => {
+    setMatchCounts((prev) => (prev[categoryId] === count ? prev : { ...prev, [categoryId]: count }));
+  }, []);
 
   async function checkProductHasModifiers(product: ProductListItem): Promise<boolean> {
     try {
@@ -129,6 +152,11 @@ function MenuContent({ brandSlug }: MenuContentProps) {
     });
     setModifierProduct(null);
   }
+
+  const totalMatches = Object.values(matchCounts).reduce((sum, n) => sum + n, 0);
+  const filterActive = isFilterActive(filters);
+  const showNoMatches =
+    filterActive && categories && categories.length > 0 && totalMatches === 0;
 
   return (
     <main style={{ maxWidth: '48rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
@@ -183,6 +211,8 @@ function MenuContent({ brandSlug }: MenuContentProps) {
         {t('storefront.menu.title')}
       </h1>
 
+      <MenuFilters filters={filters} onChange={setFilters} />
+
       {isLoading && <p style={{ color: '#6b7280' }}>{t('loading')}</p>}
       {isError && <p style={{ color: '#ef4444' }}>{t('error')}</p>}
 
@@ -196,9 +226,17 @@ function MenuContent({ brandSlug }: MenuContentProps) {
           brandSlug={brandSlug}
           categoryId={category.id}
           categoryName={category.name}
+          filters={filters}
           onAddProduct={(product) => { void handleAddProduct(product); }}
+          onMatchCountChange={handleMatchCountChange}
         />
       ))}
+
+      {showNoMatches && (
+        <p style={{ color: '#6b7280', textAlign: 'center', padding: '2rem 0' }}>
+          {t('storefront.menu.filters.noMatches')}
+        </p>
+      )}
 
       {/* Modifier modal */}
       {modifierProduct && (

--- a/src/frontend/src/features/storefront/utils/__tests__/menuFilters.test.ts
+++ b/src/frontend/src/features/storefront/utils/__tests__/menuFilters.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { Allergen, DietaryTag } from '@/types/common';
+import {
+  EMPTY_FILTERS,
+  activeFilterCount,
+  isFilterActive,
+  matchesFilters,
+  toggleInSet,
+  type MenuFilterState,
+} from '../menuFilters';
+
+function product(allergens: number[], dietaryTags: number[]) {
+  return { allergens, dietaryTags };
+}
+
+function filters(
+  excludedAllergens: number[] = [],
+  requiredDietaryTags: number[] = [],
+): MenuFilterState {
+  return {
+    excludedAllergens: new Set(excludedAllergens),
+    requiredDietaryTags: new Set(requiredDietaryTags),
+  };
+}
+
+describe('matchesFilters', () => {
+  it('returns true for any product when no filters are active', () => {
+    const p = product([Allergen.Gluten, Allergen.Nuts], []);
+    expect(matchesFilters(p, EMPTY_FILTERS)).toBe(true);
+  });
+
+  it('excludes products containing an excluded allergen', () => {
+    const p = product([Allergen.Gluten], []);
+    expect(matchesFilters(p, filters([Allergen.Gluten]))).toBe(false);
+  });
+
+  it('keeps products that do not contain any excluded allergen', () => {
+    const p = product([Allergen.Milk], []);
+    expect(matchesFilters(p, filters([Allergen.Nuts]))).toBe(true);
+  });
+
+  it('keeps a product with no allergens regardless of allergen filters', () => {
+    const p = product([], []);
+    expect(matchesFilters(p, filters([Allergen.Nuts, Allergen.Gluten]))).toBe(true);
+  });
+
+  it('keeps only products carrying every required dietary tag (AND semantics)', () => {
+    const veganGf = product([], [DietaryTag.Vegan, DietaryTag.GlutenFree]);
+    const veganOnly = product([], [DietaryTag.Vegan]);
+    const required = filters([], [DietaryTag.Vegan, DietaryTag.GlutenFree]);
+    expect(matchesFilters(veganGf, required)).toBe(true);
+    expect(matchesFilters(veganOnly, required)).toBe(false);
+  });
+
+  it('combines allergen exclusion and dietary requirement', () => {
+    const p = product([Allergen.Nuts], [DietaryTag.Vegetarian]);
+    const f = filters([Allergen.Nuts], [DietaryTag.Vegetarian]);
+    // Excluded allergen wins → product is hidden even though dietary matches.
+    expect(matchesFilters(p, f)).toBe(false);
+  });
+
+  it('returns true when both filter dimensions match', () => {
+    const p = product([Allergen.Milk], [DietaryTag.Vegetarian]);
+    const f = filters([Allergen.Nuts], [DietaryTag.Vegetarian]);
+    expect(matchesFilters(p, f)).toBe(true);
+  });
+});
+
+describe('isFilterActive', () => {
+  it('is false for the empty state', () => {
+    expect(isFilterActive(EMPTY_FILTERS)).toBe(false);
+  });
+
+  it('is true when at least one allergen or tag is selected', () => {
+    expect(isFilterActive(filters([Allergen.Gluten]))).toBe(true);
+    expect(isFilterActive(filters([], [DietaryTag.Vegan]))).toBe(true);
+  });
+});
+
+describe('activeFilterCount', () => {
+  it('sums excluded allergens and required dietary tags', () => {
+    expect(activeFilterCount(EMPTY_FILTERS)).toBe(0);
+    expect(activeFilterCount(filters([Allergen.Gluten, Allergen.Nuts]))).toBe(2);
+    expect(
+      activeFilterCount(filters([Allergen.Gluten], [DietaryTag.Vegan, DietaryTag.Halal])),
+    ).toBe(3);
+  });
+});
+
+describe('toggleInSet', () => {
+  it('adds the value when absent', () => {
+    const result = toggleInSet(new Set([1]), 2);
+    expect([...result].sort()).toEqual([1, 2]);
+  });
+
+  it('removes the value when present', () => {
+    const result = toggleInSet(new Set([1, 2]), 2);
+    expect([...result]).toEqual([1]);
+  });
+
+  it('does not mutate the input set', () => {
+    const input = new Set([1]);
+    toggleInSet(input, 2);
+    expect([...input]).toEqual([1]);
+  });
+});

--- a/src/frontend/src/features/storefront/utils/menuFilters.ts
+++ b/src/frontend/src/features/storefront/utils/menuFilters.ts
@@ -1,0 +1,47 @@
+import type { ProductListItem } from '@/types/common';
+
+/**
+ * Active storefront menu filters. Both sets are keyed by the numeric enum value
+ * (matching `Allergen` and `DietaryTag` in `@/types/common`).
+ *
+ * Semantics:
+ * - `excludedAllergens` removes products that contain any of the listed allergens.
+ * - `requiredDietaryTags` keeps only products that carry every listed dietary tag.
+ */
+export interface MenuFilterState {
+  excludedAllergens: ReadonlySet<number>;
+  requiredDietaryTags: ReadonlySet<number>;
+}
+
+export const EMPTY_FILTERS: MenuFilterState = {
+  excludedAllergens: new Set<number>(),
+  requiredDietaryTags: new Set<number>(),
+};
+
+export function isFilterActive(filters: MenuFilterState): boolean {
+  return filters.excludedAllergens.size > 0 || filters.requiredDietaryTags.size > 0;
+}
+
+export function activeFilterCount(filters: MenuFilterState): number {
+  return filters.excludedAllergens.size + filters.requiredDietaryTags.size;
+}
+
+export function matchesFilters(
+  product: Pick<ProductListItem, 'allergens' | 'dietaryTags'>,
+  filters: MenuFilterState,
+): boolean {
+  for (const allergen of product.allergens) {
+    if (filters.excludedAllergens.has(allergen)) return false;
+  }
+  for (const tag of filters.requiredDietaryTags) {
+    if (!product.dietaryTags.includes(tag)) return false;
+  }
+  return true;
+}
+
+export function toggleInSet(set: ReadonlySet<number>, value: number): Set<number> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -17,7 +17,16 @@
       "closeModal": "Schließen",
       "noCategories": "Keine Menükategorien verfügbar.",
       "loadingModifiers": "Optionen werden geladen…",
-      "noModifiers": "Keine Anpassungen verfügbar."
+      "noModifiers": "Keine Anpassungen verfügbar.",
+      "contains": "Enthält {{name}}",
+      "filters": {
+        "title": "Filter",
+        "excludeAllergens": "Allergene ausschließen",
+        "requireDietary": "Ernährungsvorgaben",
+        "clearAll": "Alle zurücksetzen",
+        "active": "{{count}} aktiv",
+        "noMatches": "Keine Produkte entsprechen Ihren Filtern."
+      }
     },
     "cart": {
       "title": "Warenkorb",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -17,7 +17,16 @@
       "closeModal": "Fermer",
       "noCategories": "Aucune catégorie de menu disponible.",
       "loadingModifiers": "Chargement des options…",
-      "noModifiers": "Aucune personnalisation disponible."
+      "noModifiers": "Aucune personnalisation disponible.",
+      "contains": "Contient {{name}}",
+      "filters": {
+        "title": "Filtres",
+        "excludeAllergens": "Exclure les allergènes",
+        "requireDietary": "Préférences alimentaires",
+        "clearAll": "Tout effacer",
+        "active": "{{count}} actif(s)",
+        "noMatches": "Aucun produit ne correspond à vos filtres."
+      }
     },
     "cart": {
       "title": "Panier",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -17,7 +17,16 @@
       "closeModal": "Sluiten",
       "noCategories": "Geen menu-categorieën beschikbaar.",
       "loadingModifiers": "Opties laden…",
-      "noModifiers": "Geen aanpassingen beschikbaar."
+      "noModifiers": "Geen aanpassingen beschikbaar.",
+      "contains": "Bevat {{name}}",
+      "filters": {
+        "title": "Filters",
+        "excludeAllergens": "Allergenen uitsluiten",
+        "requireDietary": "Dieetvereisten",
+        "clearAll": "Alles wissen",
+        "active": "{{count}} actief",
+        "noMatches": "Geen producten voldoen aan uw filters."
+      }
     },
     "cart": {
       "title": "Winkelwagen",


### PR DESCRIPTION
## Summary
- Adds a `MenuFilters` panel to the storefront menu page so customers can
  exclude allergens and require dietary tags. Filters combine (AND semantics).
- `ProductCard` now renders allergen chips (amber) and dietary chips (green)
  next to the price.
- When active filters yield zero matches, an empty-state copy explains it.

Frontend-only — `ProductListItem` already carries `allergens` and
`dietaryTags` from the API, and i18n labels for all 14 allergens and
4 dietary tags already exist in NL/FR/DE.

## Test plan
- [x] Unit tests for `matchesFilters` (exclusion, requirement, combined,
  empty-state, AND semantics) — 13 tests
- [x] Component tests for `MenuFilters` (renders all options, toggling,
  aria-pressed, clear-all) — 7 tests
- [x] Component tests for `ProductCard` chip rendering, including the
  "Contains {name}" screen-reader label — 6 tests
- [x] Full Vitest suite green (244 tests)
- [x] `tsc --noEmit` clean
- [ ] Manual storefront smoke (filters collapse, chips read correctly in
  NL/FR/DE)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)