### PR TITLE
feat: kitchen display screen (US-FP-027)

### DIFF
--- a/.agents/plans/us-fp-027-kitchen-display.md
+++ b/.agents/plans/us-fp-027-kitchen-display.md
@@ -1,0 +1,202 @@
+# US-FP-027 — View order on kitchen display
+
+GitHub issue: [#27](https://github.com/OoyeM/TheMillionthFoodOrderApp/issues/27)
+Branch: `feat/us-fp-027-kitchen-display`
+Prereqs: US-FP-022 ✅ (order lifecycle), US-FP-068 ✅ (SignalR infrastructure)
+
+## Acceptance criteria
+
+1. Kitchen display shows orders sorted by time (oldest first).
+2. Each order card shows: order number, items with modifiers, order type (Pickup/EatIn/Delivery), table number (if eat-in), time slot (if applicable), customer name.
+3. New orders appear automatically without page refresh (SignalR).
+4. Completed orders are removed from the active view (terminal statuses).
+
+**Scope note — fields that don't exist yet:**
+- `TableNumber` on `Order` lands with US-FP-024. The UI will render it *if* the response includes a non-null `tableNumber`; until then, eat-in orders simply show the "Eat-In" badge with no number. No domain or DB change in this PR.
+- "Time slot" is not yet a concept on `Order` (no story has introduced scheduled-for orders). Same approach: the UI renders a `timeSlot` field if present. No domain or DB change in this PR.
+
+This keeps US-FP-027 a pure read-side display + push feature and avoids coupling with US-FP-024.
+
+## Backend
+
+### 1. Repository — list active orders for a shop
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderRepository.cs`
+Add:
+```csharp
+Task<IReadOnlyList<Order>> GetActiveByShopAsync(Guid shopId, CancellationToken ct);
+```
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs`
+Implementation:
+- Query `Orders` where `ShopId == shopId`
+- Filter out orders whose `StatusName` matches an `OrderStatus` in the shop's lifecycle that has `IsTerminal == true`
+- Order by `CreatedAt ASC`
+- `.Include(o => o.Items).ThenInclude(i => i.SelectedModifiers)`
+
+Because `OrderStatus` lives in `OrderLifecycleConfig` (per-shop) and an order only stores `StatusName`, the implementation joins to the shop's lifecycle config:
+```csharp
+var terminalStatusNames = await _db.OrderLifecycleConfigs
+    .Where(c => c.ShopId == shopId)
+    .SelectMany(c => c.Statuses)
+    .Where(s => s.IsTerminal)
+    .Select(s => s.Name)
+    .ToListAsync(ct);
+
+return await _db.Orders
+    .Include(o => o.Items).ThenInclude(i => i.SelectedModifiers)
+    .Where(o => o.ShopId == shopId && !terminalStatusNames.Contains(o.StatusName))
+    .OrderBy(o => o.CreatedAt)
+    .ToListAsync(ct);
+```
+
+### 2. Endpoint — list active orders
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/ListActiveOrdersEndpoint.cs`
+
+- Route: `GET /api/brands/{brandSlug}/shops/{shopId}/orders/active`
+- Request: `(string BrandSlug, Guid ShopId)` route params
+- Response: `IReadOnlyList<OrderResponse>` (reuse existing `OrderResponse` + `OrderMapper`/`OrderTrackingMapper.MapOrder`)
+- `PreProcessor<BrandScopedPreProcessor<…>>`
+- `AllowAnonymous()` for parity with `GetOrderEndpoint` — auth gating across the order surface is owned by **US-FP-039**. Add a TODO comment referencing it.
+- Swagger summary + 200 response shape
+
+### 3. Tests
+
+**Unit:** `src/backend/TheMillionthFoodOrderApp.Tests.Unit/Orders/OrderRepositoryQueryShapeTests.cs` — optional, covered by integration.
+
+**Integration:** `src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs`
+- TUnit `[Test]`, `[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]`
+- Setup: brand + shop + tax config + default lifecycle (Placed/Confirmed/Preparing/Ready/PickedUp/Delivered; PickedUp + Delivered terminal)
+- Scenarios:
+  1. Returns empty list when no orders exist
+  2. Returns orders in non-terminal statuses, sorted ascending by `CreatedAt`
+  3. Excludes orders in terminal statuses
+  4. Does not return orders from other shops in the same brand
+  5. Item modifiers are included in the response
+
+## Frontend
+
+### 4. API client
+
+**File:** `src/frontend/src/api/orders.ts` (extend the existing `ordersApi`)
+```ts
+listActive: (brandSlug: string, shopId: string): Promise<OrderResponse[]> =>
+  apiClient
+    .get<OrderResponse[]>(`/brands/${brandSlug}/shops/${shopId}/orders/active`)
+    .then(r => r.data),
+```
+
+Extend `OrderResponse` with optional fields to allow forward-compatibility without breaking now:
+```ts
+tableNumber?: string | null;   // future US-FP-024
+timeSlot?: string | null;      // future
+```
+
+### 5. Hook — active orders with realtime updates
+
+**File:** `src/frontend/src/features/pos/hooks/useActiveOrders.ts`
+- `useQuery({ queryKey: ['orders', 'active', brandSlug, shopId], queryFn: () => ordersApi.listActive(...) })`
+- `staleTime: 0`, `refetchOnWindowFocus: true`
+- `useOrderUpdates({ shopGroup: { brandSlug, shopId }, onStatusChange })`
+- `onStatusChange` logic:
+  - Get current orders from cache
+  - If the updated order isn't in the cache → invalidate the query (new order arrived)
+  - If `update.newStatus` corresponds to a terminal status → optimistically remove from cache, then invalidate to reconcile
+  - Else update the matching order's `statusName` in cache
+- Return `{ orders, isLoading, connectionStatus }`
+
+Use the shop's lifecycle (already fetched server-side, expose lifecycle terminal status names via a separate `useOrderLifecycle` query) to decide what is terminal client-side. **Alternative — simpler:** always invalidate on any status change, which is correct and minimizes complexity. Recommend this for v1; revisit if real-load testing shows excessive refetches.
+
+> Decision: go with the simpler "always invalidate on any status change" approach. The hook just calls `queryClient.invalidateQueries(['orders', 'active', brandSlug, shopId])` on every `OrderStatusChanged` event. Simpler, fewer edge cases, and an invalidate on a small list (~tens of orders) is cheap.
+
+### 6. Kitchen display page
+
+**File:** `src/frontend/src/features/pos/pages/KitchenDisplay.tsx`
+
+- `useParams` → `brandSlug` (from outer route), `shopId` (from search params or route param — we'll use a query param `?shopId=...` for v1 since POS routes don't yet have `shopId`; document this as a temporary mechanism)
+- Renders:
+  - Header with shop name placeholder, `ConnectionStatus` indicator pill
+  - Grid of order cards (CSS grid, large touch-friendly tiles)
+- Order card displays:
+  - `#${orderNumber}` (large)
+  - Relative time ("3m ago") + absolute time (`HH:mm`)
+  - Order type badge with i18n label and color
+  - Conditional `tableNumber` ("Table 5") when present
+  - Conditional `timeSlot` when present
+  - `customerName` if set
+  - Item list — product name, quantity, modifier names indented under each item
+- Empty state: "No active orders" with the i18n key
+- Loading state: skeleton tiles
+- Error state: error banner with retry
+
+**File:** `src/frontend/src/features/pos/components/KitchenOrderCard.tsx`
+- Extract the card to its own component for testability
+
+### 7. Routing + auth
+
+**File:** `src/frontend/src/features/pos/routes.tsx`
+- Add `{ path: 'kitchen', element: <RequireAuth roles={['kitchen-staff', 'counter-staff', 'brand-admin']}><KitchenDisplay /></RequireAuth> }`
+- Mounted under `/:brandSlug/:lang/pos/kitchen`
+
+### 8. i18n
+
+**Files:** `src/frontend/src/i18n/locales/{nl,fr,de}/common.json`
+- `kitchen.title`
+- `kitchen.empty`
+- `kitchen.orderType.pickup` / `.eatIn` / `.delivery`
+- `kitchen.customer`
+- `kitchen.table`
+- `kitchen.timeSlot`
+- `kitchen.connection.connected` / `.connecting` / `.disconnected`
+
+### 9. Frontend tests
+
+**File:** `src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx`
+- MSW handler for `GET /api/brands/:slug/shops/:shopId/orders/active`
+- Renders cards in the order returned by the API
+- Renders item modifiers under each item
+- Renders empty state when list is empty
+- Renders table number only when present
+
+**File:** `src/frontend/src/features/pos/hooks/__tests__/useActiveOrders.test.ts`
+- Mock `useOrderUpdates` and assert invalidation is called when `onStatusChange` fires
+- Optional — light coverage; full SignalR plumbing is exercised in storefront tests already
+
+## Verification
+
+- `dotnet build TheMillionthFoodOrderApp.slnx` in `src/backend/` → 0 errors
+- `dotnet run -c Release` in `TheMillionthFoodOrderApp.Tests.Integration/` (per backend CLAUDE.md — TUnit uses `dotnet run -c Release`, not `dotnet test`)
+- `pnpm test` in `src/frontend/` → all green
+- `pnpm build` in `src/frontend/` → 0 errors
+
+## Out of scope (deferred)
+
+- Table number persistence/entry (**US-FP-024**)
+- Scheduled / time-slot orders (no story yet)
+- Audio cue / pop notification for new orders
+- Bumping orders to next status from the kitchen display itself (that's **US-FP-023** "Update order status (kitchen)")
+- Hub authorization for non-anonymous access (**US-FP-039**)
+
+## File summary
+
+**Backend (added):**
+- `Application/Orders/IOrderRepository.cs` (extended)
+- `Infrastructure/Orders/OrderRepository.cs` (extended)
+- `Api/Endpoints/Orders/ListActiveOrdersEndpoint.cs` (new)
+- `Tests.Integration/Orders/ListActiveOrdersTests.cs` (new)
+
+**Frontend (added):**
+- `api/orders.ts` (extended)
+- `features/pos/hooks/useActiveOrders.ts` (new)
+- `features/pos/pages/KitchenDisplay.tsx` (new)
+- `features/pos/components/KitchenOrderCard.tsx` (new)
+- `features/pos/components/KitchenOrderCard.module.css` (new)
+- `features/pos/pages/KitchenDisplay.module.css` (new)
+- `features/pos/routes.tsx` (extended)
+- `i18n/locales/{nl,fr,de}/common.json` (extended)
+- `features/pos/pages/__tests__/KitchenDisplay.test.tsx` (new)
+- `features/pos/hooks/__tests__/useActiveOrders.test.ts` (new)
+
+**Docs:**
+- `docs/dependency-tree.md` — mark US-FP-027 as ✅ after PR merges

--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -111,7 +111,7 @@ Once ordering works, these streams are **all independent**.
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| ⬜ | **US-FP-027** | View order on kitchen display | 022, 068 |
+| ✅ | **US-FP-027** | View order on kitchen display | 022, 068 |
 | ⬜ | **US-FP-023** | Update order status (kitchen) | 022, 027 |
 | ⬜ | **US-FP-028** | Print order ticket | 022 |
 | ⬜ | **US-FP-026** | Configure order notifications | 022 |

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/ListActiveOrdersEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/ListActiveOrdersEndpoint.cs
@@ -1,0 +1,48 @@
+using FastEndpoints;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record ListActiveOrdersRequest(
+    [property: RouteParam] string BrandSlug,
+    [property: RouteParam] Guid ShopId);
+
+public sealed record ListActiveOrdersResponse(IReadOnlyList<OrderResponse> Orders);
+
+/// <summary>
+/// Lists the active orders for a shop — those whose status is not a terminal status
+/// in the shop's lifecycle configuration. Backs the kitchen display screen (US-FP-027).
+/// Sorted by creation time ascending (oldest first).
+/// </summary>
+public sealed class ListActiveOrdersEndpoint(IOrderRepository orderRepository)
+    : Endpoint<ListActiveOrdersRequest, ListActiveOrdersResponse>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders/active";
+
+    public override void Configure()
+    {
+        Get(Route);
+        // TODO (US-FP-039): require staff role once hub/endpoint authorization is wired.
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<ListActiveOrdersRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "List active orders for a shop (kitchen display)";
+            s.Description =
+                "Returns the orders whose status is not terminal in the shop's lifecycle, " +
+                "sorted by creation time ascending. Used by the kitchen display screen.";
+            s.Response<ListActiveOrdersResponse>(200, "Active orders retrieved successfully.");
+        });
+    }
+
+    public override async Task HandleAsync(ListActiveOrdersRequest req, CancellationToken ct)
+    {
+        var orders = await orderRepository.GetActiveByShopAsync(req.ShopId, ct);
+
+        var response = new ListActiveOrdersResponse(
+            orders.Select(OrderTrackingMapper.MapOrder).ToList().AsReadOnly());
+
+        await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
@@ -18,6 +18,7 @@ internal static class OrderTrackingMapper
             order.ShopId,
             order.BrandSlug,
             order.OrderType.ToString(),
+            order.PaymentMethod.ToString(),
             order.StatusName,
             order.CustomerName,
             order.Items

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
@@ -26,4 +26,12 @@ public interface IOrderRepository
     /// Used to guard against race-condition duplicate order numbers.
     /// </summary>
     Task<bool> OrderNumberExistsAsync(Guid shopId, string orderNumber, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the active orders for a shop — those whose status is not a terminal
+    /// status in the shop's <c>OrderLifecycleConfig</c> — ordered by <c>CreatedAt</c>
+    /// ascending. Items and selected modifiers are included so kitchen-side callers
+    /// can render line details without a second round-trip.
+    /// </summary>
+    Task<IReadOnlyList<Order>> GetActiveByShopAsync(Guid shopId, CancellationToken cancellationToken = default);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
@@ -76,4 +76,27 @@ public sealed class OrderRepository(BrandDbContext dbContext, IMessageBus messag
         CancellationToken cancellationToken = default)
         => await dbContext.Orders
             .AnyAsync(o => o.ShopId == shopId && o.OrderNumber == orderNumber, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<Order>> GetActiveByShopAsync(
+        Guid shopId,
+        CancellationToken cancellationToken = default)
+    {
+        // Orders only store the status name (denormalised); terminal flag lives on
+        // OrderStatus inside the shop's lifecycle config. Materialize the small list
+        // of terminal names first, then filter orders by NOT IN that set.
+        var terminalStatusNames = await dbContext.OrderLifecycleConfigs
+            .Where(c => c.ShopId == shopId)
+            .SelectMany(c => c.Statuses)
+            .Where(s => s.IsTerminal)
+            .Select(s => s.Name)
+            .ToListAsync(cancellationToken);
+
+        return await dbContext.Orders
+            .Include(o => o.Items)
+            .ThenInclude(i => i.SelectedModifiers)
+            .Where(o => o.ShopId == shopId && !terminalStatusNames.Contains(o.StatusName))
+            .OrderBy(o => o.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs
@@ -1,0 +1,243 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Application.Products;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Infrastructure.Persistence;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Orders;
+
+/// <summary>
+/// Integration tests for GET /api/brands/{brandSlug}/shops/{shopId}/orders/active —
+/// the kitchen display endpoint (US-FP-027).
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class ListActiveOrdersTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string ActiveOrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders/active";
+
+    private static string OrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders";
+
+    private static string ShopsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/shops";
+
+    private static string ProductsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/products";
+
+    private static string OrderLifecycleUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+
+    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            Name = $"Test Shop {Guid.NewGuid().ToString("N")[..8]}",
+            Slug = $"shop-{Guid.NewGuid().ToString("N")[..8]}",
+            Address = new
+            {
+                Street = "Frietstraat",
+                Number = "1",
+                City = "Brussel",
+                PostalCode = "1000",
+                Country = "BE"
+            },
+            ContactEmail = "shop@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var response = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var shop = await response.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+
+        // Trigger default lifecycle creation (lazy-initialised on first GET)
+        await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
+
+        return shop.Id;
+    }
+
+    private async Task<Guid> CreateProductAsync(HttpClient client, string brandSlug, string name)
+    {
+        var request = new
+        {
+            BasePrice = 3.00m,
+            Translations = new[] { new { LanguageCode = "nl", Name = name, Description = (string?)null } }
+        };
+
+        var response = await client.PostAsJsonAsync(ProductsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var product = await response.Content.ReadFromJsonAsync<ProductResponse>();
+        await Assert.That(product).IsNotNull();
+        return product!.Id;
+    }
+
+    private async Task<OrderResponse> PlaceOrderAsync(
+        HttpClient client,
+        string brandSlug,
+        Guid shopId,
+        Guid productId,
+        string customerName)
+    {
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = customerName,
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brandSlug, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        return order!;
+    }
+
+    /// <summary>
+    /// No equivalent API endpoint exists to update an order's status until US-FP-023.
+    /// For the test we mutate the order's StatusName directly via a fresh BrandDbContext.
+    /// </summary>
+    private async Task MarkOrderStatusAsync(string brandSlug, Guid orderId, string statusName)
+    {
+        var options = new DbContextOptionsBuilder<BrandDbContext>()
+            .UseSqlServer(fixture.GetBrandConnectionString(brandSlug))
+            .Options;
+
+        await using var ctx = new BrandDbContext(options);
+        await ctx.Orders
+            .Where(o => o.Id == orderId)
+            .ExecuteUpdateAsync(s => s.SetProperty(o => o.StatusName, statusName));
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ListActive_NoOrders_ReturnsEmptyList()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+
+        var response = await client.GetAsync(ActiveOrdersUrl(brand, shopId));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ListActiveOrdersResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.Orders.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ListActive_MultipleOrders_ReturnsSortedByCreatedAtAscending()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "Frietje");
+
+        var first = await PlaceOrderAsync(client, brand, shopId, productId, "Alice");
+        // Small delay so CreatedAt values are distinguishable at the second precision
+        await Task.Delay(10);
+        var second = await PlaceOrderAsync(client, brand, shopId, productId, "Bob");
+        await Task.Delay(10);
+        var third = await PlaceOrderAsync(client, brand, shopId, productId, "Charlie");
+
+        var response = await client.GetAsync(ActiveOrdersUrl(brand, shopId));
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListActiveOrdersResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.Orders.Count).IsEqualTo(3);
+        await Assert.That(body.Orders[0].Id).IsEqualTo(first.Id);
+        await Assert.That(body.Orders[1].Id).IsEqualTo(second.Id);
+        await Assert.That(body.Orders[2].Id).IsEqualTo(third.Id);
+    }
+
+    [Test]
+    public async Task ListActive_ExcludesOrdersInTerminalStatuses()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "Frikandel");
+
+        var active = await PlaceOrderAsync(client, brand, shopId, productId, "Active");
+        var completed = await PlaceOrderAsync(client, brand, shopId, productId, "Completed");
+        var delivered = await PlaceOrderAsync(client, brand, shopId, productId, "Delivered");
+
+        // Default lifecycle terminal statuses: "Picked Up" and "Delivered"
+        await MarkOrderStatusAsync(brand, completed.Id, "Picked Up");
+        await MarkOrderStatusAsync(brand, delivered.Id, "Delivered");
+
+        var response = await client.GetAsync(ActiveOrdersUrl(brand, shopId));
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListActiveOrdersResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.Orders.Count).IsEqualTo(1);
+        await Assert.That(body.Orders[0].Id).IsEqualTo(active.Id);
+    }
+
+    [Test]
+    public async Task ListActive_ExcludesOrdersFromOtherShops()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.DeltaSlug;
+        var shopA = await CreateShopAsync(client, brand);
+        var shopB = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "Bicky");
+
+        var inShopA = await PlaceOrderAsync(client, brand, shopA, productId, "ShopA Customer");
+        await PlaceOrderAsync(client, brand, shopB, productId, "ShopB Customer");
+
+        var response = await client.GetAsync(ActiveOrdersUrl(brand, shopA));
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListActiveOrdersResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.Orders.Count).IsEqualTo(1);
+        await Assert.That(body.Orders[0].Id).IsEqualTo(inShopA.Id);
+        await Assert.That(body.Orders[0].ShopId).IsEqualTo(shopA);
+    }
+
+    [Test]
+    public async Task ListActive_IncludesItemDetails()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "Patatje Oorlog");
+
+        await PlaceOrderAsync(client, brand, shopId, productId, "Detail Test");
+
+        var response = await client.GetAsync(ActiveOrdersUrl(brand, shopId));
+        var body = await response.Content.ReadFromJsonAsync<ListActiveOrdersResponse>();
+
+        await Assert.That(body).IsNotNull();
+        var order = body!.Orders.Single(o => o.CustomerName == "Detail Test");
+        await Assert.That(order.Items.Count).IsEqualTo(1);
+        await Assert.That(order.Items[0].ProductName).IsEqualTo("Patatje Oorlog");
+        await Assert.That(order.Items[0].Quantity).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ListActive_NonExistentBrand_Returns404()
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync(
+            $"/api/brands/non-existent-brand/shops/{Guid.NewGuid()}/orders/active");
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+}

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -58,6 +58,14 @@ export interface OrderResponse {
   totalGross: number;
   createdAt: string;
   paymentMethod: string;
+  // Forward-compatibility — server only sends these once the corresponding stories ship
+  // (US-FP-024 for tableNumber; scheduled-time-slot orders are not yet on any story).
+  tableNumber?: string | null;
+  timeSlot?: string | null;
+}
+
+export interface ListActiveOrdersResponse {
+  orders: OrderResponse[];
 }
 
 // ---------------------------------------------------------------------------
@@ -139,4 +147,10 @@ export const ordersApi = {
         `/brands/${brandSlug}/shops/${shopId}/orders/number/${orderNumber}`,
       )
       .then((r) => r.data),
+
+  /** List active (non-terminal) orders for a shop — backs the kitchen display (US-FP-027). */
+  listActive: (brandSlug: string, shopId: string): Promise<OrderResponse[]> =>
+    apiClient
+      .get<ListActiveOrdersResponse>(`/brands/${brandSlug}/shops/${shopId}/orders/active`)
+      .then((r) => r.data.orders),
 };

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -1,0 +1,148 @@
+import { useTranslation } from 'react-i18next';
+import type { OrderResponse, OrderType } from '@api/orders';
+
+interface KitchenOrderCardProps {
+  order: OrderResponse;
+}
+
+const orderTypeColor: Record<OrderType, string> = {
+  Pickup: '#2563eb',
+  EatIn: '#9333ea',
+  Delivery: '#059669',
+};
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return new Intl.DateTimeFormat('nl-BE', { hour: '2-digit', minute: '2-digit' }).format(d);
+}
+
+function formatRelative(iso: string, now: number): string {
+  const elapsedMs = now - new Date(iso).getTime();
+  const minutes = Math.max(0, Math.floor(elapsedMs / 60_000));
+  if (minutes < 1) return '<1m';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+export function KitchenOrderCard({ order }: KitchenOrderCardProps) {
+  const { t } = useTranslation('common');
+  const typeLabel = t(`pos.kitchen.orderType.${order.orderType}`);
+  const typeColor = orderTypeColor[order.orderType];
+  // Capturing now once at render keeps re-renders deterministic; the page itself
+  // re-renders on every SignalR invalidation, so the relative time stays fresh enough.
+  const now = Date.now();
+
+  return (
+    <article
+      data-testid="kitchen-order-card"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+        padding: '1rem',
+        background: '#ffffff',
+        borderRadius: '0.75rem',
+        border: '1px solid #e5e7eb',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+        minHeight: '12rem',
+      }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          gap: '0.5rem',
+        }}
+      >
+        <h2 style={{ fontSize: '1.75rem', fontWeight: 800, margin: 0 }}>#{order.orderNumber}</h2>
+        <div style={{ fontSize: '0.875rem', color: '#6b7280', textAlign: 'right' }}>
+          <div style={{ fontWeight: 600 }}>{formatRelative(order.createdAt, now)}</div>
+          <div>{formatTime(order.createdAt)}</div>
+        </div>
+      </header>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', alignItems: 'center' }}>
+        <span
+          style={{
+            display: 'inline-block',
+            padding: '0.25rem 0.625rem',
+            background: typeColor,
+            color: '#ffffff',
+            borderRadius: '999px',
+            fontSize: '0.8125rem',
+            fontWeight: 700,
+          }}
+        >
+          {typeLabel}
+        </span>
+        {order.tableNumber != null && order.tableNumber.length > 0 && (
+          <span
+            data-testid="kitchen-order-table"
+            style={{
+              padding: '0.25rem 0.625rem',
+              background: '#fef3c7',
+              color: '#92400e',
+              borderRadius: '999px',
+              fontSize: '0.8125rem',
+              fontWeight: 700,
+            }}
+          >
+            {t('pos.kitchen.table', { number: order.tableNumber })}
+          </span>
+        )}
+        {order.timeSlot != null && order.timeSlot.length > 0 && (
+          <span
+            data-testid="kitchen-order-timeslot"
+            style={{
+              padding: '0.25rem 0.625rem',
+              background: '#e0e7ff',
+              color: '#3730a3',
+              borderRadius: '999px',
+              fontSize: '0.8125rem',
+              fontWeight: 700,
+            }}
+          >
+            {t('pos.kitchen.timeSlot', { value: order.timeSlot })}
+          </span>
+        )}
+        {order.customerName != null && order.customerName.length > 0 && (
+          <span style={{ fontSize: '0.875rem', color: '#374151' }}>
+            {t('pos.kitchen.customer', { name: order.customerName })}
+          </span>
+        )}
+      </div>
+
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: '0.375rem' }}>
+        {order.items.map((item, idx) => (
+          <li key={`${order.id}-${item.productId}-${idx}`}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5rem' }}>
+              <span style={{ fontWeight: 700, fontSize: '1rem', minWidth: '2rem' }}>
+                {item.quantity}×
+              </span>
+              <span style={{ fontSize: '1rem' }}>{item.productName}</span>
+            </div>
+            {item.selectedModifiers.length > 0 && (
+              <ul
+                style={{
+                  listStyle: 'none',
+                  margin: '0.125rem 0 0 2.5rem',
+                  padding: 0,
+                  display: 'grid',
+                  gap: '0.125rem',
+                }}
+              >
+                {item.selectedModifiers.map((mod) => (
+                  <li key={mod.modifierId} style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+                    + {mod.modifierName}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/frontend/src/features/pos/hooks/__tests__/useActiveOrders.test.ts
+++ b/src/frontend/src/features/pos/hooks/__tests__/useActiveOrders.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+
+import { server } from '../../../../test/msw/server';
+
+// Capture the SignalR callback so the test can fire it manually.
+let capturedOnStatusChange: ((u: unknown) => void) | undefined;
+vi.mock('../../../../api/useOrderUpdates', () => ({
+  useOrderUpdates: (opts: { onStatusChange?: (u: unknown) => void }) => {
+    capturedOnStatusChange = opts.onStatusChange;
+    return { status: 'connected' as const };
+  },
+}));
+
+import { useActiveOrders } from '../useActiveOrders';
+
+const brandSlug = 'frietjes';
+const shopId = '00000000-0000-0000-0000-000000000099';
+
+function makeWrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+describe('useActiveOrders', () => {
+  beforeEach(() => {
+    capturedOnStatusChange = undefined;
+  });
+
+  it('invalidates the active-orders query when a status change event fires', async () => {
+    let callCount = 0;
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () => {
+        callCount += 1;
+        return HttpResponse.json({ orders: [] });
+      }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useActiveOrders(brandSlug, shopId), {
+      wrapper: makeWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(callCount).toBe(1);
+    expect(capturedOnStatusChange).toBeDefined();
+
+    await act(async () => {
+      capturedOnStatusChange!({ orderId: 'x', newStatus: 'Preparing' });
+    });
+
+    await waitFor(() => expect(callCount).toBe(2));
+  });
+
+  it('does not run the query when brandSlug or shopId is empty', async () => {
+    let callCount = 0;
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () => {
+        callCount += 1;
+        return HttpResponse.json({ orders: [] });
+      }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    renderHook(() => useActiveOrders('', shopId), {
+      wrapper: makeWrapper(client),
+    });
+    // Give the query a tick — it should still not fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(callCount).toBe(0);
+  });
+});

--- a/src/frontend/src/features/pos/hooks/useActiveOrders.ts
+++ b/src/frontend/src/features/pos/hooks/useActiveOrders.ts
@@ -1,0 +1,48 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ordersApi, type OrderResponse } from '@api/orders';
+import { useOrderUpdates } from '@api/useOrderUpdates';
+import type { ConnectionStatus } from '@api/useSignalR';
+
+export const activeOrdersQueryKey = (brandSlug: string, shopId: string) =>
+  ['orders', 'active', brandSlug, shopId] as const;
+
+/**
+ * Subscribes to the shop's active orders for the kitchen display.
+ *
+ * Real-time invalidation: any `OrderStatusChanged` event for this shop refetches the
+ * list — covers new orders, status changes, and completions in a single code path.
+ * The list is small (active orders for one shop) so the refetch cost is trivial.
+ */
+export function useActiveOrders(brandSlug: string, shopId: string): {
+  orders: OrderResponse[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  connectionStatus: ConnectionStatus;
+} {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<OrderResponse[]>({
+    queryKey: activeOrdersQueryKey(brandSlug, shopId),
+    queryFn: () => ordersApi.listActive(brandSlug, shopId),
+    enabled: brandSlug.length > 0 && shopId.length > 0,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+  });
+
+  const hasShop = brandSlug.length > 0 && shopId.length > 0;
+  const { status: connectionStatus } = useOrderUpdates({
+    ...(hasShop ? { shopGroup: { brandSlug, shopId } } : {}),
+    onStatusChange: () => {
+      void queryClient.invalidateQueries({
+        queryKey: activeOrdersQueryKey(brandSlug, shopId),
+      });
+    },
+  });
+
+  return {
+    orders: query.data,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    connectionStatus,
+  };
+}

--- a/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
+++ b/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
@@ -1,0 +1,124 @@
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useActiveOrders } from '../hooks/useActiveOrders';
+import { KitchenOrderCard } from '../components/KitchenOrderCard';
+import type { ConnectionStatus } from '@api/useSignalR';
+
+const connectionColor: Record<ConnectionStatus, string> = {
+  connected: '#16a34a',
+  connecting: '#d97706',
+  reconnecting: '#d97706',
+  disconnected: '#dc2626',
+};
+
+export function KitchenDisplay() {
+  const { t } = useTranslation('common');
+  const { brandSlug, shopId } = useParams<{
+    brandSlug: string;
+    lang: string;
+    shopId: string;
+  }>();
+
+  const resolvedBrand = brandSlug ?? '';
+  const resolvedShop = shopId ?? '';
+
+  const { orders, isLoading, isError, connectionStatus } = useActiveOrders(
+    resolvedBrand,
+    resolvedShop,
+  );
+
+  return (
+    <main
+      style={{
+        maxWidth: '90rem',
+        margin: '0 auto',
+        padding: '1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+      }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: '1rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <h1 style={{ fontSize: '1.75rem', fontWeight: 800, margin: 0 }}>
+          {t('pos.kitchen.title')}
+        </h1>
+        <div
+          data-testid="kitchen-connection-status"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            padding: '0.375rem 0.75rem',
+            background: '#f3f4f6',
+            borderRadius: '999px',
+            fontSize: '0.8125rem',
+            fontWeight: 600,
+            color: '#374151',
+          }}
+        >
+          <span
+            style={{
+              width: '0.625rem',
+              height: '0.625rem',
+              borderRadius: '50%',
+              background: connectionColor[connectionStatus],
+              display: 'inline-block',
+            }}
+          />
+          {t(`pos.kitchen.connection.${connectionStatus}`)}
+        </div>
+      </header>
+
+      {isLoading && (
+        <p style={{ color: '#6b7280', margin: 0 }} data-testid="kitchen-loading">
+          {t('loading')}
+        </p>
+      )}
+
+      {isError && (
+        <p style={{ color: '#dc2626', margin: 0 }} data-testid="kitchen-error">
+          {t('error')}
+        </p>
+      )}
+
+      {!isLoading && !isError && orders !== undefined && orders.length === 0 && (
+        <p
+          style={{
+            color: '#6b7280',
+            margin: 0,
+            padding: '2rem',
+            textAlign: 'center',
+            background: '#f9fafb',
+            borderRadius: '0.75rem',
+          }}
+          data-testid="kitchen-empty"
+        >
+          {t('pos.kitchen.empty')}
+        </p>
+      )}
+
+      {orders !== undefined && orders.length > 0 && (
+        <section
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(18rem, 1fr))',
+            gap: '0.75rem',
+          }}
+          data-testid="kitchen-order-grid"
+        >
+          {orders.map((order) => (
+            <KitchenOrderCard key={order.id} order={order} />
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
+++ b/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+
+import { renderWithProviders } from '../../../../test/testUtils';
+import { server } from '../../../../test/msw/server';
+import '../../../../i18n/config';
+
+// The SignalR hub is exercised end-to-end elsewhere — for the kitchen page we mock
+// it so the test never touches a real WebSocket. Keep this mock at module-top so it
+// applies before the component imports it.
+vi.mock('../../../../api/useOrderUpdates', () => ({
+  useOrderUpdates: () => ({ status: 'connected' as const }),
+}));
+
+import { KitchenDisplay } from '../KitchenDisplay';
+
+const brandSlug = 'frietjes';
+const shopId = '00000000-0000-0000-0000-000000000001';
+
+function makeOrder(overrides: Partial<{
+  id: string;
+  orderNumber: string;
+  orderType: 'Pickup' | 'EatIn' | 'Delivery';
+  tableNumber: string | null;
+  customerName: string | null;
+  items: Array<{ productName: string; quantity: number; modifiers: Array<{ name: string }> }>;
+}>) {
+  const items = overrides.items ?? [
+    { productName: 'Frietje', quantity: 1, modifiers: [] },
+  ];
+  return {
+    id: overrides.id ?? 'order-1',
+    orderNumber: overrides.orderNumber ?? '0001',
+    shopId,
+    brandSlug,
+    orderType: overrides.orderType ?? 'Pickup',
+    statusName: 'Placed',
+    customerName: overrides.customerName ?? null,
+    items: items.map((it, idx) => ({
+      productId: `prod-${idx}`,
+      productName: it.productName,
+      quantity: it.quantity,
+      unitGrossPrice: 3.5,
+      unitNetPrice: 3.3,
+      unitVatAmount: 0.2,
+      lineTotal: 3.5 * it.quantity,
+      selectedModifiers: it.modifiers.map((m, mIdx) => ({
+        modifierId: `mod-${idx}-${mIdx}`,
+        modifierName: m.name,
+        priceAdjustment: 0,
+      })),
+    })),
+    vatRatePercent: 6,
+    subtotalGross: 3.5,
+    totalVatAmount: 0.2,
+    totalNet: 3.3,
+    totalGross: 3.5,
+    createdAt: '2026-05-13T12:00:00Z',
+    paymentMethod: 'CashAtPickup',
+    tableNumber: overrides.tableNumber ?? null,
+  };
+}
+
+function renderPage() {
+  return renderWithProviders(
+    <Routes>
+      <Route
+        path="/:brandSlug/:lang/pos/shops/:shopId/kitchen"
+        element={<KitchenDisplay />}
+      />
+    </Routes>,
+    { initialEntries: [`/${brandSlug}/nl/pos/shops/${shopId}/kitchen`] },
+  );
+}
+
+describe('KitchenDisplay', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({ orders: [] }),
+      ),
+    );
+  });
+
+  it('shows the empty state when there are no active orders', async () => {
+    renderPage();
+    expect(await screen.findByTestId('kitchen-empty')).toBeInTheDocument();
+  });
+
+  it('renders order cards in the order returned by the API', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({
+          orders: [
+            makeOrder({ id: 'a', orderNumber: '0001', customerName: 'Alice' }),
+            makeOrder({ id: 'b', orderNumber: '0002', customerName: 'Bob' }),
+            makeOrder({ id: 'c', orderNumber: '0003', customerName: 'Carla' }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const cards = await screen.findAllByTestId('kitchen-order-card');
+    expect(cards).toHaveLength(3);
+    expect(within(cards[0]!).getByText('#0001')).toBeInTheDocument();
+    expect(within(cards[1]!).getByText('#0002')).toBeInTheDocument();
+    expect(within(cards[2]!).getByText('#0003')).toBeInTheDocument();
+  });
+
+  it('renders each item with its modifiers', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({
+          orders: [
+            makeOrder({
+              id: 'a',
+              orderNumber: '0010',
+              items: [
+                {
+                  productName: 'Frietje Speciaal',
+                  quantity: 2,
+                  modifiers: [{ name: 'Extra mayo' }, { name: 'Geen ui' }],
+                },
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Frietje Speciaal')).toBeInTheDocument();
+    expect(screen.getByText('2×')).toBeInTheDocument();
+    expect(screen.getByText('+ Extra mayo')).toBeInTheDocument();
+    expect(screen.getByText('+ Geen ui')).toBeInTheDocument();
+  });
+
+  it('renders the table number badge only when present', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({
+          orders: [
+            makeOrder({ id: 'a', orderNumber: '0021', orderType: 'EatIn', tableNumber: '5' }),
+            makeOrder({ id: 'b', orderNumber: '0022', orderType: 'Pickup', tableNumber: null }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId('kitchen-order-card')).toHaveLength(2),
+    );
+
+    const tableBadges = screen.queryAllByTestId('kitchen-order-table');
+    expect(tableBadges).toHaveLength(1);
+    expect(tableBadges[0]).toHaveTextContent('5');
+  });
+
+  it('renders the connection status indicator', async () => {
+    renderPage();
+    expect(await screen.findByTestId('kitchen-connection-status')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -85,7 +85,25 @@
     }
   },
   "pos": {
-    "description": "Kassensystem für den Laden."
+    "description": "Kassensystem für den Laden.",
+    "kitchen": {
+      "title": "Küchendisplay",
+      "empty": "Keine aktiven Bestellungen.",
+      "customer": "Kunde: {{name}}",
+      "table": "Tisch {{number}}",
+      "timeSlot": "Zeitfenster: {{value}}",
+      "orderType": {
+        "Pickup": "Abholung",
+        "EatIn": "Vor Ort",
+        "Delivery": "Lieferung"
+      },
+      "connection": {
+        "connected": "Live",
+        "connecting": "Verbinden…",
+        "reconnecting": "Wiederverbinden…",
+        "disconnected": "Offline"
+      }
+    }
   },
   "allergens": {
     "Gluten": "Gluten",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -85,7 +85,25 @@
     }
   },
   "pos": {
-    "description": "Système de caisse en magasin."
+    "description": "Système de caisse en magasin.",
+    "kitchen": {
+      "title": "Écran de cuisine",
+      "empty": "Aucune commande active.",
+      "customer": "Client : {{name}}",
+      "table": "Table {{number}}",
+      "timeSlot": "Créneau : {{value}}",
+      "orderType": {
+        "Pickup": "À emporter",
+        "EatIn": "Sur place",
+        "Delivery": "Livraison"
+      },
+      "connection": {
+        "connected": "En direct",
+        "connecting": "Connexion…",
+        "reconnecting": "Reconnexion…",
+        "disconnected": "Hors ligne"
+      }
+    }
   },
   "allergens": {
     "Gluten": "Gluten",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -85,7 +85,25 @@
     }
   },
   "pos": {
-    "description": "Kassasysteem voor in de winkel."
+    "description": "Kassasysteem voor in de winkel.",
+    "kitchen": {
+      "title": "Keukendisplay",
+      "empty": "Geen actieve bestellingen.",
+      "customer": "Klant: {{name}}",
+      "table": "Tafel {{number}}",
+      "timeSlot": "Tijdslot: {{value}}",
+      "orderType": {
+        "Pickup": "Afhalen",
+        "EatIn": "Ter plaatse",
+        "Delivery": "Bezorging"
+      },
+      "connection": {
+        "connected": "Live",
+        "connecting": "Verbinden…",
+        "reconnecting": "Opnieuw verbinden…",
+        "disconnected": "Verbinding verbroken"
+      }
+    }
   },
   "allergens": {
     "Gluten": "Gluten",

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -18,6 +18,10 @@ const LazyPosDashboard = lazy(() =>
   import('@features/pos/pages/Dashboard').then((m) => ({ default: m.PosDashboard })),
 );
 
+const LazyKitchenDisplay = lazy(() =>
+  import('@features/pos/pages/KitchenDisplay').then((m) => ({ default: m.KitchenDisplay })),
+);
+
 /**
  * Resolves the initial locale for the root redirect.
  * Priority: explicit user preference (localStorage) → browser language → 'nl' (fallback).
@@ -76,6 +80,16 @@ export const router = createBrowserRouter([
             element: (
               <SuspenseWrapper>
                 <LazyPosDashboard />
+              </SuspenseWrapper>
+            ),
+          },
+          {
+            // Kitchen display screen (US-FP-027) — shop-scoped because each store
+            // has its own pass and the staff member is at a single station.
+            path: 'shops/:shopId/kitchen',
+            element: (
+              <SuspenseWrapper>
+                <LazyKitchenDisplay />
               </SuspenseWrapper>
             ),
           },


### PR DESCRIPTION
## Summary
- New `GET /api/brands/{slug}/shops/{shopId}/orders/active` endpoint returns the active (non-terminal) orders for a shop, sorted by creation time, with items + modifiers included. Uses the shop's `OrderLifecycleConfig` terminal flag to decide what counts as active.
- New kitchen display page at `/:brand/:lang/pos/shops/:shopId/kitchen` (gated by the existing POS `RequireAuth` for kitchen-staff / counter-staff / floor-staff / shop-manager). `useActiveOrders` hook combines TanStack Query with the existing SignalR shop group — every `OrderStatusChanged` event invalidates the cache, so new orders appear and completed orders disappear without a refresh.
- Order cards show order number, age, type, customer, and items with modifiers. `tableNumber` and `timeSlot` slots are rendered conditionally so US-FP-024 and future scheduled-order work drop straight in with no UI churn.
- i18n keys added for NL / FR / DE.
- Drive-by: fixes a pre-existing build break in `OrderTrackingMapper` that was missing the `PaymentMethod` argument since #119 added it to `OrderResponse`.

## Out of scope (deferred)
- Table number on the `Order` aggregate → US-FP-024
- Scheduled / time-slot orders → no story yet
- Bumping orders to next status from the kitchen display → US-FP-023
- Hub / endpoint authorization beyond `AllowAnonymous` → US-FP-039

## Test plan
- [x] `dotnet build TheMillionthFoodOrderApp.slnx` — 0 errors
- [x] `dotnet run -c Release --treenode-filter "/*/*/ListActiveOrdersTests/*"` — 6/6 pass (real SQL Server via Testcontainers)
- [x] `pnpm build` — type-check + production build green
- [x] `pnpm test` — 225/225 pass, including new `KitchenDisplay.test.tsx` (5) and `useActiveOrders.test.ts` (2)
- [ ] Manual: start backend (`dotnet run --project AppHost`) + frontend (`pnpm dev`), sign in as `kitchen-staff@frietjes`, navigate to `/frietjes/nl/pos/shops/{shopId}/kitchen`, place an order from a second tab as a customer, confirm the new order appears without refresh, then transition it to a terminal status and confirm it disappears

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)