### PR TITLE
feat: US-FP-018 — Place an in-store order (counter staff)

### DIFF
--- a/.agents/plans/us-fp-018-place-instore-order.md
+++ b/.agents/plans/us-fp-018-place-instore-order.md
@@ -1,0 +1,302 @@
+# US-FP-018 — Place an in-store order (counter staff)
+
+GitHub issue: [#18](https://github.com/OoyeM/TheMillionthFoodOrderApp/issues/18)
+Branch: `feat/us-fp-18-usfp018-place-an-instore-order-counter-s` (already checked out)
+Prereqs: US-FP-016 ✅ (place online order), US-FP-022 ✅ (order lifecycle), US-FP-027 ✅ (kitchen display), US-FP-068 ✅ (SignalR), US-FP-058 ✅ (mock payments)
+
+## 1. Summary
+
+Build a touch-friendly POS screen at `/:brandSlug/:lang/pos/shops/:shopId/order` that lets counter staff:
+
+- Browse the brand's menu (categories + product tiles) with large, finger-sized buttons sized for a tablet in landscape.
+- Add products, including modifier selections and combos, to an in-memory ticket.
+- Pick order type (Pickup / Eat-In) and, when Eat-In, enter a table number.
+- Submit the order to the existing `POST /api/brands/{slug}/shops/{shopId}/orders` endpoint with `PaymentMethod=CashAtPickup` ("pay at pickup"). The order flows through the same `Order.Create` → `OrderCreatedEvent` → Wolverine → `OrderCreatedHandler` → SignalR pipeline, so the existing Kitchen Display (US-FP-027) picks it up automatically.
+
+**Architecture approach — reuse, don't fork.** Almost all backend plumbing already exists. The only backend change required by US-FP-018 itself is **adding `TableNumber` to the `Order` aggregate** (already declared on the frontend `OrderResponse` as `tableNumber?` and already rendered by `KitchenOrderCard`). The frontend work is the substantive deliverable: a new POS feature module mirroring the storefront menu + cart pattern but optimised for touch.
+
+**Scope decisions (recommended — surface to user):**
+
+1. **Eat-in / table number**: implement **option (a)** — capture `tableNumber` as part of this story because AC explicitly requires it. The field becomes a permanent column on `Order` (nullable, only meaningful when `OrderType=EatIn`). US-FP-024 will later add the customer-facing equivalent and pair this with the US-FP-066 enable/disable flag; until then, the POS always allows Eat-In.
+2. **Ticket printer**: explicitly **out of scope**. The AC mentions it; we satisfy that AC by re-using the same `OrderCreatedEvent` Wolverine pipe the kitchen display already listens on. US-FP-028 will plug a printer handler into the same event later — no change to this story.
+3. **Payment**: every POS order is created with `PaymentMethod = CashAtPickup` for both Pickup and Eat-In. US-FP-058 mock-payment screen is not invoked. This matches the AC ("pickup = pay at pickup") and treats Eat-In the same way (settle in person). Card/Bancontact at counter is a separate concern.
+4. **Auth**: route already guarded with `RequireAuth roles={['counter-staff', 'floor-staff', 'kitchen-staff', 'shop-manager']}`. Mock auth has a `counter-staff` persona. Real Keycloak staff login (US-FP-039 ⬜) is *not* blocking — mock-auth is sufficient to demonstrate this story end-to-end, and the BFF endpoint already accepts an authenticated counter-staff bearer token (the endpoint itself is `AllowAnonymous` per US-FP-016 conventions, with auth gating deferred to US-FP-039). Surface as a risk.
+5. **Shop selection**: the POS user lands on a dashboard and must pick a shop before ordering. We can either (a) read `brandSlug + shopId` from the staff user's `BrandUserRole` assignment (once US-FP-039 ships) or (b) for this story show a simple shop picker on the `/pos` dashboard. Recommend (b) for now: a `ShopPicker` page listing the brand's shops, persisting the choice to `localStorage` (key `pos:active-shop:{brandSlug}`).
+
+## 2. Backend changes
+
+### 2.1 Domain — add `TableNumber` to `Order`
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs`
+
+- Add nullable `public string? TableNumber { get; private set; }`. Use `string` not `int` to allow alphanumeric labels (e.g. "T-12", "Bar-3"); matches FE typing `tableNumber: string | null`.
+- Extend `Order.Create(...)` factory with a `string? tableNumber` parameter (place after `customerName`).
+- Add an invariant: when `orderType == OrderType.EatIn`, `tableNumber` may be null OR non-empty (do **not** require it at the domain level — the API/validation layer will gate this. Rationale: US-FP-024 + US-FP-066 will later allow eat-in without a table when the shop opts out, and we want to model that without breaking the aggregate).
+- Optionally trim and length-cap in the factory: `tableNumber?.Trim()` with max 20 chars (throw `ArgumentException` if too long).
+
+### 2.2 Domain — extend `OrderCreatedEvent`
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderCreatedEvent.cs`
+
+- Add `string? TableNumber` to the record.
+- Update `Order.Create` to pass `tableNumber` when raising the event. This isn't strictly required (the handler currently only forwards status), but it's cheap and lets the future printer handler render the table number without a re-fetch.
+
+### 2.3 Infrastructure — EF configuration + migration
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs`
+
+```csharp
+builder.Property(o => o.TableNumber).HasMaxLength(20);  // nullable, no IsRequired
+```
+
+**New migration:** `dotnet ef migrations add AddOrderTableNumber --context BrandDbContext --output-dir Persistence/Migrations/Brand` from inside `src/backend/TheMillionthFoodOrderApp.Infrastructure` with the standard startup-project flag. Generates `*_AddOrderTableNumber.cs` adding `TableNumber NVARCHAR(20) NULL` to the `Orders` table.
+
+### 2.4 Application — DTO and request plumbing
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs`
+
+- Add `string? TableNumber` to the record (after `CustomerName`).
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs`
+
+- Add `string? TableNumber` to the response record. **Frontend already expects this field as `tableNumber`** — wiring it through completes the contract.
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs`
+
+- Pass `request.TableNumber` into `Order.Create(...)`.
+- Include `order.TableNumber` in `MapToResponse(...)`.
+- No new business rule: do **not** require eat-in to have a table number at this layer (deferred to US-FP-066).
+
+### 2.5 API — endpoint, validation, response mapping
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs`
+
+- Add `string? TableNumber` to `CreateOrderApiRequest`.
+- Add to `CreateOrderRequestValidator`:
+  ```csharp
+  RuleFor(x => x.TableNumber).MaximumLength(20).When(x => x.TableNumber is not null);
+  // The story AC says table number is required for eat-in — apply at the API layer:
+  RuleFor(x => x.TableNumber)
+      .NotEmpty()
+      .When(x => string.Equals(x.OrderType, "EatIn", StringComparison.OrdinalIgnoreCase))
+      .WithMessage("TableNumber is required for eat-in orders.");
+  ```
+- Pass `req.TableNumber` to the new `CreateOrderRequest` constructor.
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs`
+
+- Map `Order.TableNumber` → `OrderResponse.TableNumber` so the kitchen display's `GET /orders/active` response and the tracking response include it for newly placed POS orders.
+
+### 2.6 Integration tests
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs` — extend existing class.
+
+Add scenarios:
+- `PlaceOrder_EatIn_WithTableNumber_PersistsAndReturnsIt` — POST with `OrderType=EatIn`, `TableNumber="T-12"`; assert 201 + response includes `tableNumber == "T-12"`.
+- `PlaceOrder_EatIn_WithoutTableNumber_Returns400` — POST with `OrderType=EatIn`, no table number; assert 400.
+- `PlaceOrder_Pickup_WithoutTableNumber_Returns201` — table number not required for pickup.
+- `PlaceOrder_EatIn_TableNumberTooLong_Returns400` — 21 chars.
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs` — extend to assert `tableNumber` is non-null in the response when an eat-in order with a table number was placed (proves the kitchen display will see it).
+
+These follow the **TUnit** pattern (`[Test]`, `await Assert.That(...)`, `[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]`) per `src/backend/CLAUDE.md`.
+
+### 2.7 Notification handler — no change required
+
+`OrderCreatedHandler` already broadcasts every new order to the shop's SignalR group via the existing `status-changed` pipeline. POS orders use the same `OrderService.CreateOrderAsync` path, so the kitchen display will receive them with zero new code. This satisfies AC "Order is submitted and triggers the same fulfillment flow as online orders".
+
+## 3. Frontend changes
+
+All changes land under `src/frontend/src/features/pos/`. The pattern mirrors the storefront module but is purpose-built for touch — tile-grid layout, large buttons, no over-the-cart drawer (left/right two-pane layout fits a 10" tablet in landscape).
+
+### 3.1 Routes — POS shell + new screens
+
+**File:** `src/frontend/src/router.tsx` — replace the inline `posRoutes` with the module's export and add the new routes:
+
+```tsx
+import { posRoutes } from '@features/pos/routes';
+// ...
+{
+  path: 'pos',
+  element: (
+    <RequireAuth roles={['counter-staff', 'floor-staff', 'kitchen-staff', 'shop-manager']}>
+      <AppVariantLayout variant="pos" />
+    </RequireAuth>
+  ),
+  children: posRoutes,
+}
+```
+
+**File:** `src/frontend/src/features/pos/routes.tsx` — replace the placeholder. Wire:
+- `index` → `PosDashboard` (now a shop picker)
+- `shops/:shopId/kitchen` → `KitchenDisplay` (existing, just relocated from `router.tsx` into the feature module so all POS routes live together)
+- `shops/:shopId/order` → `NewOrderPage` (new, the main deliverable)
+- `shops/:shopId/order/confirmation/:orderId` → `OrderPlacedPage` (new, terse confirmation tuned for staff)
+
+Lazy-load via React.lazy where appropriate, following the existing kitchen-display pattern.
+
+### 3.2 Dashboard / shop picker
+
+**File:** `src/frontend/src/features/pos/pages/Dashboard.tsx` — replace placeholder with a shop picker.
+
+- Use `shopsApi.list(brandSlug)` (already in `src/frontend/src/api/shops.ts`).
+- Render shop cards as full-width touch tiles ("Open ordering" + "Open kitchen display" buttons per shop).
+- Persist the last-used shop in `localStorage` (`pos:last-shop:{brandSlug}`) and auto-redirect to `/pos/shops/:shopId/order` on next visit.
+
+### 3.3 New-order page (the heart of this story)
+
+**File:** `src/frontend/src/features/pos/pages/NewOrderPage.tsx`
+
+Two-pane layout (CSS grid `grid-template-columns: 1fr 22rem`):
+
+- **Left pane — menu**:
+  - Category tabs across the top (horizontal scroll if many).
+  - Product grid: 3–4 columns of `ProductTile` components sized ≥ 80×80mm equivalent (≈ `min-height: 7rem`, `padding: 1.25rem`, `font-size: 1rem`+).
+  - Tap a tile → if product has modifier groups, open `PosModifierModal` (touch-friendly variant of the existing `ModifierModal`); otherwise add directly to the in-memory order.
+  - Reuse `useStorefrontCategories` + `useStorefrontCategoryProducts` from `@features/storefront/hooks/useStorefrontMenu.ts`. Same data, different rendering — no duplication of fetching logic.
+- **Right pane — ticket**:
+  - Live list of items with `+ / –` qty buttons (44px hit targets).
+  - Order-type toggle: large pickup/eat-in segmented control.
+  - Table-number input, conditionally rendered only when EatIn is selected — numeric keyboard hint (`inputMode="numeric"` but `type="text"` to permit "T-12").
+  - Optional customer-name input (matches existing endpoint contract).
+  - Subtotal display.
+  - "Place order" primary button (full-width, 56px tall).
+
+### 3.4 Components
+
+**File:** `src/frontend/src/features/pos/components/ProductTile.tsx`
+- Large square card, product name top, price bottom, optional image. Tap area = entire tile.
+
+**File:** `src/frontend/src/features/pos/components/PosTicket.tsx`
+- Renders the in-memory order: items, modifiers, qty steppers, line totals, subtotal.
+- Receives the order state via props (lift state to `NewOrderPage` to keep the ticket and menu in sync).
+
+**File:** `src/frontend/src/features/pos/components/PosModifierModal.tsx`
+- Touch-friendly modifier picker. May be implemented as a slim wrapper around the existing `ModifierModal` from storefront with `posMode` prop, **or** a fresh component if the storefront modal's styling can't be easily scaled. Decide during execution; recommend wrapper first.
+
+**File:** `src/frontend/src/features/pos/components/OrderTypeSelector.tsx`
+- Segmented control: Pickup / Eat-In. Delivery omitted from POS for now.
+
+### 3.5 In-memory order state
+
+**File:** `src/frontend/src/features/pos/hooks/usePosOrder.ts`
+
+A simple `useReducer` (action types `ADD_ITEM`, `REMOVE_ITEM`, `UPDATE_QUANTITY`, `SET_ORDER_TYPE`, `SET_TABLE_NUMBER`, `SET_CUSTOMER_NAME`, `RESET`). **Not** persisted to localStorage — counter staff move fast and a stale ticket on reload is worse than starting fresh. Different from the storefront `CartContext`, which intentionally persists.
+
+### 3.6 Mutation — create order
+
+**File:** `src/frontend/src/features/pos/hooks/useCreatePosOrder.ts`
+
+Thin wrapper around `ordersApi.create` (existing in `src/frontend/src/api/orders.ts`). On success, reset the ticket and navigate to `OrderPlacedPage`.
+
+**File:** `src/frontend/src/api/orders.ts` — extend `CreateOrderRequest` interface to include `tableNumber?: string | null`. `OrderResponse.tableNumber` already exists.
+
+### 3.7 Confirmation page
+
+**File:** `src/frontend/src/features/pos/pages/OrderPlacedPage.tsx`
+- Massive order number ("# ABC123"), order type, table number (if any), totals.
+- Two big buttons: "New order" → back to `NewOrderPage`; "Print receipt" disabled with tooltip "Coming in US-FP-028".
+- Auto-redirect to new order after 10s.
+
+### 3.8 i18n keys
+
+**Files:** `src/frontend/src/i18n/locales/{nl,fr,de}/common.json` — extend the existing `pos.*` namespace with `pos.dashboard`, `pos.order` (ticket, orderType, tableNumber, customerName, submitError), and `pos.confirmation` groups. Mirror NL across FR and DE.
+
+### 3.9 Tests
+
+- **Component (Vitest):** `ProductTile`, `PosTicket`, `OrderTypeSelector` rendering + interaction tests.
+- **Hook (Vitest):** `usePosOrder` reducer transitions.
+- **Page integration (Vitest + RTL):** `NewOrderPage` — selecting EatIn surfaces the table-number input; submit posts with `tableNumber`.
+- **E2E (Playwright, optional follow-up):** smoke test placing a POS order and seeing it in the kitchen display.
+
+## 4. Auth
+
+- The route is already guarded for staff roles; `MockAuthProvider` exposes a `counter-staff` persona out of the box.
+- Real Keycloak staff login (**US-FP-039**) is **not blocking** this story end-to-end via mock auth, but production sign-in is incomplete. Surface as an open question — the user may want US-FP-039 first.
+- The `POST /orders` endpoint is currently `AllowAnonymous()` (deliberate, per US-FP-016, with a comment pointing to US-FP-039). Don't tighten it in this PR; that's US-FP-039's job.
+
+## 5. Fulfillment flow integration
+
+End-to-end after this story:
+
+1. Counter staff submits → `POST /api/brands/{slug}/shops/{shopId}/orders` with `paymentMethod=CashAtPickup`, `tableNumber` populated when EatIn.
+2. `OrderService.CreateOrderAsync` builds the `Order` aggregate identically to online orders (same VAT logic, same lifecycle opening status, same denormalisation rules, same `ORDER_NUMBER_CONFLICT` retry loop).
+3. `Order.Create` raises `OrderCreatedEvent`. `OrderRepository.SaveChangesAsync` collects domain events, calls `DomainEventDispatcher.PublishAsync(events, messageBus)`.
+4. **Wolverine** routes the event to `OrderCreatedHandler` (Infrastructure/Notifications), which calls `IOrderNotificationService.NotifyOrderStatusChangedAsync` with `previousStatus=""` (signalling a brand-new order).
+5. `SignalROrderNotificationService` pushes to the shop group; `KitchenDisplay` (US-FP-027) is already subscribed and refreshes via `useActiveOrders` → `ordersApi.listActive` → cards rerender with the new POS order.
+6. `KitchenOrderCard` already renders `order.tableNumber` and `order.orderType` badge — once the backend sends `tableNumber` in the active-orders response, eat-in POS orders show the table chip with zero kitchen-display code changes.
+
+Printer integration (US-FP-028) will plug a second handler into the same `OrderCreatedEvent`. No changes needed in this PR.
+
+## 6. Test plan
+
+**Backend (TUnit):**
+- New tests in `PlaceOrderTests.cs` and `ListActiveOrdersTests.cs` (see §2.6).
+- Run all existing order integration tests to confirm no regression.
+
+**Frontend (Vitest):**
+- `pnpm test` in `src/frontend` — new component/hook/page tests pass.
+- `pnpm build` — type-check passes (especially the new `tableNumber` field on `CreateOrderRequest`).
+
+**Manual verification (Aspire up, mock auth):**
+1. `cd src/backend && dotnet run --project TheMillionthFoodOrderApp.AppHost`
+2. `cd src/frontend && pnpm dev`
+3. Visit `http://localhost:5173/bff/login?mock=counter-staff@frietjes`.
+4. Navigate to `/frietjes/nl/pos` → pick a seeded shop.
+5. Tap several products, add modifiers, switch order type to Eat-In, enter `T-12`, submit.
+6. Open `/frietjes/nl/pos/shops/{id}/kitchen` in another tab — the POS order appears in real time with the table-number chip and Eat-In badge.
+7. Open `/frietjes/nl/shops/{id}/menu` (storefront) in a third tab and place an online order — confirm POS-tab kitchen display also sees it (proves both channels share the pipe).
+8. Visit Swagger → `POST /orders` → verify `tableNumber` appears in request and response schemas.
+
+## 7. Open questions / risks
+
+1. **(must decide)** Eat-in scope: implement here vs defer to US-FP-024 + US-FP-066. **Recommend implement here** because the AC is explicit; defer the *enable/disable* and *customer-side* flows.
+2. **(must decide)** Staff login: are we OK relying on mock auth for the demo, with real Keycloak staff login coming in US-FP-039? If not, US-FP-039 should land first.
+3. **(should decide)** Should the POS allow the counter staff to override `customerName` ("Jan", "table 5", etc.) the same way the storefront does? Recommend **yes** — keep the field, optional, same as online.
+4. **(should decide)** Should we surface a "Quick combo / favourites" row at the top of the menu pane for the top-selling products? **Out of scope** for MVP, but worth a follow-up issue.
+5. **Risk — touch testing without a tablet**: AC requires tablet-sized screens. Mitigate by viewport CSS media queries (`@media (min-width: 768px) and (pointer: coarse)`) and a Playwright test pinning the viewport to 1024×768. Manual verification on a real tablet should still be requested from the user.
+6. **Risk — shop selection without staff–shop binding**: until US-FP-032/039 are fully wired, any staff member can pick any shop. Acceptable for MVP; document the gap.
+7. **Risk — `tableNumber` as a string vs int**: keeping it `string?` allows for "T-12" style labels but means the storefront/kitchen display can't sort numerically. Recommend `string?` (matches existing FE typing).
+
+## 8. File-by-file change list
+
+### Backend — modify
+
+- `src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs` — add `TableNumber`, extend `Create` factory.
+- `src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderCreatedEvent.cs` — add `TableNumber`.
+- `src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs` — map `TableNumber` column (NVARCHAR(20) NULL).
+- `src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs` — add `TableNumber`.
+- `src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs` — add `TableNumber`.
+- `src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs` — thread `TableNumber` through factory + mapper.
+- `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs` — request field, validator rule (`NotEmpty` when EatIn), pass-through.
+- `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs` — map `TableNumber` into responses for `GET /orders/{id}` and `GET /orders/active`.
+- `src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs` — new tests.
+- `src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs` — assert `tableNumber` propagation.
+
+### Backend — create
+
+- `src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/{timestamp}_AddOrderTableNumber.cs` (+ Designer + snapshot updates) via `dotnet ef migrations add`.
+
+### Frontend — modify
+
+- `src/frontend/src/router.tsx` — use `posRoutes` from feature module; remove the inline kitchen-display registration (relocated).
+- `src/frontend/src/features/pos/routes.tsx` — full routes object: dashboard, kitchen, new-order, confirmation.
+- `src/frontend/src/features/pos/pages/Dashboard.tsx` — replace placeholder with shop picker.
+- `src/frontend/src/api/orders.ts` — add `tableNumber?: string | null` to `CreateOrderRequest`.
+- `src/frontend/src/i18n/locales/{nl,fr,de}/common.json` — extend `pos.*`.
+
+### Frontend — create
+
+- `src/frontend/src/features/pos/pages/NewOrderPage.tsx`
+- `src/frontend/src/features/pos/pages/OrderPlacedPage.tsx`
+- `src/frontend/src/features/pos/components/ProductTile.tsx`
+- `src/frontend/src/features/pos/components/PosTicket.tsx`
+- `src/frontend/src/features/pos/components/PosModifierModal.tsx`
+- `src/frontend/src/features/pos/components/OrderTypeSelector.tsx`
+- `src/frontend/src/features/pos/hooks/usePosOrder.ts`
+- `src/frontend/src/features/pos/hooks/useCreatePosOrder.ts`
+- Tests under `src/frontend/src/features/pos/**/__tests__/*.test.{ts,tsx}` mirroring §3.9.
+
+### Documentation
+
+- Update `docs/dependency-tree.md` row for US-FP-018 from ⬜ to ✅ on PR.

--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -1,7 +1,7 @@
 # User Story Dependency Tree & Progress Tracker
 
 > Generated from [frietjes-platform.md](./extract-prd/user-stories/frietjes-platform.md)
-> Last updated: 2026-04-09
+> Last updated: 2026-05-21
 
 ## Progress Legend
 
@@ -99,7 +99,7 @@ Once brands + shops exist, these streams are **independent of each other**.
 | ✅ | **US-FP-016** | Place an online order | 005, 006, 007, 014, 022, 046 |
 | ✅ | **US-FP-058** | Complete payment flow (mocked) | 016 |
 | ⬜ | **US-FP-017** | Place an order as a guest | 016 |
-| ⬜ | **US-FP-018** | Place an in-store order (POS) | 016 |
+| ✅ | **US-FP-018** | Place an in-store order (POS) | 016 |
 
 ---
 

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
@@ -15,7 +15,8 @@ public sealed record CreateOrderApiRequest(
     string OrderType,
     string PaymentMethod,
     string? CustomerName,
-    List<OrderItemApiInput> Items);
+    List<OrderItemApiInput> Items,
+    string? TableNumber = null);
 
 public sealed class CreateOrderRequestValidator : Validator<CreateOrderApiRequest>
 {
@@ -47,6 +48,17 @@ public sealed class CreateOrderRequestValidator : Validator<CreateOrderApiReques
         RuleFor(x => x.CustomerName)
             .MaximumLength(200)
             .When(x => x.CustomerName is not null);
+
+        // TableNumber: optional globally, but required when order type is EatIn.
+        // Alphanumeric labels (e.g. "T-12") are valid — max 20 chars.
+        RuleFor(x => x.TableNumber)
+            .MaximumLength(20)
+            .When(x => x.TableNumber is not null);
+
+        RuleFor(x => x.TableNumber)
+            .NotEmpty()
+            .When(x => string.Equals(x.OrderType, "EatIn", StringComparison.OrdinalIgnoreCase))
+            .WithMessage("TableNumber is required for eat-in orders.");
     }
 }
 
@@ -89,7 +101,8 @@ public sealed class CreateOrderEndpoint(IOrderService orderService)
                         i.Quantity,
                         (i.SelectedModifierIds ?? []).AsReadOnly()))
                     .ToList()
-                    .AsReadOnly());
+                    .AsReadOnly(),
+                req.TableNumber);
 
             var response = await orderService.CreateOrderAsync(appRequest, ct);
 

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
@@ -41,5 +41,6 @@ internal static class OrderTrackingMapper
             order.TotalVatAmount,
             order.TotalNet,
             order.TotalGross,
-            order.CreatedAt);
+            order.CreatedAt,
+            order.TableNumber);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs
@@ -9,4 +9,5 @@ public sealed record CreateOrderRequest(
     string OrderType,
     string PaymentMethod,
     string? CustomerName,
-    IReadOnlyList<OrderItemInput> Items);
+    IReadOnlyList<OrderItemInput> Items,
+    string? TableNumber = null);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
@@ -33,4 +33,5 @@ public sealed record OrderResponse(
     decimal TotalVatAmount,
     decimal TotalNet,
     decimal TotalGross,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    string? TableNumber = null);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -168,7 +168,8 @@ public sealed class OrderService(
                 openingStatus.Name,
                 request.CustomerName,
                 vatRate,
-                orderItems);
+                orderItems,
+                request.TableNumber);
 
             try
             {
@@ -247,5 +248,6 @@ public sealed class OrderService(
             order.TotalVatAmount,
             order.TotalNet,
             order.TotalGross,
-            order.CreatedAt);
+            order.CreatedAt,
+            order.TableNumber);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
@@ -24,6 +24,14 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
     /// <summary>Optional customer name for display on kitchen displays and receipts.</summary>
     public string? CustomerName { get; private set; }
 
+    /// <summary>
+    /// Optional table number for eat-in orders. Stored as a string to support
+    /// alphanumeric labels (e.g. "T-12", "Bar-3"). Validated at the API layer
+    /// when OrderType is EatIn. Domain layer accepts null to allow future
+    /// eat-in-without-table scenarios (US-FP-066).
+    /// </summary>
+    public string? TableNumber { get; private set; }
+
     /// <summary>VAT rate applied to this order (6 for Pickup/Delivery, 21 for EatIn).</summary>
     public decimal VatRatePercent { get; private set; }
 
@@ -67,11 +75,17 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
         string statusName,
         string? customerName,
         decimal vatRatePercent,
-        IEnumerable<OrderItem> items)
+        IEnumerable<OrderItem> items,
+        string? tableNumber = null)
     {
         var itemList = items.ToList();
         if (itemList.Count == 0)
             throw new ArgumentException("An order must contain at least one item.", nameof(items));
+
+        // Trim and length-cap the table number — alphanumeric labels like "T-12" are valid
+        var trimmedTableNumber = tableNumber?.Trim();
+        if (trimmedTableNumber is { Length: > 20 })
+            throw new ArgumentException("TableNumber must not exceed 20 characters.", nameof(tableNumber));
 
         var subtotalGross = itemList.Sum(i => i.LineTotal);
         var totalVatAmount = itemList.Sum(i => i.UnitVatAmount * i.Quantity);
@@ -89,6 +103,7 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
             PaymentMethod = paymentMethod,
             StatusName = statusName,
             CustomerName = customerName,
+            TableNumber = trimmedTableNumber,
             VatRatePercent = vatRatePercent,
             SubtotalGross = Math.Round(subtotalGross, 2, MidpointRounding.AwayFromZero),
             TotalVatAmount = Math.Round(totalVatAmount, 2, MidpointRounding.AwayFromZero),
@@ -107,7 +122,8 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
             brandSlug,
             orderNumber,
             statusName,
-            customerName));
+            customerName,
+            trimmedTableNumber));
 
         return order;
     }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderCreatedEvent.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/OrderCreatedEvent.cs
@@ -13,7 +13,8 @@ public sealed record OrderCreatedEvent(
     string BrandSlug,
     string OrderNumber,
     string StatusName,
-    string? CustomerName) : IDomainEvent
+    string? CustomerName,
+    string? TableNumber) : IDomainEvent
 {
     public DateTimeOffset OccurredOn { get; } = DateTimeOffset.UtcNow;
 }

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
@@ -38,6 +38,11 @@ public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.Property(o => o.CustomerName)
             .HasMaxLength(200);
 
+        // Nullable; required only for eat-in orders (enforced at the API/validation layer).
+        // String type supports alphanumeric table labels such as "T-12" and "Bar-3".
+        builder.Property(o => o.TableNumber)
+            .HasMaxLength(20);
+
         builder.Property(o => o.VatRatePercent)
             .HasColumnType("decimal(5,2)")
             .IsRequired();

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260521081838_AddOrderTableNumber.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260521081838_AddOrderTableNumber.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260521081838_AddOrderTableNumber")]
+    partial class AddOrderTableNumber
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260521081838_AddOrderTableNumber.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260521081838_AddOrderTableNumber.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddOrderTableNumber : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TableNumber",
+                table: "Orders",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TableNumber",
+                table: "Orders");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs
@@ -240,4 +240,41 @@ public sealed class ListActiveOrdersTests(IntegrationTestBase fixture)
             $"/api/brands/non-existent-brand/shops/{Guid.NewGuid()}/orders/active");
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
     }
+
+    [Test]
+    public async Task ListActive_EatInOrderWithTableNumber_ReturnsTableNumberInResponse()
+    {
+        // Proves the kitchen display will see the table number once an eat-in POS order is placed.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "POS Frietje");
+
+        // Place an eat-in order with a table number (simulates counter staff using the POS)
+        var request = new
+        {
+            OrderType = "EatIn",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            TableNumber = "T-7",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var placeResponse = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+        await Assert.That(placeResponse.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        // Fetch active orders (kitchen display endpoint) and confirm table number is present
+        var activeResponse = await client.GetAsync(ActiveOrdersUrl(brand, shopId));
+        await Assert.That(activeResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await activeResponse.Content.ReadFromJsonAsync<ListActiveOrdersResponse>();
+        await Assert.That(body).IsNotNull();
+
+        var eatInOrder = body!.Orders.FirstOrDefault(o => o.OrderType == "EatIn");
+        await Assert.That(eatInOrder).IsNotNull();
+        await Assert.That(eatInOrder!.TableNumber).IsEqualTo("T-7");
+    }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
@@ -581,6 +581,125 @@ public sealed class PlaceOrderTests(IntegrationTestBase fixture)
         await Assert.That(item.SelectedModifiers[0].PriceAdjustment).IsEqualTo(0.50m);
     }
 
+    // ── TableNumber / EatIn ───────────────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_EatIn_WithTableNumber_PersistsAndReturnsIt()
+    {
+        // EatIn with a table number should return 201 and echo the table number back.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 3.50m, name: "Frietje EatIn");
+
+        var request = new
+        {
+            OrderType = "EatIn",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            TableNumber = "T-12",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.TableNumber).IsEqualTo("T-12");
+        await Assert.That(order.OrderType).IsEqualTo("EatIn");
+    }
+
+    [Test]
+    public async Task PlaceOrder_EatIn_WithoutTableNumber_Returns400()
+    {
+        // EatIn without a table number must be rejected by the API validator.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 3.50m, name: "Frietje NoTable");
+
+        var request = new
+        {
+            OrderType = "EatIn",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            // TableNumber intentionally omitted
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task PlaceOrder_Pickup_WithoutTableNumber_Returns201()
+    {
+        // Pickup orders do not require a table number.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.00m, name: "Frietje Pickup");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            // TableNumber intentionally omitted
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.TableNumber).IsNull();
+    }
+
+    [Test]
+    public async Task PlaceOrder_EatIn_TableNumberTooLong_Returns400()
+    {
+        // A table number exceeding 20 characters should be rejected.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.00m, name: "Frietje LongTable");
+
+        var request = new
+        {
+            OrderType = "EatIn",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            TableNumber = new string('A', 21), // 21 characters — exceeds max of 20
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
     // ── PaymentMethod ─────────────────────────────────────────────────────────
 
     [Test]

--- a/src/frontend/src/App.test.tsx
+++ b/src/frontend/src/App.test.tsx
@@ -32,11 +32,16 @@ describe('App smoke test', () => {
 
   it('renders the POS dashboard without crashing', async () => {
     const { PosDashboard } = await import('@features/pos/pages/Dashboard');
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
 
     render(
-      <MemoryRouter>
-        <PosDashboard />
-      </MemoryRouter>,
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <PosDashboard />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByRole('heading', { name: 'POS Dashboard' })).toBeInTheDocument();

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -17,6 +17,8 @@ export type PaymentMethod = 'CashAtPickup' | 'CreditCard' | 'Bancontact';
 export interface CreateOrderRequest {
   orderType: OrderType;
   customerName?: string | null;
+  /** Required when orderType is EatIn; null/undefined for Pickup and Delivery. */
+  tableNumber?: string | null;
   items: OrderItemRequest[];
   paymentMethod: PaymentMethod;
 }

--- a/src/frontend/src/features/pos/components/OrderTypeSelector.tsx
+++ b/src/frontend/src/features/pos/components/OrderTypeSelector.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+import type { OrderType } from '@api/orders';
+
+interface OrderTypeSelectorProps {
+  value: OrderType;
+  onChange: (type: OrderType) => void;
+}
+
+const POS_ORDER_TYPES: OrderType[] = ['Pickup', 'EatIn'];
+
+/**
+ * Segmented control for choosing Pickup or Eat-In on the POS ticket.
+ * Delivery is intentionally omitted from POS (counter staff only handle in-store).
+ * Buttons meet the 44px minimum hit-target spec.
+ */
+export function OrderTypeSelector({ value, onChange }: OrderTypeSelectorProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <div
+      role="group"
+      aria-label={t('pos.order.orderType')}
+      style={{
+        display: 'flex',
+        gap: '0.5rem',
+      }}
+    >
+      {POS_ORDER_TYPES.map((type) => {
+        const isSelected = value === type;
+        return (
+          <button
+            key={type}
+            type="button"
+            aria-pressed={isSelected}
+            onClick={() => onChange(type)}
+            style={{
+              flex: 1,
+              minHeight: '2.75rem', // 44px
+              padding: '0.5rem 0.75rem',
+              borderRadius: '0.5rem',
+              border: isSelected ? '2px solid #111827' : '2px solid #d1d5db',
+              background: isSelected ? '#111827' : '#f9fafb',
+              color: isSelected ? '#fff' : '#374151',
+              fontWeight: 600,
+              fontSize: '0.9375rem',
+              cursor: 'pointer',
+              transition: 'all 0.15s ease',
+            }}
+          >
+            {t(`pos.kitchen.orderType.${type}`)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/frontend/src/features/pos/components/PosModifierModal.tsx
+++ b/src/frontend/src/features/pos/components/PosModifierModal.tsx
@@ -1,0 +1,260 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ProductListItem, ModifierResponse } from '@/types/common';
+import { useProductModifierGroups } from '@features/storefront/hooks/useStorefrontMenu';
+import type { PosTicketModifier } from '../hooks/usePosOrder';
+
+interface PosModifierModalProps {
+  brandSlug: string;
+  product: ProductListItem;
+  onConfirm: (selectedModifiers: PosTicketModifier[]) => void;
+  onClose: () => void;
+}
+
+/**
+ * Touch-friendly modifier picker for the POS new-order page.
+ * Reuses the same modifier data as the storefront (useProductModifierGroups)
+ * but renders with larger touch targets suited to a 10" landscape tablet.
+ */
+export function PosModifierModal({ brandSlug, product, onConfirm, onClose }: PosModifierModalProps) {
+  const { t } = useTranslation('common');
+  const { data: modifierGroups, isLoading } = useProductModifierGroups(brandSlug, product.id);
+  const [selectedModifierIds, setSelectedModifierIds] = useState<Set<string>>(new Set());
+
+  function toggleModifier(modifier: ModifierResponse) {
+    setSelectedModifierIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(modifier.id)) {
+        next.delete(modifier.id);
+      } else {
+        next.add(modifier.id);
+      }
+      return next;
+    });
+  }
+
+  function handleConfirm() {
+    if (!modifierGroups) {
+      onConfirm([]);
+      return;
+    }
+
+    const selected: PosTicketModifier[] = [];
+    for (const group of modifierGroups) {
+      for (const modifier of group.modifiers) {
+        if (selectedModifierIds.has(modifier.id)) {
+          const modifierName = modifier.translations[0]?.name ?? '';
+          selected.push({
+            modifierId: modifier.id,
+            modifierName,
+            priceAdjustment: modifier.priceAdjustment,
+          });
+        }
+      }
+    }
+    onConfirm(selected);
+  }
+
+  const formattedBasePrice = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: product.basePrice.currency || 'EUR',
+  }).format(product.basePrice.amount);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        role="presentation"
+        onClick={onClose}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.45)',
+          zIndex: 200,
+        }}
+      />
+
+      {/* Modal panel — larger than storefront version for tablet */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('storefront.menu.customise')}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          margin: 'auto',
+          width: 'min(36rem, calc(100vw - 2rem))',
+          maxHeight: 'calc(100vh - 4rem)',
+          background: '#fff',
+          borderRadius: '1rem',
+          boxShadow: '0 24px 80px rgba(0,0,0,0.3)',
+          zIndex: 201,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: '1.5rem 1.75rem',
+            borderBottom: '1px solid #e5e7eb',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+          }}
+        >
+          <div>
+            <h2 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 700, color: '#111827' }}>
+              {product.name}
+            </h2>
+            <p style={{ margin: '0.25rem 0 0', fontSize: '1rem', color: '#6b7280' }}>
+              {formattedBasePrice}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('storefront.menu.closeModal')}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: '#6b7280',
+              fontSize: '1.75rem',
+              lineHeight: 1,
+              padding: '0.25rem',
+              minWidth: '2.75rem',
+              minHeight: '2.75rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '1.25rem 1.75rem' }}>
+          {isLoading && (
+            <p style={{ color: '#6b7280', fontSize: '1rem' }}>
+              {t('storefront.menu.loadingModifiers')}
+            </p>
+          )}
+
+          {!isLoading && modifierGroups && modifierGroups.length === 0 && (
+            <p style={{ color: '#6b7280', fontSize: '1rem' }}>
+              {t('storefront.menu.noModifiers')}
+            </p>
+          )}
+
+          {!isLoading &&
+            modifierGroups?.map((group) => (
+              <div key={group.modifierGroupId} style={{ marginBottom: '1.5rem' }}>
+                <h3
+                  style={{
+                    margin: '0 0 0.75rem',
+                    fontSize: '1.0625rem',
+                    fontWeight: 600,
+                    color: '#374151',
+                  }}
+                >
+                  {group.name}
+                </h3>
+                {group.modifiers.map((modifier) => {
+                  const modifierName = modifier.translations[0]?.name ?? '';
+                  const isChecked = selectedModifierIds.has(modifier.id);
+                  const adjustmentLabel =
+                    modifier.priceAdjustment !== 0
+                      ? ` (+${new Intl.NumberFormat('nl-BE', {
+                          style: 'currency',
+                          currency: 'EUR',
+                        }).format(modifier.priceAdjustment)})`
+                      : '';
+
+                  return (
+                    <label
+                      key={modifier.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '1rem',
+                        padding: '0.75rem 0',
+                        cursor: 'pointer',
+                        fontSize: '1rem',
+                        color: '#111827',
+                        borderBottom: '1px solid #f3f4f6',
+                        minHeight: '2.75rem', // 44px touch target
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={() => toggleModifier(modifier)}
+                        style={{ width: '1.375rem', height: '1.375rem', cursor: 'pointer' }}
+                      />
+                      <span style={{ flex: 1 }}>{modifierName}</span>
+                      {adjustmentLabel && (
+                        <span style={{ color: '#6b7280', fontSize: '0.9375rem' }}>
+                          {adjustmentLabel}
+                        </span>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: '1.25rem 1.75rem',
+            borderTop: '1px solid #e5e7eb',
+            display: 'flex',
+            gap: '0.75rem',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: '0.75rem 1.5rem',
+              minHeight: '2.75rem',
+              borderRadius: '0.5rem',
+              border: '1px solid #d1d5db',
+              background: '#fff',
+              color: '#374151',
+              fontWeight: 600,
+              fontSize: '1rem',
+              cursor: 'pointer',
+            }}
+          >
+            {t('storefront.menu.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isLoading}
+            style={{
+              padding: '0.75rem 1.5rem',
+              minHeight: '2.75rem',
+              borderRadius: '0.5rem',
+              border: 'none',
+              background: '#111827',
+              color: '#fff',
+              fontWeight: 600,
+              fontSize: '1rem',
+              cursor: isLoading ? 'not-allowed' : 'pointer',
+              opacity: isLoading ? 0.6 : 1,
+            }}
+          >
+            {t('pos.order.addToOrder')}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/frontend/src/features/pos/components/PosTicket.tsx
+++ b/src/frontend/src/features/pos/components/PosTicket.tsx
@@ -1,0 +1,332 @@
+import { useTranslation } from 'react-i18next';
+import type { PosOrderAction, PosOrderState, PosTicketItem } from '../hooks/usePosOrder';
+import { OrderTypeSelector } from './OrderTypeSelector';
+import type { OrderType } from '@api/orders';
+
+interface PosTicketProps {
+  state: PosOrderState;
+  subtotal: number;
+  dispatch: React.Dispatch<PosOrderAction>;
+  onPlaceOrder: () => void;
+  isSubmitting: boolean;
+  submitError: string | null;
+}
+
+/**
+ * Right-pane ticket panel for the POS new-order page.
+ * Displays the current order items with +/- controls, order type selector,
+ * conditional table-number input (eat-in only), optional customer name,
+ * subtotal, and the primary "Place order" button.
+ */
+export function PosTicket({
+  state,
+  subtotal,
+  dispatch,
+  onPlaceOrder,
+  isSubmitting,
+  submitError,
+}: PosTicketProps) {
+  const { t } = useTranslation('common');
+
+  const formattedSubtotal = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(subtotal);
+
+  const canSubmit =
+    state.items.length > 0 &&
+    !isSubmitting &&
+    (state.orderType !== 'EatIn' || state.tableNumber.trim().length > 0);
+
+  return (
+    <aside
+      data-testid="pos-ticket"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        background: '#f9fafb',
+        borderLeft: '1px solid #e5e7eb',
+        padding: '1rem',
+        overflowY: 'auto',
+      }}
+    >
+      {/* Header */}
+      <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 700, color: '#111827' }}>
+        {t('pos.order.ticket')}
+      </h2>
+
+      {/* Items */}
+      {state.items.length === 0 ? (
+        <p style={{ color: '#9ca3af', fontSize: '0.875rem', margin: 0 }}>
+          {t('pos.order.empty')}
+        </p>
+      ) : (
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          {state.items.map((item) => (
+            <TicketLineItem key={item.key} item={item} dispatch={dispatch} />
+          ))}
+        </ul>
+      )}
+
+      <hr style={{ border: 'none', borderTop: '1px solid #e5e7eb', margin: '0.25rem 0' }} />
+
+      {/* Order type */}
+      <div>
+        <label
+          style={{ display: 'block', fontWeight: 600, fontSize: '0.875rem', color: '#374151', marginBottom: '0.5rem' }}
+        >
+          {t('pos.order.orderType')}
+        </label>
+        <OrderTypeSelector
+          value={state.orderType as OrderType}
+          onChange={(type) =>
+            dispatch({ type: 'SET_ORDER_TYPE', payload: { orderType: type } })
+          }
+        />
+      </div>
+
+      {/* Table number — eat-in only */}
+      {state.orderType === 'EatIn' && (
+        <div>
+          <label
+            htmlFor="pos-table-number"
+            style={{ display: 'block', fontWeight: 600, fontSize: '0.875rem', color: '#374151', marginBottom: '0.375rem' }}
+          >
+            {t('pos.order.tableNumberLabel')}
+            <span style={{ color: '#dc2626', marginLeft: '0.25rem' }}>*</span>
+          </label>
+          <input
+            id="pos-table-number"
+            data-testid="pos-table-number-input"
+            type="text"
+            inputMode="numeric"
+            value={state.tableNumber}
+            onChange={(e) =>
+              dispatch({
+                type: 'SET_TABLE_NUMBER',
+                payload: { tableNumber: e.target.value.slice(0, 20) },
+              })
+            }
+            placeholder={t('pos.order.tableNumberPlaceholder')}
+            style={{
+              width: '100%',
+              padding: '0.625rem 0.75rem',
+              border: '1px solid #d1d5db',
+              borderRadius: '0.5rem',
+              fontSize: '1rem',
+              background: '#fff',
+              color: '#111827',
+              minHeight: '2.75rem',
+              boxSizing: 'border-box',
+            }}
+          />
+        </div>
+      )}
+
+      {/* Customer name (optional) */}
+      <div>
+        <label
+          htmlFor="pos-customer-name"
+          style={{ display: 'block', fontWeight: 600, fontSize: '0.875rem', color: '#374151', marginBottom: '0.375rem' }}
+        >
+          {t('pos.order.customerNameLabel')}
+          <span style={{ color: '#9ca3af', marginLeft: '0.25rem', fontWeight: 400 }}>
+            ({t('storefront.checkout.optional')})
+          </span>
+        </label>
+        <input
+          id="pos-customer-name"
+          type="text"
+          value={state.customerName}
+          onChange={(e) =>
+            dispatch({ type: 'SET_CUSTOMER_NAME', payload: { customerName: e.target.value } })
+          }
+          placeholder={t('pos.order.customerNamePlaceholder')}
+          style={{
+            width: '100%',
+            padding: '0.625rem 0.75rem',
+            border: '1px solid #d1d5db',
+            borderRadius: '0.5rem',
+            fontSize: '1rem',
+            background: '#fff',
+            color: '#111827',
+            minHeight: '2.75rem',
+            boxSizing: 'border-box',
+          }}
+        />
+      </div>
+
+      <hr style={{ border: 'none', borderTop: '1px solid #e5e7eb', margin: '0.25rem 0' }} />
+
+      {/* Subtotal */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          fontWeight: 700,
+          fontSize: '1.0625rem',
+          color: '#111827',
+        }}
+      >
+        <span>{t('pos.order.subtotal')}</span>
+        <span data-testid="pos-subtotal">{formattedSubtotal}</span>
+      </div>
+
+      {/* Submit error */}
+      {submitError && (
+        <p style={{ color: '#dc2626', fontSize: '0.875rem', margin: 0 }}>{submitError}</p>
+      )}
+
+      {/* Place order button — full width, 56px tall */}
+      <button
+        type="button"
+        data-testid="pos-place-order-btn"
+        disabled={!canSubmit}
+        onClick={onPlaceOrder}
+        style={{
+          width: '100%',
+          minHeight: '3.5rem', // 56px
+          padding: '0.75rem 1rem',
+          borderRadius: '0.75rem',
+          border: 'none',
+          background: canSubmit ? '#111827' : '#d1d5db',
+          color: canSubmit ? '#fff' : '#9ca3af',
+          fontWeight: 700,
+          fontSize: '1.0625rem',
+          cursor: canSubmit ? 'pointer' : 'not-allowed',
+          transition: 'background 0.15s ease',
+          marginTop: 'auto',
+        }}
+      >
+        {isSubmitting ? t('pos.order.placing') : t('pos.order.placeOrder')}
+      </button>
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Ticket line item sub-component
+// ---------------------------------------------------------------------------
+
+function TicketLineItem({
+  item,
+  dispatch,
+}: {
+  item: PosTicketItem;
+  dispatch: React.Dispatch<PosOrderAction>;
+}) {
+  const formattedLineTotal = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(item.unitGrossPrice * item.quantity);
+
+  return (
+    <li
+      style={{
+        background: '#fff',
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.5rem',
+        padding: '0.625rem 0.75rem',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.5rem' }}>
+        <span style={{ fontSize: '0.9375rem', fontWeight: 600, color: '#111827', flex: 1 }}>
+          {item.productName}
+        </span>
+        <span style={{ fontSize: '0.9375rem', fontWeight: 600, color: '#374151', whiteSpace: 'nowrap' }}>
+          {formattedLineTotal}
+        </span>
+      </div>
+
+      {/* Modifier list */}
+      {item.selectedModifiers.length > 0 && (
+        <ul style={{ listStyle: 'none', margin: '0.25rem 0 0', padding: 0 }}>
+          {item.selectedModifiers.map((m) => (
+            <li key={m.modifierId} style={{ fontSize: '0.8125rem', color: '#6b7280' }}>
+              + {m.modifierName}
+              {m.priceAdjustment !== 0 &&
+                ` (+${new Intl.NumberFormat('nl-BE', { style: 'currency', currency: 'EUR' }).format(m.priceAdjustment)})`}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Quantity stepper */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          marginTop: '0.5rem',
+        }}
+      >
+        <button
+          type="button"
+          aria-label="Hoeveelheid verlagen"
+          onClick={() =>
+            dispatch({
+              type: 'UPDATE_QUANTITY',
+              payload: { key: item.key, quantity: item.quantity - 1 },
+            })
+          }
+          style={{
+            width: '2.75rem', // 44px
+            height: '2.75rem',
+            borderRadius: '0.375rem',
+            border: '1px solid #d1d5db',
+            background: '#f3f4f6',
+            color: '#374151',
+            fontSize: '1.25rem',
+            fontWeight: 700,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          −
+        </button>
+        <span
+          style={{
+            minWidth: '2rem',
+            textAlign: 'center',
+            fontSize: '1rem',
+            fontWeight: 700,
+            color: '#111827',
+          }}
+          data-testid={`qty-${item.key}`}
+        >
+          {item.quantity}
+        </span>
+        <button
+          type="button"
+          aria-label="Hoeveelheid verhogen"
+          onClick={() =>
+            dispatch({
+              type: 'UPDATE_QUANTITY',
+              payload: { key: item.key, quantity: item.quantity + 1 },
+            })
+          }
+          style={{
+            width: '2.75rem',
+            height: '2.75rem',
+            borderRadius: '0.375rem',
+            border: '1px solid #d1d5db',
+            background: '#f3f4f6',
+            color: '#374151',
+            fontSize: '1.25rem',
+            fontWeight: 700,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          +
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/src/frontend/src/features/pos/components/ProductTile.tsx
+++ b/src/frontend/src/features/pos/components/ProductTile.tsx
@@ -1,0 +1,74 @@
+import type { ProductListItem } from '@/types/common';
+
+interface ProductTileProps {
+  product: ProductListItem;
+  onTap: (product: ProductListItem) => void;
+}
+
+/**
+ * Large square tile representing a single product on the POS menu grid.
+ * Meets touch UX spec: min-height 7rem, padding 1.25rem, entire tile is tappable.
+ */
+export function ProductTile({ product, onTap }: ProductTileProps) {
+  const formattedPrice = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: product.basePrice.currency || 'EUR',
+  }).format(product.basePrice.amount);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onTap(product)}
+      data-testid={`product-tile-${product.id}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        minHeight: '7rem',
+        padding: '1.25rem',
+        background: '#fff',
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.75rem',
+        cursor: 'pointer',
+        textAlign: 'left',
+        width: '100%',
+        transition: 'box-shadow 0.15s ease, border-color 0.15s ease',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+      }}
+      onMouseDown={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.boxShadow =
+          '0 0 0 2px #111827 inset';
+      }}
+      onMouseUp={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.boxShadow =
+          '0 1px 3px rgba(0,0,0,0.06)';
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.boxShadow =
+          '0 1px 3px rgba(0,0,0,0.06)';
+      }}
+    >
+      <span
+        style={{
+          fontSize: '1rem',
+          fontWeight: 600,
+          color: '#111827',
+          lineHeight: 1.3,
+          overflowWrap: 'break-word',
+        }}
+      >
+        {product.name}
+      </span>
+      <span
+        style={{
+          fontSize: '1rem',
+          fontWeight: 700,
+          color: '#374151',
+          marginTop: '0.5rem',
+        }}
+      >
+        {formattedPrice}
+      </span>
+    </button>
+  );
+}

--- a/src/frontend/src/features/pos/components/__tests__/OrderTypeSelector.test.tsx
+++ b/src/frontend/src/features/pos/components/__tests__/OrderTypeSelector.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '../../../../i18n/config';
+import { OrderTypeSelector } from '../OrderTypeSelector';
+
+describe('OrderTypeSelector', () => {
+  it('renders Pickup and EatIn buttons', () => {
+    render(<OrderTypeSelector value="Pickup" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /afhalen/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ter plaatse/i })).toBeInTheDocument();
+  });
+
+  it('marks the active type as pressed', () => {
+    render(<OrderTypeSelector value="EatIn" onChange={() => {}} />);
+    const eatInBtn = screen.getByRole('button', { name: /ter plaatse/i });
+    expect(eatInBtn).toHaveAttribute('aria-pressed', 'true');
+    const pickupBtn = screen.getByRole('button', { name: /afhalen/i });
+    expect(pickupBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onChange with EatIn when the EatIn button is clicked', () => {
+    const handleChange = vi.fn();
+    render(<OrderTypeSelector value="Pickup" onChange={handleChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /ter plaatse/i }));
+    expect(handleChange).toHaveBeenCalledWith('EatIn');
+  });
+
+  it('calls onChange with Pickup when the Pickup button is clicked', () => {
+    const handleChange = vi.fn();
+    render(<OrderTypeSelector value="EatIn" onChange={handleChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /afhalen/i }));
+    expect(handleChange).toHaveBeenCalledWith('Pickup');
+  });
+
+  it('does NOT render a Delivery button', () => {
+    render(<OrderTypeSelector value="Pickup" onChange={() => {}} />);
+    expect(screen.queryByRole('button', { name: /bezorging/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/pos/components/__tests__/PosTicket.test.tsx
+++ b/src/frontend/src/features/pos/components/__tests__/PosTicket.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '../../../../i18n/config';
+import { PosTicket } from '../PosTicket';
+import type { PosOrderState } from '../../hooks/usePosOrder';
+
+function makeState(overrides?: Partial<PosOrderState>): PosOrderState {
+  return {
+    items: [],
+    orderType: 'Pickup',
+    tableNumber: '',
+    customerName: '',
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+describe('PosTicket', () => {
+  it('shows empty message when there are no items', () => {
+    render(
+      <PosTicket
+        state={makeState()}
+        subtotal={0}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByTestId('pos-ticket')).toBeInTheDocument();
+  });
+
+  it('renders a line item with quantity and name', () => {
+    const state = makeState({
+      items: [
+        {
+          key: 'p1',
+          productId: 'p1',
+          productName: 'Frietje Klein',
+          unitGrossPrice: 3.5,
+          quantity: 2,
+          selectedModifiers: [],
+        },
+      ],
+    });
+
+    render(
+      <PosTicket
+        state={state}
+        subtotal={7}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+
+    expect(screen.getByText('Frietje Klein')).toBeInTheDocument();
+    expect(screen.getByTestId('qty-p1')).toHaveTextContent('2');
+    expect(screen.getByTestId('pos-subtotal')).toHaveTextContent(/7/);
+  });
+
+  it('shows the table number input only when EatIn is selected', () => {
+    const { rerender } = render(
+      <PosTicket
+        state={makeState({ orderType: 'Pickup' })}
+        subtotal={0}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+
+    expect(screen.queryByTestId('pos-table-number-input')).not.toBeInTheDocument();
+
+    rerender(
+      <PosTicket
+        state={makeState({ orderType: 'EatIn' })}
+        subtotal={0}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+
+    expect(screen.getByTestId('pos-table-number-input')).toBeInTheDocument();
+  });
+
+  it('disables "Place order" when ticket is empty', () => {
+    render(
+      <PosTicket
+        state={makeState()}
+        subtotal={0}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByTestId('pos-place-order-btn')).toBeDisabled();
+  });
+
+  it('disables "Place order" when EatIn is selected but table number is empty', () => {
+    const state = makeState({
+      orderType: 'EatIn',
+      tableNumber: '',
+      items: [
+        {
+          key: 'p1',
+          productId: 'p1',
+          productName: 'Frietje',
+          unitGrossPrice: 3.5,
+          quantity: 1,
+          selectedModifiers: [],
+        },
+      ],
+    });
+    render(
+      <PosTicket
+        state={state}
+        subtotal={3.5}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByTestId('pos-place-order-btn')).toBeDisabled();
+  });
+
+  it('enables "Place order" when EatIn and table number are both set', () => {
+    const state = makeState({
+      orderType: 'EatIn',
+      tableNumber: 'T-5',
+      items: [
+        {
+          key: 'p1',
+          productId: 'p1',
+          productName: 'Frietje',
+          unitGrossPrice: 3.5,
+          quantity: 1,
+          selectedModifiers: [],
+        },
+      ],
+    });
+    render(
+      <PosTicket
+        state={state}
+        subtotal={3.5}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByTestId('pos-place-order-btn')).not.toBeDisabled();
+  });
+
+  it('calls onPlaceOrder when the button is clicked', () => {
+    const handlePlace = vi.fn();
+    const state = makeState({
+      orderType: 'Pickup',
+      items: [
+        {
+          key: 'p1',
+          productId: 'p1',
+          productName: 'Frietje',
+          unitGrossPrice: 3.5,
+          quantity: 1,
+          selectedModifiers: [],
+        },
+      ],
+    });
+    render(
+      <PosTicket
+        state={state}
+        subtotal={3.5}
+        dispatch={noop}
+        onPlaceOrder={handlePlace}
+        isSubmitting={false}
+        submitError={null}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('pos-place-order-btn'));
+    expect(handlePlace).toHaveBeenCalledOnce();
+  });
+
+  it('shows submit error when present', () => {
+    render(
+      <PosTicket
+        state={makeState()}
+        subtotal={0}
+        dispatch={noop}
+        onPlaceOrder={noop}
+        isSubmitting={false}
+        submitError="Er is iets misgegaan"
+      />,
+    );
+    expect(screen.getByText('Er is iets misgegaan')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/pos/components/__tests__/ProductTile.test.tsx
+++ b/src/frontend/src/features/pos/components/__tests__/ProductTile.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '../../../../i18n/config';
+import { ProductTile } from '../ProductTile';
+import type { ProductListItem } from '@/types/common';
+
+function makeProduct(overrides?: Partial<ProductListItem>): ProductListItem {
+  return {
+    id: 'p1',
+    productType: 'Simple',
+    name: 'Frietje Klein',
+    basePrice: { amount: 3.5, currency: 'EUR' },
+    imageUrl: null,
+    menuCategoryId: null,
+    sortOrderInCategory: 0,
+    allergens: [],
+    dietaryTags: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ProductTile', () => {
+  it('renders the product name', () => {
+    const product = makeProduct({ name: 'Frietje Groot' });
+    render(<ProductTile product={product} onTap={() => {}} />);
+    expect(screen.getByText('Frietje Groot')).toBeInTheDocument();
+  });
+
+  it('renders the formatted price', () => {
+    const product = makeProduct({ basePrice: { amount: 3.5, currency: 'EUR' } });
+    render(<ProductTile product={product} onTap={() => {}} />);
+    // Belgian locale formats 3.5 EUR as "€ 3,50" or "€3,50"
+    expect(screen.getByText(/3,50/)).toBeInTheDocument();
+  });
+
+  it('calls onTap with the product when clicked', () => {
+    const product = makeProduct();
+    const handleTap = vi.fn();
+    render(<ProductTile product={product} onTap={handleTap} />);
+    fireEvent.click(screen.getByTestId(`product-tile-${product.id}`));
+    expect(handleTap).toHaveBeenCalledOnce();
+    expect(handleTap).toHaveBeenCalledWith(product);
+  });
+
+  it('has the expected data-testid', () => {
+    const product = makeProduct({ id: 'test-id-123' });
+    render(<ProductTile product={product} onTap={() => {}} />);
+    expect(screen.getByTestId('product-tile-test-id-123')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/pos/hooks/__tests__/usePosOrder.test.ts
+++ b/src/frontend/src/features/pos/hooks/__tests__/usePosOrder.test.ts
@@ -1,0 +1,169 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { usePosOrder } from '../usePosOrder';
+
+describe('usePosOrder', () => {
+  it('starts with an empty ticket', () => {
+    const { result } = renderHook(() => usePosOrder());
+    expect(result.current.state.items).toHaveLength(0);
+    expect(result.current.state.orderType).toBe('Pickup');
+    expect(result.current.state.tableNumber).toBe('');
+    expect(result.current.subtotal).toBe(0);
+  });
+
+  it('ADD_ITEM adds a product to the ticket', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: {
+          productId: 'p1',
+          productName: 'Frietje',
+          unitGrossPrice: 3.5,
+          selectedModifiers: [],
+        },
+      });
+    });
+
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.items[0]?.productName).toBe('Frietje');
+    expect(result.current.state.items[0]?.quantity).toBe(1);
+    expect(result.current.subtotal).toBe(3.5);
+  });
+
+  it('ADD_ITEM merges quantity when the same product+modifiers is added twice', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: { productId: 'p1', productName: 'Frietje', unitGrossPrice: 3.5, selectedModifiers: [] },
+      });
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: { productId: 'p1', productName: 'Frietje', unitGrossPrice: 3.5, selectedModifiers: [] },
+      });
+    });
+
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.items[0]?.quantity).toBe(2);
+    expect(result.current.subtotal).toBe(7);
+  });
+
+  it('ADD_ITEM creates separate lines for same product with different modifiers', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: {
+          productId: 'p1',
+          productName: 'Frietje',
+          unitGrossPrice: 3.5,
+          selectedModifiers: [],
+        },
+      });
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: {
+          productId: 'p1',
+          productName: 'Frietje',
+          unitGrossPrice: 4.0,
+          selectedModifiers: [{ modifierId: 'm1', modifierName: 'Extra groot', priceAdjustment: 0.5 }],
+        },
+      });
+    });
+
+    expect(result.current.state.items).toHaveLength(2);
+  });
+
+  it('UPDATE_QUANTITY removes item when quantity is set to 0', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: { productId: 'p1', productName: 'Frietje', unitGrossPrice: 3.5, selectedModifiers: [] },
+      });
+    });
+    const key = result.current.state.items[0]!.key;
+    act(() => {
+      result.current.dispatch({ type: 'UPDATE_QUANTITY', payload: { key, quantity: 0 } });
+    });
+
+    expect(result.current.state.items).toHaveLength(0);
+  });
+
+  it('REMOVE_ITEM removes item by key', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: { productId: 'p1', productName: 'Frietje', unitGrossPrice: 3.5, selectedModifiers: [] },
+      });
+    });
+    const key = result.current.state.items[0]!.key;
+    act(() => {
+      result.current.dispatch({ type: 'REMOVE_ITEM', payload: { key } });
+    });
+
+    expect(result.current.state.items).toHaveLength(0);
+  });
+
+  it('SET_ORDER_TYPE updates the order type', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({ type: 'SET_ORDER_TYPE', payload: { orderType: 'EatIn' } });
+    });
+
+    expect(result.current.state.orderType).toBe('EatIn');
+  });
+
+  it('SET_ORDER_TYPE clears table number when switching away from EatIn', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({ type: 'SET_ORDER_TYPE', payload: { orderType: 'EatIn' } });
+      result.current.dispatch({ type: 'SET_TABLE_NUMBER', payload: { tableNumber: 'T-12' } });
+    });
+    expect(result.current.state.tableNumber).toBe('T-12');
+
+    act(() => {
+      result.current.dispatch({ type: 'SET_ORDER_TYPE', payload: { orderType: 'Pickup' } });
+    });
+
+    expect(result.current.state.tableNumber).toBe('');
+  });
+
+  it('SET_TABLE_NUMBER updates the table number', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({ type: 'SET_TABLE_NUMBER', payload: { tableNumber: 'Bar-3' } });
+    });
+
+    expect(result.current.state.tableNumber).toBe('Bar-3');
+  });
+
+  it('SET_CUSTOMER_NAME updates the customer name', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({ type: 'SET_CUSTOMER_NAME', payload: { customerName: 'Jan' } });
+    });
+
+    expect(result.current.state.customerName).toBe('Jan');
+  });
+
+  it('RESET returns to initial state', () => {
+    const { result } = renderHook(() => usePosOrder());
+    act(() => {
+      result.current.dispatch({
+        type: 'ADD_ITEM',
+        payload: { productId: 'p1', productName: 'Frietje', unitGrossPrice: 3.5, selectedModifiers: [] },
+      });
+      result.current.dispatch({ type: 'SET_ORDER_TYPE', payload: { orderType: 'EatIn' } });
+      result.current.dispatch({ type: 'SET_TABLE_NUMBER', payload: { tableNumber: 'T-1' } });
+      result.current.dispatch({ type: 'RESET' });
+    });
+
+    expect(result.current.state.items).toHaveLength(0);
+    expect(result.current.state.orderType).toBe('Pickup');
+    expect(result.current.state.tableNumber).toBe('');
+    expect(result.current.subtotal).toBe(0);
+  });
+});

--- a/src/frontend/src/features/pos/hooks/useCreatePosOrder.ts
+++ b/src/frontend/src/features/pos/hooks/useCreatePosOrder.ts
@@ -1,0 +1,38 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ordersApi } from '@api/orders';
+import type { CreateOrderRequest, OrderResponse } from '@api/orders';
+import type { PosOrderAction } from './usePosOrder';
+
+/**
+ * Mutation hook for submitting a POS order.
+ * On success, dispatches a RESET to clear the ticket and navigates to the
+ * order confirmation page.
+ *
+ * All POS orders use PaymentMethod=CashAtPickup per US-FP-018 scope decision.
+ */
+export function useCreatePosOrder(
+  dispatch: React.Dispatch<PosOrderAction>,
+) {
+  const navigate = useNavigate();
+  const { brandSlug, lang, shopId } = useParams<{
+    brandSlug: string;
+    lang: string;
+    shopId: string;
+  }>();
+
+  const resolvedBrand = brandSlug ?? '';
+  const resolvedShop = shopId ?? '';
+  const resolvedLang = lang ?? 'nl';
+
+  return useMutation<OrderResponse, Error, CreateOrderRequest>({
+    mutationFn: (data: CreateOrderRequest) =>
+      ordersApi.create(resolvedBrand, resolvedShop, data),
+    onSuccess: (order) => {
+      dispatch({ type: 'RESET' });
+      navigate(
+        `/${resolvedBrand}/${resolvedLang}/pos/shops/${resolvedShop}/order/confirmation/${order.id}`,
+      );
+    },
+  });
+}

--- a/src/frontend/src/features/pos/hooks/usePosOrder.ts
+++ b/src/frontend/src/features/pos/hooks/usePosOrder.ts
@@ -1,0 +1,197 @@
+import { useReducer } from 'react';
+import type { OrderType } from '@api/orders';
+
+// ---------------------------------------------------------------------------
+// State types
+// ---------------------------------------------------------------------------
+
+export interface PosTicketModifier {
+  modifierId: string;
+  modifierName: string;
+  priceAdjustment: number;
+}
+
+export interface PosTicketItem {
+  /** Unique key within the ticket — productId plus a modifier fingerprint for deduplication. */
+  key: string;
+  productId: string;
+  productName: string;
+  unitGrossPrice: number;
+  quantity: number;
+  selectedModifiers: PosTicketModifier[];
+}
+
+export interface PosOrderState {
+  items: PosTicketItem[];
+  orderType: OrderType;
+  tableNumber: string;
+  customerName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Action types
+// ---------------------------------------------------------------------------
+
+type AddItemAction = {
+  type: 'ADD_ITEM';
+  payload: Omit<PosTicketItem, 'key' | 'quantity'>;
+};
+
+type RemoveItemAction = {
+  type: 'REMOVE_ITEM';
+  payload: { key: string };
+};
+
+type UpdateQuantityAction = {
+  type: 'UPDATE_QUANTITY';
+  payload: { key: string; quantity: number };
+};
+
+type SetOrderTypeAction = {
+  type: 'SET_ORDER_TYPE';
+  payload: { orderType: OrderType };
+};
+
+type SetTableNumberAction = {
+  type: 'SET_TABLE_NUMBER';
+  payload: { tableNumber: string };
+};
+
+type SetCustomerNameAction = {
+  type: 'SET_CUSTOMER_NAME';
+  payload: { customerName: string };
+};
+
+type ResetAction = { type: 'RESET' };
+
+export type PosOrderAction =
+  | AddItemAction
+  | RemoveItemAction
+  | UpdateQuantityAction
+  | SetOrderTypeAction
+  | SetTableNumberAction
+  | SetCustomerNameAction
+  | ResetAction;
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+const initialState: PosOrderState = {
+  items: [],
+  orderType: 'Pickup',
+  tableNumber: '',
+  customerName: '',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a stable key for a ticket item based on the product ID and selected
+ * modifier IDs (sorted). Two items with the same product and same modifiers are
+ * treated as the same line and their quantities are merged.
+ */
+function buildItemKey(productId: string, modifierIds: string[]): string {
+  const sortedIds = [...modifierIds].sort().join(',');
+  return sortedIds ? `${productId}__${sortedIds}` : productId;
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function posOrderReducer(state: PosOrderState, action: PosOrderAction): PosOrderState {
+  switch (action.type) {
+    case 'ADD_ITEM': {
+      const { productId, productName, unitGrossPrice, selectedModifiers } = action.payload;
+      const modifierIds = selectedModifiers.map((m) => m.modifierId);
+      const key = buildItemKey(productId, modifierIds);
+
+      const existingIndex = state.items.findIndex((i) => i.key === key);
+      if (existingIndex >= 0) {
+        // Merge into existing line
+        const updated = state.items.map((item, idx) =>
+          idx === existingIndex ? { ...item, quantity: item.quantity + 1 } : item,
+        );
+        return { ...state, items: updated };
+      }
+
+      const newItem: PosTicketItem = {
+        key,
+        productId,
+        productName,
+        unitGrossPrice,
+        quantity: 1,
+        selectedModifiers,
+      };
+      return { ...state, items: [...state.items, newItem] };
+    }
+
+    case 'REMOVE_ITEM': {
+      return {
+        ...state,
+        items: state.items.filter((i) => i.key !== action.payload.key),
+      };
+    }
+
+    case 'UPDATE_QUANTITY': {
+      const { key, quantity } = action.payload;
+      if (quantity <= 0) {
+        return { ...state, items: state.items.filter((i) => i.key !== key) };
+      }
+      return {
+        ...state,
+        items: state.items.map((i) =>
+          i.key === key ? { ...i, quantity: Math.min(quantity, 99) } : i,
+        ),
+      };
+    }
+
+    case 'SET_ORDER_TYPE': {
+      return {
+        ...state,
+        orderType: action.payload.orderType,
+        // Clear table number when switching away from eat-in
+        tableNumber:
+          action.payload.orderType !== 'EatIn' ? '' : state.tableNumber,
+      };
+    }
+
+    case 'SET_TABLE_NUMBER': {
+      return { ...state, tableNumber: action.payload.tableNumber };
+    }
+
+    case 'SET_CUSTOMER_NAME': {
+      return { ...state, customerName: action.payload.customerName };
+    }
+
+    case 'RESET': {
+      return { ...initialState };
+    }
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory POS order state managed with useReducer.
+ * NOT persisted to localStorage — counter staff move fast and a stale ticket
+ * on reload is worse than starting fresh. Contrast with storefront CartContext.
+ */
+export function usePosOrder() {
+  const [state, dispatch] = useReducer(posOrderReducer, initialState);
+
+  const subtotal = state.items.reduce(
+    (sum, item) => sum + item.unitGrossPrice * item.quantity,
+    0,
+  );
+
+  return { state, dispatch, subtotal };
+}

--- a/src/frontend/src/features/pos/pages/Dashboard.tsx
+++ b/src/frontend/src/features/pos/pages/Dashboard.tsx
@@ -1,8 +1,146 @@
+import { useEffect } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { shopsApi } from '@api/shops';
+import type { Shop } from '@/types/common';
+
+const LAST_SHOP_KEY = (brandSlug: string) => `pos:last-shop:${brandSlug}`;
+
+/**
+ * POS dashboard — shop picker.
+ * Lists all active shops for the brand. Staff tap a shop to start ordering.
+ * Persists the last-used shop to localStorage and auto-redirects on next visit.
+ */
 export function PosDashboard() {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const { brandSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
+
+  const resolvedBrand = brandSlug ?? '';
+  const resolvedLang = lang ?? 'nl';
+
+  const { data: shops, isLoading, isError } = useQuery<Shop[]>({
+    queryKey: ['pos', 'shops', resolvedBrand],
+    queryFn: () => shopsApi.list(resolvedBrand),
+    enabled: resolvedBrand.length > 0,
+  });
+
+  // Auto-redirect to the last-used shop's order page
+  useEffect(() => {
+    const lastShop = localStorage.getItem(LAST_SHOP_KEY(resolvedBrand));
+    if (lastShop && shops) {
+      const exists = shops.some((s) => s.id === lastShop);
+      if (exists) {
+        navigate(`/${resolvedBrand}/${resolvedLang}/pos/shops/${lastShop}/order`, {
+          replace: true,
+        });
+      }
+    }
+  }, [shops, resolvedBrand, resolvedLang, navigate]);
+
+  function handleSelectShop(shopId: string) {
+    localStorage.setItem(LAST_SHOP_KEY(resolvedBrand), shopId);
+    navigate(`/${resolvedBrand}/${resolvedLang}/pos/shops/${shopId}/order`);
+  }
+
   return (
-    <main>
-      <h1>POS Dashboard</h1>
-      <p>Point of sale interface — touch-friendly, offline-capable.</p>
+    <main
+      style={{
+        maxWidth: '56rem',
+        margin: '0 auto',
+        padding: '2rem 1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.5rem',
+      }}
+    >
+      <h1 style={{ margin: 0, fontSize: '1.75rem', fontWeight: 800, color: '#111827' }}>
+        {t('pos.dashboard.title')}
+      </h1>
+      <p style={{ margin: 0, color: '#6b7280' }}>{t('pos.dashboard.selectShop')}</p>
+
+      {isLoading && <p style={{ color: '#9ca3af' }}>{t('loading')}</p>}
+      {isError && <p style={{ color: '#dc2626' }}>{t('error')}</p>}
+
+      {shops && shops.length === 0 && (
+        <p style={{ color: '#9ca3af' }}>{t('pos.dashboard.noShops')}</p>
+      )}
+
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {shops
+          ?.filter((shop) => shop.isActive)
+          .map((shop) => (
+            <li
+              key={shop.id}
+              style={{
+                background: '#fff',
+                border: '1px solid #e5e7eb',
+                borderRadius: '0.75rem',
+                padding: '1.25rem 1.5rem',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  flexWrap: 'wrap',
+                  gap: '1rem',
+                }}
+              >
+                <div>
+                  <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 700, color: '#111827' }}>
+                    {shop.name}
+                  </h2>
+                  <p style={{ margin: '0.25rem 0 0', fontSize: '0.875rem', color: '#6b7280' }}>
+                    {shop.address.street} {shop.address.number}, {shop.address.city}
+                  </p>
+                </div>
+                <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectShop(shop.id)}
+                    style={{
+                      minHeight: '2.75rem',
+                      padding: '0.625rem 1.25rem',
+                      background: '#111827',
+                      color: '#fff',
+                      fontWeight: 600,
+                      fontSize: '0.9375rem',
+                      border: 'none',
+                      borderRadius: '0.5rem',
+                      cursor: 'pointer',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {t('pos.dashboard.openOrdering')}
+                  </button>
+                  <Link
+                    to={`/${resolvedBrand}/${resolvedLang}/pos/shops/${shop.id}/kitchen`}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      minHeight: '2.75rem',
+                      padding: '0.625rem 1.25rem',
+                      background: '#f3f4f6',
+                      color: '#374151',
+                      fontWeight: 600,
+                      fontSize: '0.9375rem',
+                      border: '1px solid #e5e7eb',
+                      borderRadius: '0.5rem',
+                      textDecoration: 'none',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {t('pos.dashboard.openKitchen')}
+                  </Link>
+                </div>
+              </div>
+            </li>
+          ))}
+      </ul>
     </main>
   );
 }

--- a/src/frontend/src/features/pos/pages/NewOrderPage.tsx
+++ b/src/frontend/src/features/pos/pages/NewOrderPage.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useStorefrontCategories, useStorefrontCategoryProducts } from '@features/storefront/hooks/useStorefrontMenu';
+import { ProductTile } from '../components/ProductTile';
+import { PosTicket } from '../components/PosTicket';
+import { PosModifierModal } from '../components/PosModifierModal';
+import { usePosOrder } from '../hooks/usePosOrder';
+import { useCreatePosOrder } from '../hooks/useCreatePosOrder';
+import type { ProductListItem } from '@/types/common';
+import type { PosTicketModifier } from '../hooks/usePosOrder';
+
+/**
+ * POS new-order page — the heart of US-FP-018.
+ * Two-pane layout (CSS grid 1fr 22rem) optimised for 10" landscape tablet.
+ * Left pane: category tabs + product grid.
+ * Right pane: live ticket with qty controls, order type selector, table number, submit.
+ */
+export function NewOrderPage() {
+  const { t } = useTranslation('common');
+  const { brandSlug, lang } = useParams<{
+    brandSlug: string;
+    lang: string;
+    shopId: string;
+  }>();
+
+  const resolvedBrand = brandSlug ?? '';
+  const resolvedLang = lang ?? 'nl';
+
+  const { state, dispatch, subtotal } = usePosOrder();
+  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const [pendingProduct, setPendingProduct] = useState<ProductListItem | null>(null);
+
+  // Data hooks — reuse storefront queries (same cache, no duplication)
+  const { data: categories, isLoading: categoriesLoading } = useStorefrontCategories(resolvedBrand);
+  const firstCategoryId = categories?.[0]?.id ?? null;
+  const resolvedCategoryId = activeCategoryId ?? firstCategoryId;
+
+  const { data: products, isLoading: productsLoading } = useStorefrontCategoryProducts(
+    resolvedBrand,
+    resolvedCategoryId ?? '',
+  );
+
+  // Mutation
+  const createOrder = useCreatePosOrder(dispatch);
+
+  function handleProductTap(product: ProductListItem) {
+    // If product has no modifier groups we know about at tile level, just add it.
+    // The PosModifierModal will check and show "no modifiers" if none exist.
+    // To avoid an extra round-trip, we open the modal for all products so staff
+    // can confirm. Products with no modifiers get a quick "Add" button.
+    setPendingProduct(product);
+  }
+
+  function handleModifierConfirm(modifiers: PosTicketModifier[]) {
+    if (!pendingProduct) return;
+    dispatch({
+      type: 'ADD_ITEM',
+      payload: {
+        productId: pendingProduct.id,
+        productName: pendingProduct.name,
+        unitGrossPrice: pendingProduct.basePrice.amount,
+        selectedModifiers: modifiers,
+      },
+    });
+    setPendingProduct(null);
+  }
+
+  function handlePlaceOrder() {
+    if (state.items.length === 0) return;
+
+    createOrder.mutate({
+      orderType: state.orderType,
+      paymentMethod: 'CashAtPickup',
+      customerName: state.customerName.trim() || null,
+      tableNumber: state.orderType === 'EatIn' ? state.tableNumber.trim() : null,
+      items: state.items.map((item) => ({
+        productId: item.productId,
+        quantity: item.quantity,
+        selectedModifierIds: item.selectedModifiers.map((m) => m.modifierId),
+      })),
+    });
+  }
+
+  const submitError = createOrder.isError
+    ? (createOrder.error?.message ?? t('pos.order.submitError'))
+    : null;
+
+  return (
+    <div
+      style={{
+        height: '100dvh',
+        display: 'grid',
+        gridTemplateColumns: '1fr 22rem',
+        overflow: 'hidden',
+      }}
+    >
+      {/* ── Left pane — menu ── */}
+      <main
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Top bar */}
+        <header
+          style={{
+            padding: '0.75rem 1rem',
+            borderBottom: '1px solid #e5e7eb',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '0.75rem',
+            flexShrink: 0,
+          }}
+        >
+          <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 800, color: '#111827' }}>
+            {t('pos.order.title')}
+          </h1>
+          <Link
+            to={`/${resolvedBrand}/${resolvedLang}/pos`}
+            style={{
+              fontSize: '0.875rem',
+              color: '#6b7280',
+              textDecoration: 'none',
+              padding: '0.375rem 0.75rem',
+              border: '1px solid #d1d5db',
+              borderRadius: '0.375rem',
+            }}
+          >
+            ← {t('pos.dashboard.backToDashboard')}
+          </Link>
+        </header>
+
+        {/* Category tabs */}
+        {categoriesLoading ? (
+          <p style={{ padding: '1rem', color: '#9ca3af' }}>{t('loading')}</p>
+        ) : (
+          <nav
+            style={{
+              display: 'flex',
+              gap: '0.5rem',
+              padding: '0.75rem 1rem',
+              overflowX: 'auto',
+              flexShrink: 0,
+              borderBottom: '1px solid #f3f4f6',
+            }}
+            aria-label="Menu categorieën"
+          >
+            {categories?.map((cat) => {
+              const isActive = (resolvedCategoryId === cat.id);
+              return (
+                <button
+                  key={cat.id}
+                  type="button"
+                  onClick={() => setActiveCategoryId(cat.id)}
+                  style={{
+                    padding: '0.5rem 1rem',
+                    minHeight: '2.75rem',
+                    borderRadius: '2rem',
+                    border: isActive ? '2px solid #111827' : '2px solid #e5e7eb',
+                    background: isActive ? '#111827' : '#fff',
+                    color: isActive ? '#fff' : '#374151',
+                    fontWeight: 600,
+                    fontSize: '0.9375rem',
+                    cursor: 'pointer',
+                    whiteSpace: 'nowrap',
+                    flexShrink: 0,
+                  }}
+                >
+                  {cat.name}
+                </button>
+              );
+            })}
+          </nav>
+        )}
+
+        {/* Product grid */}
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: '1rem',
+          }}
+        >
+          {productsLoading ? (
+            <p style={{ color: '#9ca3af' }}>{t('loading')}</p>
+          ) : products && products.length > 0 ? (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(8rem, 1fr))',
+                gap: '0.75rem',
+              }}
+            >
+              {products.map((product) => (
+                <ProductTile key={product.id} product={product} onTap={handleProductTap} />
+              ))}
+            </div>
+          ) : (
+            <p style={{ color: '#9ca3af' }}>{t('storefront.menu.noCategories')}</p>
+          )}
+        </div>
+      </main>
+
+      {/* ── Right pane — ticket ── */}
+      <PosTicket
+        state={state}
+        subtotal={subtotal}
+        dispatch={dispatch}
+        onPlaceOrder={handlePlaceOrder}
+        isSubmitting={createOrder.isPending}
+        submitError={submitError}
+      />
+
+      {/* Modifier modal */}
+      {pendingProduct && (
+        <PosModifierModal
+          brandSlug={resolvedBrand}
+          product={pendingProduct}
+          onConfirm={handleModifierConfirm}
+          onClose={() => setPendingProduct(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/pos/pages/OrderPlacedPage.tsx
+++ b/src/frontend/src/features/pos/pages/OrderPlacedPage.tsx
@@ -1,0 +1,202 @@
+import { useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { ordersApi } from '@api/orders';
+
+const AUTO_REDIRECT_SECONDS = 10;
+
+/**
+ * POS order confirmation page — shown after a successful order submission.
+ * Shows the order number prominently, order type, table number (if eat-in),
+ * and item totals. Auto-redirects to new order after 10 seconds.
+ */
+export function OrderPlacedPage() {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const { brandSlug, lang, shopId, orderId } = useParams<{
+    brandSlug: string;
+    lang: string;
+    shopId: string;
+    orderId: string;
+  }>();
+
+  const resolvedBrand = brandSlug ?? '';
+  const resolvedShop = shopId ?? '';
+  const resolvedLang = lang ?? 'nl';
+  const resolvedOrderId = orderId ?? '';
+
+  const { data: order } = useQuery({
+    queryKey: ['pos', 'order', resolvedOrderId],
+    queryFn: () => ordersApi.getById(resolvedBrand, resolvedShop, resolvedOrderId),
+    enabled: resolvedOrderId.length > 0,
+  });
+
+  const newOrderPath = `/${resolvedBrand}/${resolvedLang}/pos/shops/${resolvedShop}/order`;
+
+  // Auto-redirect after 10 seconds
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigate(newOrderPath);
+    }, AUTO_REDIRECT_SECONDS * 1000);
+    return () => clearTimeout(timer);
+  }, [navigate, newOrderPath]);
+
+  const formattedTotal = order
+    ? new Intl.NumberFormat(`${resolvedLang}-BE`, { style: 'currency', currency: 'EUR' }).format(
+        order.totalGross,
+      )
+    : null;
+
+  return (
+    <main
+      style={{
+        minHeight: '100dvh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+        background: '#f0fdf4',
+        gap: '1.5rem',
+        textAlign: 'center',
+      }}
+    >
+      {/* Check mark */}
+      <div
+        style={{
+          width: '5rem',
+          height: '5rem',
+          borderRadius: '50%',
+          background: '#22c55e',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '2.5rem',
+          color: '#fff',
+        }}
+      >
+        ✓
+      </div>
+
+      <h1 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 800, color: '#166534' }}>
+        {t('pos.confirmation.title')}
+      </h1>
+
+      {/* Order number — prominent display */}
+      {order && (
+        <div
+          data-testid="pos-order-number"
+          style={{
+            background: '#fff',
+            border: '2px solid #22c55e',
+            borderRadius: '1rem',
+            padding: '1.5rem 3rem',
+          }}
+        >
+          <p style={{ margin: '0 0 0.25rem', fontSize: '0.875rem', color: '#6b7280', fontWeight: 600 }}>
+            {t('pos.confirmation.orderNumber')}
+          </p>
+          <p style={{ margin: 0, fontSize: '3rem', fontWeight: 900, color: '#111827', letterSpacing: '0.05em' }}>
+            #{order.orderNumber}
+          </p>
+        </div>
+      )}
+
+      {/* Order details */}
+      {order && (
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: '0.75rem',
+            padding: '1.25rem 1.5rem',
+            minWidth: '18rem',
+            textAlign: 'left',
+            border: '1px solid #e5e7eb',
+          }}
+        >
+          <dl style={{ margin: 0, display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+              <dt style={{ color: '#6b7280', fontSize: '0.875rem' }}>{t('pos.confirmation.orderType')}</dt>
+              <dd style={{ margin: 0, fontWeight: 600, fontSize: '0.9375rem', color: '#111827' }}>
+                {t(`pos.kitchen.orderType.${order.orderType}`)}
+              </dd>
+            </div>
+
+            {order.tableNumber && (
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+                <dt style={{ color: '#6b7280', fontSize: '0.875rem' }}>{t('pos.confirmation.tableNumber')}</dt>
+                <dd style={{ margin: 0, fontWeight: 600, fontSize: '0.9375rem', color: '#111827' }}>
+                  {order.tableNumber}
+                </dd>
+              </div>
+            )}
+
+            {order.customerName && (
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+                <dt style={{ color: '#6b7280', fontSize: '0.875rem' }}>{t('pos.confirmation.customerName')}</dt>
+                <dd style={{ margin: 0, fontWeight: 600, fontSize: '0.9375rem', color: '#111827' }}>
+                  {order.customerName}
+                </dd>
+              </div>
+            )}
+
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', borderTop: '1px solid #f3f4f6', paddingTop: '0.625rem' }}>
+              <dt style={{ color: '#6b7280', fontSize: '0.875rem' }}>{t('pos.confirmation.total')}</dt>
+              <dd style={{ margin: 0, fontWeight: 700, fontSize: '1.0625rem', color: '#111827' }}>
+                {formattedTotal}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Link
+          to={newOrderPath}
+          data-testid="pos-new-order-btn"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '3rem',
+            padding: '0.75rem 2rem',
+            background: '#111827',
+            color: '#fff',
+            fontWeight: 700,
+            fontSize: '1rem',
+            borderRadius: '0.75rem',
+            textDecoration: 'none',
+          }}
+        >
+          {t('pos.confirmation.newOrder')}
+        </Link>
+
+        <button
+          type="button"
+          disabled
+          title={t('pos.confirmation.printReceiptTooltip')}
+          style={{
+            minHeight: '3rem',
+            padding: '0.75rem 2rem',
+            background: '#f3f4f6',
+            color: '#9ca3af',
+            fontWeight: 600,
+            fontSize: '1rem',
+            borderRadius: '0.75rem',
+            border: '1px solid #e5e7eb',
+            cursor: 'not-allowed',
+          }}
+        >
+          {t('pos.confirmation.printReceipt')}
+        </button>
+      </div>
+
+      {/* Auto-redirect notice */}
+      <p style={{ color: '#9ca3af', fontSize: '0.8125rem', margin: 0 }}>
+        {t('pos.confirmation.autoRedirect', { seconds: AUTO_REDIRECT_SECONDS })}
+      </p>
+    </main>
+  );
+}

--- a/src/frontend/src/features/pos/pages/__tests__/NewOrderPage.test.tsx
+++ b/src/frontend/src/features/pos/pages/__tests__/NewOrderPage.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+
+import { renderWithProviders } from '../../../../test/testUtils';
+import { server } from '../../../../test/msw/server';
+import '../../../../i18n/config';
+
+// Mock SignalR so it never tries to open a WebSocket
+vi.mock('../../../../api/useOrderUpdates', () => ({
+  useOrderUpdates: () => ({ status: 'connected' as const }),
+}));
+
+import { NewOrderPage } from '../NewOrderPage';
+
+const brandSlug = 'frietjes';
+const shopId = '00000000-0000-0000-0000-000000000001';
+const categoryId = 'cat-1';
+
+const mockCategories = [
+  { id: categoryId, name: 'Frieten', sortOrder: 0 },
+];
+
+const mockProducts = [
+  {
+    id: 'prod-1',
+    name: 'Frietje Klein',
+    basePrice: { amount: 3.5, currency: 'EUR' },
+    imageUrl: null,
+    sortOrderInCategory: 0,
+    allergens: [],
+    dietaryTags: [],
+  },
+  {
+    id: 'prod-2',
+    name: 'Frietje Groot',
+    basePrice: { amount: 5.0, currency: 'EUR' },
+    imageUrl: null,
+    sortOrderInCategory: 1,
+    allergens: [],
+    dietaryTags: [],
+  },
+];
+
+function renderPage() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/:brandSlug/:lang/pos/shops/:shopId/order" element={<NewOrderPage />} />
+    </Routes>,
+    { initialEntries: [`/${brandSlug}/nl/pos/shops/${shopId}/order`] },
+  );
+}
+
+describe('NewOrderPage', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/menu-categories`, () =>
+        HttpResponse.json(mockCategories),
+      ),
+      http.get(`/api/brands/${brandSlug}/menu-categories/${categoryId}/products`, () =>
+        HttpResponse.json(mockProducts),
+      ),
+      http.get(`/api/brands/${brandSlug}/products/:productId/modifier-groups`, () =>
+        HttpResponse.json([]),
+      ),
+    );
+  });
+
+  it('renders the page title', async () => {
+    renderPage();
+    expect(await screen.findByText(/nieuwe bestelling/i)).toBeInTheDocument();
+  });
+
+  it('renders category tabs after loading', async () => {
+    renderPage();
+    expect(await screen.findByRole('button', { name: 'Frieten' })).toBeInTheDocument();
+  });
+
+  it('renders product tiles after loading', async () => {
+    renderPage();
+    expect(await screen.findByTestId('product-tile-prod-1')).toBeInTheDocument();
+    expect(screen.getByTestId('product-tile-prod-2')).toBeInTheDocument();
+  });
+
+  it('shows the table number input only when EatIn is selected', async () => {
+    renderPage();
+
+    // Wait for page to load
+    await screen.findByTestId('pos-ticket');
+
+    // Initially Pickup — no table number input
+    expect(screen.queryByTestId('pos-table-number-input')).not.toBeInTheDocument();
+
+    // Switch to EatIn
+    fireEvent.click(screen.getByRole('button', { name: /ter plaatse/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-table-number-input')).toBeInTheDocument();
+    });
+  });
+
+  it('disables Place order button when EatIn is selected without a table number', async () => {
+    renderPage();
+    await screen.findByTestId('pos-ticket');
+
+    // Add a product — wait for tile, click it, wait for non-disabled Add button, click
+    const tile = await screen.findByTestId('product-tile-prod-1');
+    fireEvent.click(tile);
+
+    // Wait for the "Add to order" button to appear and be enabled (modifier query resolved)
+    const addBtn = await screen.findByRole('button', { name: /toevoegen aan bon/i });
+    await waitFor(() => expect(addBtn).not.toBeDisabled());
+    fireEvent.click(addBtn);
+
+    // Wait for item to appear in ticket (subtotal becomes non-zero once item is added)
+    await waitFor(() =>
+      expect(screen.getByTestId('pos-subtotal')).toHaveTextContent(/3,50/),
+    );
+
+    // Switch to EatIn
+    fireEvent.click(screen.getByRole('button', { name: /ter plaatse/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-place-order-btn')).toBeDisabled();
+    });
+  });
+
+  it('enables Place order button when EatIn and table number are set', async () => {
+    renderPage();
+    await screen.findByTestId('pos-ticket');
+
+    // Add a product
+    const tile = await screen.findByTestId('product-tile-prod-1');
+    fireEvent.click(tile);
+
+    const addBtn = await screen.findByRole('button', { name: /toevoegen aan bon/i });
+    await waitFor(() => expect(addBtn).not.toBeDisabled());
+    fireEvent.click(addBtn);
+
+    // Wait for item to appear in ticket (subtotal becomes non-zero once item is added)
+    await waitFor(() =>
+      expect(screen.getByTestId('pos-subtotal')).toHaveTextContent(/3,50/),
+    );
+
+    // Switch to EatIn and enter table number
+    fireEvent.click(screen.getByRole('button', { name: /ter plaatse/i }));
+    const tableInput = await screen.findByTestId('pos-table-number-input');
+    fireEvent.change(tableInput, { target: { value: 'T-5' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-place-order-btn')).not.toBeDisabled();
+    });
+  });
+
+  it('submits with tableNumber when EatIn order is placed', async () => {
+    let capturedBody: unknown = null;
+
+    server.use(
+      http.post(`/api/brands/${brandSlug}/shops/${shopId}/orders`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(
+          {
+            id: 'order-123',
+            orderNumber: 'ABC123',
+            shopId,
+            brandSlug,
+            orderType: 'EatIn',
+            paymentMethod: 'CashAtPickup',
+            statusName: 'Placed',
+            customerName: null,
+            tableNumber: 'T-12',
+            items: [],
+            vatRatePercent: 21,
+            subtotalGross: 3.5,
+            totalVatAmount: 0.61,
+            totalNet: 2.89,
+            totalGross: 3.5,
+            createdAt: new Date().toISOString(),
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderPage();
+    await screen.findByTestId('pos-ticket');
+
+    // Add a product
+    const tile = await screen.findByTestId('product-tile-prod-1');
+    fireEvent.click(tile);
+
+    const addBtn = await screen.findByRole('button', { name: /toevoegen aan bon/i });
+    await waitFor(() => expect(addBtn).not.toBeDisabled());
+    fireEvent.click(addBtn);
+
+    // Wait for item to appear in ticket (subtotal becomes non-zero once item is added)
+    await waitFor(() =>
+      expect(screen.getByTestId('pos-subtotal')).toHaveTextContent(/3,50/),
+    );
+
+    // Switch to EatIn and enter table number
+    fireEvent.click(screen.getByRole('button', { name: /ter plaatse/i }));
+    const tableInput = await screen.findByTestId('pos-table-number-input');
+    fireEvent.change(tableInput, { target: { value: 'T-12' } });
+
+    // Submit
+    await waitFor(() =>
+      expect(screen.getByTestId('pos-place-order-btn')).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByTestId('pos-place-order-btn'));
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        orderType: 'EatIn',
+        tableNumber: 'T-12',
+        paymentMethod: 'CashAtPickup',
+      });
+    });
+  });
+});

--- a/src/frontend/src/features/pos/routes.tsx
+++ b/src/frontend/src/features/pos/routes.tsx
@@ -1,17 +1,62 @@
-// fallow-ignore-file unused-file
-//
-// POS route module. Wired up by US-FP-018 (POS ordering).
-
+import { lazy } from 'react';
 import type { RouteObject } from 'react-router-dom';
+import { SuspenseWrapper } from '@components/SuspenseWrapper';
 import { PosDashboard } from './pages/Dashboard';
+
+// Lazy-load heavier POS pages — split into separate chunks
+const LazyKitchenDisplay = lazy(() =>
+  import('./pages/KitchenDisplay').then((m) => ({ default: m.KitchenDisplay })),
+);
+
+const LazyNewOrderPage = lazy(() =>
+  import('./pages/NewOrderPage').then((m) => ({ default: m.NewOrderPage })),
+);
+
+const LazyOrderPlacedPage = lazy(() =>
+  import('./pages/OrderPlacedPage').then((m) => ({ default: m.OrderPlacedPage })),
+);
 
 /**
  * Route configuration for the in-store POS interface.
- * These routes are nested under /:brandSlug/:lang/pos/ in the main router.
+ * Nested under /:brandSlug/:lang/pos/ in the main router.
+ *
+ * Routes:
+ *   index                                      → PosDashboard (shop picker)
+ *   shops/:shopId/kitchen                      → KitchenDisplay (US-FP-027)
+ *   shops/:shopId/order                        → NewOrderPage (US-FP-018)
+ *   shops/:shopId/order/confirmation/:orderId  → OrderPlacedPage (US-FP-018)
  */
 export const posRoutes: RouteObject[] = [
   {
     index: true,
-    element: <PosDashboard />,
+    element: (
+      <SuspenseWrapper>
+        <PosDashboard />
+      </SuspenseWrapper>
+    ),
+  },
+  {
+    path: 'shops/:shopId/kitchen',
+    element: (
+      <SuspenseWrapper>
+        <LazyKitchenDisplay />
+      </SuspenseWrapper>
+    ),
+  },
+  {
+    path: 'shops/:shopId/order',
+    element: (
+      <SuspenseWrapper>
+        <LazyNewOrderPage />
+      </SuspenseWrapper>
+    ),
+  },
+  {
+    path: 'shops/:shopId/order/confirmation/:orderId',
+    element: (
+      <SuspenseWrapper>
+        <LazyOrderPlacedPage />
+      </SuspenseWrapper>
+    ),
   },
 ];

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -95,6 +95,41 @@
   },
   "pos": {
     "description": "Kassensystem für den Laden.",
+    "dashboard": {
+      "title": "POS-Dashboard",
+      "selectShop": "Wählen Sie ein Geschäft aus, um zu beginnen.",
+      "noShops": "Keine aktiven Geschäfte verfügbar.",
+      "openOrdering": "Bestellung aufnehmen",
+      "openKitchen": "Küchendisplay öffnen",
+      "backToDashboard": "Zurück zum Dashboard"
+    },
+    "order": {
+      "title": "Neue Bestellung",
+      "ticket": "Bon",
+      "empty": "Produkte zum Bon hinzufügen.",
+      "orderType": "Bestellart",
+      "tableNumberLabel": "Tischnummer",
+      "tableNumberPlaceholder": "z.B. T-12 oder 5",
+      "customerNameLabel": "Kundenname",
+      "customerNamePlaceholder": "Optional",
+      "subtotal": "Zwischensumme",
+      "placeOrder": "Bestellung aufgeben",
+      "placing": "Wird aufgegeben…",
+      "addToOrder": "Zum Bon hinzufügen",
+      "submitError": "Bestellung fehlgeschlagen. Bitte erneut versuchen."
+    },
+    "confirmation": {
+      "title": "Bestellung aufgegeben!",
+      "orderNumber": "Bestellnummer",
+      "orderType": "Bestellart",
+      "tableNumber": "Tisch",
+      "customerName": "Kundenname",
+      "total": "Gesamt",
+      "newOrder": "Neue Bestellung",
+      "printReceipt": "Bon drucken",
+      "printReceiptTooltip": "Bondrucker verfügbar in US-FP-028",
+      "autoRedirect": "Automatische Weiterleitung in {{seconds}} Sekunden…"
+    },
     "kitchen": {
       "title": "Küchendisplay",
       "empty": "Keine aktiven Bestellungen.",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -95,6 +95,41 @@
   },
   "pos": {
     "description": "Système de caisse en magasin.",
+    "dashboard": {
+      "title": "Tableau de bord POS",
+      "selectShop": "Sélectionnez un magasin pour commencer.",
+      "noShops": "Aucun magasin actif disponible.",
+      "openOrdering": "Passer une commande",
+      "openKitchen": "Ouvrir l'écran de cuisine",
+      "backToDashboard": "Retour au tableau de bord"
+    },
+    "order": {
+      "title": "Nouvelle commande",
+      "ticket": "Ticket",
+      "empty": "Ajoutez des produits au ticket.",
+      "orderType": "Type de commande",
+      "tableNumberLabel": "Numéro de table",
+      "tableNumberPlaceholder": "ex. T-12 ou 5",
+      "customerNameLabel": "Nom du client",
+      "customerNamePlaceholder": "Optionnel",
+      "subtotal": "Sous-total",
+      "placeOrder": "Passer la commande",
+      "placing": "En cours…",
+      "addToOrder": "Ajouter au ticket",
+      "submitError": "Échec de la commande. Veuillez réessayer."
+    },
+    "confirmation": {
+      "title": "Commande passée !",
+      "orderNumber": "Numéro de commande",
+      "orderType": "Type de commande",
+      "tableNumber": "Table",
+      "customerName": "Nom du client",
+      "total": "Total",
+      "newOrder": "Nouvelle commande",
+      "printReceipt": "Imprimer le reçu",
+      "printReceiptTooltip": "Imprimante de reçus disponible dans US-FP-028",
+      "autoRedirect": "Redirection automatique dans {{seconds}} secondes…"
+    },
     "kitchen": {
       "title": "Écran de cuisine",
       "empty": "Aucune commande active.",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -95,6 +95,41 @@
   },
   "pos": {
     "description": "Kassasysteem voor in de winkel.",
+    "dashboard": {
+      "title": "POS Dashboard",
+      "selectShop": "Selecteer een winkel om te beginnen.",
+      "noShops": "Geen actieve winkels beschikbaar.",
+      "openOrdering": "Bestelling plaatsen",
+      "openKitchen": "Keukendisplay openen",
+      "backToDashboard": "Terug naar dashboard"
+    },
+    "order": {
+      "title": "Nieuwe bestelling",
+      "ticket": "Bon",
+      "empty": "Voeg producten toe aan de bon.",
+      "orderType": "Besteltype",
+      "tableNumberLabel": "Tafelnummer",
+      "tableNumberPlaceholder": "bijv. T-12 of 5",
+      "customerNameLabel": "Klantnaam",
+      "customerNamePlaceholder": "Optioneel",
+      "subtotal": "Subtotaal",
+      "placeOrder": "Bestelling plaatsen",
+      "placing": "Bezig…",
+      "addToOrder": "Toevoegen aan bon",
+      "submitError": "Bestelling plaatsen mislukt. Probeer opnieuw."
+    },
+    "confirmation": {
+      "title": "Bestelling geplaatst!",
+      "orderNumber": "Bestelnummer",
+      "orderType": "Besteltype",
+      "tableNumber": "Tafel",
+      "customerName": "Klantnaam",
+      "total": "Totaal",
+      "newOrder": "Nieuwe bestelling",
+      "printReceipt": "Bon afdrukken",
+      "printReceiptTooltip": "Bonprinter beschikbaar in US-FP-028",
+      "autoRedirect": "Automatisch doorgestuurd over {{seconds}} seconden…"
+    },
     "kitchen": {
       "title": "Keukendisplay",
       "empty": "Geen actieve bestellingen.",

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -1,26 +1,13 @@
-import { lazy } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import { extractPrimaryLocale } from '@/types/common';
 import { LANGUAGE_PREF_KEY } from '@features/storefront/components/LanguageSelector';
 import { AppShell } from '@components/AppShell';
 import { AppVariantLayout } from '@components/AppVariantLayout';
-import { SuspenseWrapper } from '@components/SuspenseWrapper';
 import { RequireAuth } from '@/auth/RequireAuth';
 import { adminRoutes } from '@features/admin/routes';
 import { storefrontRoutes } from '@features/storefront/routes';
 import { ThemeProvider } from '@features/storefront/components/ThemeProvider';
-
-// ---------------------------------------------------------------------------
-// Lazy-loaded feature pages — split into separate chunks by Vite/Rollup
-// ---------------------------------------------------------------------------
-
-const LazyPosDashboard = lazy(() =>
-  import('@features/pos/pages/Dashboard').then((m) => ({ default: m.PosDashboard })),
-);
-
-const LazyKitchenDisplay = lazy(() =>
-  import('@features/pos/pages/KitchenDisplay').then((m) => ({ default: m.KitchenDisplay })),
-);
+import { posRoutes } from '@features/pos/routes';
 
 /**
  * Resolves the initial locale for the root redirect.
@@ -74,26 +61,7 @@ export const router = createBrowserRouter([
             <AppVariantLayout variant="pos" />
           </RequireAuth>
         ),
-        children: [
-          {
-            index: true,
-            element: (
-              <SuspenseWrapper>
-                <LazyPosDashboard />
-              </SuspenseWrapper>
-            ),
-          },
-          {
-            // Kitchen display screen (US-FP-027) — shop-scoped because each store
-            // has its own pass and the staff member is at a single station.
-            path: 'shops/:shopId/kitchen',
-            element: (
-              <SuspenseWrapper>
-                <LazyKitchenDisplay />
-              </SuspenseWrapper>
-            ),
-          },
-        ],
+        children: posRoutes,
       },
       // ── Admin ────────────────────────────────────────────────────────────
       {


### PR DESCRIPTION
## Summary

- Counter staff can now place walk-in orders through a touch-friendly POS screen that submits via the existing online-ordering pipeline, so the kitchen display (US-FP-027) picks them up via SignalR with zero extra plumbing.
- New tablet-optimised UX under `/{brand}/{lang}/pos/shops/:shopId/order`: shop picker dashboard, two-pane new-order screen (product tiles + live ticket), order-type segmented control, conditional table-number input, and a confirmation page.
- Adds nullable `Order.TableNumber` (NVARCHAR(20)) with API-layer validation requiring it for `OrderType=EatIn`. The domain stays permissive so US-FP-066 (per-shop eat-in toggle) and US-FP-024 (customer eat-in) can layer on without breaking the aggregate.

## Scope decisions (approved before execution)

- Eat-in + table number **in scope** (matches the AC); US-FP-024 / US-FP-066 stay deferred.
- Ticket printer **out of scope** — US-FP-028 will hook into the same `OrderCreatedEvent` later.
- All POS orders use `PaymentMethod=CashAtPickup`; no mock-payment screen invoked.
- Mock auth's `counter-staff` persona is sufficient for demo; real Keycloak staff login is US-FP-039.

## Plan

See `.agents/plans/us-fp-018-place-instore-order.md`.

## Test plan

- [x] Backend builds clean (`dotnet build` — 0 errors).
- [x] Backend unit tests pass (TUnit, 249/249).
- [x] Frontend type-check + production build pass (`pnpm build`).
- [x] Frontend tests pass (Vitest, 286/286 across 55 files), including new `usePosOrder` reducer, `ProductTile`, `PosTicket`, `OrderTypeSelector`, and `NewOrderPage` (end-to-end add-and-submit) tests.
- [ ] Backend integration tests (require Docker for Testcontainers — not run locally; CI will execute). New scenarios in `PlaceOrderTests` and `ListActiveOrdersTests` cover the EatIn-with-table, EatIn-without-table (400), Pickup-without-table, and too-long-table cases plus the active-orders surface.
- [ ] Manual verification on a tablet-sized viewport with mock auth (`counter-staff` persona): pick a shop, build a ticket, switch order type to Eat-In with `T-12`, place order, see it appear in the kitchen display in real time.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)