### PR TITLE
US-FP-018: in-store POS ordering (counter staff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ nunit-*.xml
 
 # Claude
 .claude/settings.local.json
+.claude/worktrees/
 node_modules/
 
 # Fallow caches (any depth)

--- a/OUTPUT_SUMMARY.md
+++ b/OUTPUT_SUMMARY.md
@@ -1,0 +1,81 @@
+# US-FP-018 — `/workflows` arm output summary
+
+**Story:** US-FP-018 — *Place an in-store order (counter staff)*: a touch-friendly POS interface so walk-in customers are served efficiently.
+**Branch:** `tryWithClaudeWorkflows` (no merge/push).
+**Orchestration backbone:** Claude Code's built-in `Workflow` tool (`/workflows`) — used in place of an external planning skill for decomposition, fan-out, pipelining, and adversarial quality gates.
+**Final status:** Understand ✅ · Design ✅ · Backend implement ✅ (`1ddb0a4`) · Frontend implement ✅ (`9589791`) · Final review + gap-closing ✅ (commit pending). **Feature complete and green end-to-end.**
+
+This run was **manual and interactive** — the user drove, approving each phase boundary and making the consequential calls. The notes below mark who decided what.
+
+---
+
+## 1. Architectural decisions (and who made them)
+
+| # | Decision | Outcome | Decided by |
+|---|---|---|---|
+| D1 | In-store submit path | **New authenticated endpoint** `POST .../orders/in-store` (`Roles("CounterStaff")`) reusing `OrderService`; public `POST .../orders` stays anonymous and unchanged | **User** — chose from 3 options the Understand workflow surfaced with evidence |
+| D2 | "Same fulfillment flow" scope | **SignalR-only** — reuse the existing `OrderCreatedEvent → OrderHub` fan-out; defer real KDS screen + ticket printer to US-FP-027 | **User** — workflow showed online orders already do exactly this |
+| D3 | Table number storage | **Persisted on the `Order` aggregate** (field + EF mapping + BrandDb migration), required only for in-store eat-in | **User** — kitchen ticket needs it |
+| D4 | Staff tracking | **Persist `CreatedByStaffId`** (same migration), captured server-side from the auth principal | **User confirmed** — flagged by Claude as a consequence of choosing an authenticated endpoint |
+| D5 | Implementation cadence | **Backend first → checkpoint → frontend + tests → final review** | **User** |
+| D6 | Pre-existing `OrderTrackingMapper` bug fix | **Keep it** in the backend slice | **User** — surfaced by Claude as a scope deviation |
+| D7 | Residual test gaps (R1/R2) | **Close them** in the review pass (write the two missing tests) | **User** |
+| — | ~13 implementation micro-decisions (separate service method, numeric table input, inline error panel, minimal confirmation screen, separate validator class, auto-gen migration, hardcoded EUR, table range 1–999, return new fields on `OrderResponse`, etc.) | Workflow-recommended defaults | **Workflow-suggested, Claude accepted & flagged** |
+
+**Mechanical decisions Claude made directly** (not escalated): reader/probe/designer counts and slicing, reader tooling (codebase-memory-graph-first with Read/Grep fallback), and — most consequentially — **keeping all code-writing single-threaded** rather than fanning out parallel writers (see §2.3).
+
+---
+
+## 2. How `/workflows` shaped the plan
+
+Five workflows ran in sequence, each its own phase, with a user checkpoint at every boundary. Totals: **5 workflows, 27 subagents, ~2.52M subagent tokens.**
+
+### 2.1 `understand-us-fp-018` (5 agents, ~427k tok)
+4 parallel `Explore` readers (POS app · Order backend · storefront checkout · fulfillment) → **barrier** → 1 synthesizer. Barrier justified: synthesis cross-references all four reads. Produced a reuse map showing the **backend is ~90% reusable**, an explicit **endpoint-vs-param evidence table**, and established that **no channel/source/table-number concept exists in `src/`** today — so D1–D4 were genuine design choices, not discoveries.
+
+### 2.2 `design-us-fp-018` (7 agents, ~613k tok)
+Probe (3 parallel) → **barrier** → Design (3 parallel: backend/frontend/tests) → **barrier** → 1 consistency critic. Produced a ~30-task ordered spec, an **AC-coverage matrix** (all 6 ACs → tasks + tests), `reuseViolations: []`. **Adversarial verify earned its keep:** the critic returned `contractConsistency: false` — `OrderResponse` was missing `tableNumber`/`createdByStaffId` — adding a task *before* any code was written.
+
+### 2.3 `implement-us-fp-018-backend` (5 agents, ~448k tok)
+**Deliberate orchestration choice:** the backend slice is one tightly-coupled contract, so **fanning out parallel writers would produce inconsistent, conflicting code**. The workflow kept *writing* coherent (1 implementer) and spent parallelism on **review**: Build (1) → Review (3 parallel lenses, barrier) → Repair (1). The contract reviewer (HIGH) caught `CreatedByStaffId` leaking into the app-layer request DTO → repair made it a **server-side-only parameter**. Repair added 2 tests and **correctly dismissed a false positive** (asserting `OrderCreatedEvent` is in `DomainEvents` would always fail — `CollectAndClear()` runs before `SaveChanges`). Also fixed a **pre-existing `OrderTrackingMapper` bug**.
+
+### 2.4 `implement-us-fp-018-frontend` (5 agents, ~511k tok)
+Same shape (Build → 3-lens Review → Repair), same single-threaded-writing discipline. The Build agent wrote 4 test files; **review caught coverage holes** and repair closed several (added the `PosOrderConfirmation` spec, made the AC2 test assert the *correct* product's modifiers, added combo-re-add and exact-key payload assertions, added MSW payload validation) and fixed a genuine **React Router anti-pattern** (render-time `navigate()` → `useEffect`).
+
+### 2.5 `review-us-fp-018` (5 agents, ~524k tok) — final cross-cutting pass
+4 parallel lenses over the whole feature (e2e+contract · security/auth · AC+tests · quality/reuse) → **barrier** → 1 close+repair agent. Per D7 it wrote the two mandated tests — **`PosModifierFlow.test.tsx` (t-16, AC5 end-to-end UI modifier flow)** and **`PosDashboardGuard.test.tsx` (t-17, AC4 real-`Dashboard` guard)** — and **principled-dismissed** the "remove redundant validation" suggestions (kept DDD defense-in-depth), deferring shared-code refactors as documented follow-ups.
+
+### 2.6 Independent verification (Claude, outside the workflows) — where it mattered most
+After **every** implement/review workflow, Claude re-ran the real gates rather than trusting self-reports. This was not ceremony:
+- **Backend phase:** the LSP flagged the new test file as uncompilable; a real `dotnet build` proved it compiled (0 errors) — the LSP was **stale** (unrestored `.csproj` refs).
+- **Review phase:** the workflow self-reported "typecheck 0 errors," but an independent `tsc --noEmit` caught a real **`TS6133` unused-variable error** (`addItemToOrder`) in the generated `PosDashboardGuard.test.tsx`. Vitest had passed because esbuild strips types and does not enforce `tsc`. Claude removed the dead helper; typecheck then passed. **Lesson: a workflow agent's claim of "green" is only trustworthy for gates it actually ran — independent gate-running is essential.**
+- A reported `MSB3492` solution-build file-lock turned out **transient** (a process holding `obj` files during concurrent builds); it did not recur on a clean re-run.
+
+---
+
+## 3. Final state — verified green
+
+- **Backend:** `dotnet build` → 0 errors; **268 TUnit unit tests** pass (incl. the new in-store endpoint/validator tests) + **6 integration tests** (real SQL via Testcontainers). Commit `1ddb0a4`.
+- **Frontend:** `tsc --noEmit` → 0 errors; **255 Vitest tests across 52 files** pass (incl. 7 POS spec files). Commit `9589791` + a pending commit for the review-pass tests/fixes.
+- **API contract:** `POST /api/brands/{brandSlug}/shops/{shopId}/orders/in-store` — request carries `tableNumber` (required for eat-in); server forces `CashAtPickup` and sets `CreatedByStaffId` from the token; response returns both new fields. Public endpoint untouched.
+- **ACs:** AC1–AC6 each covered by implementation **and** test (AC5's UI modifier path and AC4's real-`Dashboard` guard closed in the review pass).
+
+---
+
+## 4. Compromises, open questions, and follow-ups
+
+**Closed during the run:** R1 (AC5 end-to-end UI modifier flow) and R2 (AC4 real-`Dashboard` guard) — both now have dedicated tests.
+
+**Documented follow-ups (deliberately out of scope):**
+- **Staff-id claim name** — code uses fallback `NameIdentifier → "sub" → "userId"`; confirm against what the BFF actually forwards in a running environment.
+- **Role-gated HTTP backend test** — integration tests drive the service via DI (Testing env uses JWT Bearer with no mock tokens); `Roles("CounterStaff")` is proven by an anonymous→401 HTTP test + the `Configure()` declaration, not a role-bearing HTTP test.
+- **Touch-target / tablet-viewport tests (AC1/AC6)** and **SignalR fan-out (AC5)** need Playwright / a running hub — not expressible in JSDOM/Vitest; deferred.
+- **Refactor duplication:** `PosModifierModal` vs storefront `ModifierModal`, `PosOrderContext` vs `CartContext` reducer, `OrderTrackingMapper` vs `OrderService` private mapper, and the two FluentValidation validators — all candidates for shared extraction, deferred as separate stories.
+- **Known limitation:** a combo is a **single order line** (no per-component customization) — matches today's order flow.
+- POS order state is **transient per-terminal** (lost on reload, intentional).
+
+---
+
+## 5. Process note for the comparison
+
+`/workflows` was a strong fit for the **read / design / review** phases — genuine parallel fan-out with barriers placed only where cross-item synthesis required them, and adversarial critics that twice changed the outcome before it could ship (the design critic adding the `OrderResponse` contract task; the implement reviewer de-leaking `CreatedByStaffId`). Its main limit showed at the **writing** step: parallel writers across a coupled contract are counterproductive, so the high-value pattern was *single-threaded writing + fan-out verification*. Two recurring caveats: workflow agents' **self-reported "green" was not always real** (a `tsc` error slipped through a Vitest-only check), and **stale tooling/transient build locks** produced false alarms — both caught only by Claude independently re-running the actual build/typecheck/test gates after each phase.

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateInStoreOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateInStoreOrderEndpoint.cs
@@ -26,6 +26,9 @@ public sealed class CreateInStoreOrderRequestValidator : Validator<CreateInStore
             .Must(v => Enum.TryParse<OrderType>(v, ignoreCase: true, out var parsed) && Enum.IsDefined(parsed))
             .WithMessage($"OrderType must be one of: {string.Join(", ", Enum.GetNames<OrderType>())}.");
 
+        // PaymentMethod is validated for enum-syntax only.
+        // OrderService.CreateInStoreOrderAsync will override it to CashAtPickup server-side
+        // regardless of the client-submitted value — the field is accepted for API symmetry.
         RuleFor(x => x.PaymentMethod)
             .NotEmpty().WithMessage("PaymentMethod is required.")
             .Must(v => Enum.TryParse<Domain.Orders.PaymentMethod>(v, ignoreCase: true, out var parsed) && Enum.IsDefined(parsed))

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateInStoreOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateInStoreOrderEndpoint.cs
@@ -1,0 +1,151 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentValidation;
+using FluentValidation.Results;
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record CreateInStoreOrderApiRequest(
+    [property: RouteParam] string BrandSlug,
+    [property: RouteParam] Guid ShopId,
+    string OrderType,
+    string PaymentMethod,
+    string? CustomerName,
+    int? TableNumber,
+    List<OrderItemApiInput> Items);
+
+public sealed class CreateInStoreOrderRequestValidator : Validator<CreateInStoreOrderApiRequest>
+{
+    public CreateInStoreOrderRequestValidator()
+    {
+        RuleFor(x => x.OrderType)
+            .NotEmpty().WithMessage("OrderType is required.")
+            .Must(v => Enum.TryParse<OrderType>(v, ignoreCase: true, out var parsed) && Enum.IsDefined(parsed))
+            .WithMessage($"OrderType must be one of: {string.Join(", ", Enum.GetNames<OrderType>())}.");
+
+        RuleFor(x => x.PaymentMethod)
+            .NotEmpty().WithMessage("PaymentMethod is required.")
+            .Must(v => Enum.TryParse<Domain.Orders.PaymentMethod>(v, ignoreCase: true, out var parsed) && Enum.IsDefined(parsed))
+            .WithMessage($"PaymentMethod must be one of: {string.Join(", ", Enum.GetNames<Domain.Orders.PaymentMethod>())}.");
+
+        RuleFor(x => x.Items)
+            .NotEmpty().WithMessage("At least one item is required.");
+
+        RuleForEach(x => x.Items).ChildRules(item =>
+        {
+            item.RuleFor(i => i.ProductId)
+                .NotEmpty().WithMessage("ProductId is required.");
+
+            item.RuleFor(i => i.Quantity)
+                .GreaterThan(0).WithMessage("Quantity must be greater than zero.")
+                .LessThanOrEqualTo(99).WithMessage("Quantity cannot exceed 99.");
+        });
+
+        RuleFor(x => x.CustomerName)
+            .MaximumLength(200)
+            .When(x => x.CustomerName is not null);
+
+        // TableNumber is required and must be > 0 only when OrderType is EatIn
+        RuleFor(x => x.TableNumber)
+            .NotNull().WithMessage("TableNumber is required for EatIn orders.")
+            .GreaterThan(0).WithMessage("TableNumber must be greater than zero.")
+            .When(x => string.Equals(x.OrderType, "EatIn", StringComparison.OrdinalIgnoreCase));
+    }
+}
+
+/// <summary>
+/// Creates a new in-store order on behalf of authenticated counter staff.
+/// Route: POST /api/brands/{brandSlug}/shops/{shopId}/orders/in-store
+///
+/// Differences from the public <see cref="CreateOrderEndpoint"/>:
+/// <list type="bullet">
+///   <item><description>Requires the <c>CounterStaff</c> role — anonymous access is not permitted.</description></item>
+///   <item><description>PaymentMethod is forced to <c>CashAtPickup</c> server-side.</description></item>
+///   <item><description>TableNumber is required for EatIn orders.</description></item>
+///   <item><description>CreatedByStaffId is extracted from the authenticated user's claims (never trusted from the client).</description></item>
+/// </list>
+/// </summary>
+public sealed class CreateInStoreOrderEndpoint(IOrderService orderService)
+    : Endpoint<CreateInStoreOrderApiRequest, OrderResponse>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders/in-store";
+
+    public override void Configure()
+    {
+        Post(Route);
+        Roles("CounterStaff");
+        PreProcessor<BrandScopedPreProcessor<CreateInStoreOrderApiRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Place a new in-store order (counter staff)";
+            s.Description =
+                "Creates a new in-store order for the specified shop by authenticated counter staff. " +
+                "PaymentMethod is forced to CashAtPickup. " +
+                "TableNumber is required for EatIn orders. " +
+                "Staff identity is captured server-side from the authenticated user.";
+            s.Response<OrderResponse>(201, "In-store order placed successfully.");
+            s.Response(400, "Validation error or unknown product/modifier.");
+            s.Response(401, "Authentication required.");
+            s.Response(403, "Caller does not have the CounterStaff role.");
+            s.Response(404, "Shop or brand not found.");
+        });
+    }
+
+    public override async Task HandleAsync(CreateInStoreOrderApiRequest req, CancellationToken ct)
+    {
+        // Extract staff ID from the authenticated user.
+        // Prefer the standard OIDC 'sub' claim (ClaimTypes.NameIdentifier maps to 'sub' when
+        // MapInboundClaims=false, but some issuers send it under the literal "sub" key).
+        // Fall back to a 'userId' claim as a secondary convention used by some identity providers.
+        var staffIdString =
+            HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)  // maps to 'sub' via JwtBearer
+            ?? HttpContext.User.FindFirstValue("sub")                    // literal 'sub' claim
+            ?? HttpContext.User.FindFirstValue("userId");                // fallback convention
+
+        Guid? createdByStaffId = null;
+        if (staffIdString is not null && Guid.TryParse(staffIdString, out var parsedStaffId))
+            createdByStaffId = parsedStaffId;
+
+        try
+        {
+            var appRequest = new CreateInStoreOrderRequest(
+                req.ShopId,
+                req.BrandSlug,
+                req.OrderType,
+                req.PaymentMethod,
+                req.CustomerName,
+                req.TableNumber,
+                req.Items
+                    .Select(i => new OrderItemInput(
+                        i.ProductId,
+                        i.Quantity,
+                        (i.SelectedModifierIds ?? []).AsReadOnly()))
+                    .ToList()
+                    .AsReadOnly());
+
+            // createdByStaffId is passed as a separate explicit parameter so the service
+            // never reads it from the DTO — it is always the server-extracted claim value.
+            var response = await orderService.CreateInStoreOrderAsync(appRequest, createdByStaffId, ct);
+
+            await HttpContext.Response.SendAsync(response, statusCode: 201, cancellation: ct);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            var failures = new List<ValidationFailure> { new("items", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+        catch (ArgumentException ex)
+        {
+            var failures = new List<ValidationFailure> { new("request", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            var failures = new List<ValidationFailure> { new("request", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
@@ -41,5 +41,7 @@ internal static class OrderTrackingMapper
             order.TotalVatAmount,
             order.TotalNet,
             order.TotalGross,
-            order.CreatedAt);
+            order.CreatedAt,
+            order.TableNumber,
+            order.CreatedByStaffId);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/ModifierGroups/ModifierGroupDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/ModifierGroups/ModifierGroupDtos.cs
@@ -54,7 +54,9 @@ public sealed record ProductModifierGroupResponse(
     Guid Id,
     Guid ProductId,
     Guid ModifierGroupId,
-    int SortOrder);
+    string Name,
+    int SortOrder,
+    IReadOnlyList<ModifierResponse> Modifiers);
 
 public sealed record SetProductModifierGroupsRequest(
     IReadOnlyList<ProductModifierGroupAssignment> Assignments);

--- a/src/backend/TheMillionthFoodOrderApp.Application/ModifierGroups/ModifierGroupService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/ModifierGroups/ModifierGroupService.cs
@@ -113,11 +113,37 @@ public sealed class ModifierGroupService(
         Guid productId,
         CancellationToken cancellationToken = default)
     {
+        var primaryLanguage = await GetPrimaryLanguageAsync(cancellationToken);
         var assignments = await modifierGroupRepository.GetProductModifierGroupsAsync(productId, cancellationToken);
-        return assignments
-            .Select(pmg => new ProductModifierGroupResponse(pmg.Id, pmg.ProductId, pmg.ModifierGroupId, pmg.SortOrder))
-            .ToList()
-            .AsReadOnly();
+
+        var result = new List<ProductModifierGroupResponse>(assignments.Count);
+        foreach (var pmg in assignments)
+        {
+            // The assignment only stores the group id + sort order; load the full group
+            // so the response carries the resolved name + modifiers the menu UI needs.
+            var group = await modifierGroupRepository.GetByIdAsync(pmg.ModifierGroupId, cancellationToken);
+            if (group is null)
+                continue; // assigned group was soft-deleted — skip rather than emit a broken row
+
+            var name = TranslationResolver.ResolveName(
+                group.Translations, t => t.LanguageCode, t => t.Name, primaryLanguage);
+
+            var modifiers = group.Modifiers
+                .OrderBy(m => m.SortOrder)
+                .Select(m => new ModifierResponse(
+                    m.Id,
+                    m.PriceAdjustment,
+                    m.SortOrder,
+                    m.Translations
+                        .Select(t => new ModifierTranslationResponse(t.LanguageCode, t.Name))
+                        .ToList().AsReadOnly()))
+                .ToList().AsReadOnly();
+
+            result.Add(new ProductModifierGroupResponse(
+                pmg.Id, pmg.ProductId, pmg.ModifierGroupId, name, pmg.SortOrder, modifiers));
+        }
+
+        return result.AsReadOnly();
     }
 
     public async Task SetProductModifierGroupsAsync(

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateInStoreOrderRequest.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateInStoreOrderRequest.cs
@@ -1,0 +1,18 @@
+namespace TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+/// <summary>
+/// Application-layer DTO for placing a new in-store order via counter staff.
+/// PaymentMethod is forced to CashAtPickup by the service regardless of what is passed.
+/// Note: CreatedByStaffId is NOT part of this DTO — it is captured server-side from the
+/// authenticated user's claims and passed as a separate explicit parameter to
+/// <see cref="IOrderService.CreateInStoreOrderAsync"/> to prevent any possibility of
+/// client-supplied values being trusted.
+/// </summary>
+public sealed record CreateInStoreOrderRequest(
+    Guid ShopId,
+    string BrandSlug,
+    string OrderType,
+    string PaymentMethod,
+    string? CustomerName,
+    int? TableNumber,
+    IReadOnlyList<OrderItemInput> Items);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
@@ -17,7 +17,15 @@ public sealed record OrderItemResponse(
     decimal LineTotal,
     IReadOnlyList<SelectedModifierResponse> SelectedModifiers);
 
-/// <summary>Full response DTO returned when an order is created or retrieved.</summary>
+/// <summary>
+/// Full response DTO returned when an order is created or retrieved.
+/// <para>
+/// <c>TableNumber</c> and <c>CreatedByStaffId</c> are populated only for in-store orders
+/// placed via the counter-staff endpoint. They are <see langword="null"/> for customer-facing
+/// online orders (public <c>POST /orders</c>). API consumers must not assume these fields
+/// are always populated.
+/// </para>
+/// </summary>
 public sealed record OrderResponse(
     Guid Id,
     string OrderNumber,
@@ -33,4 +41,8 @@ public sealed record OrderResponse(
     decimal TotalVatAmount,
     decimal TotalNet,
     decimal TotalGross,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    /// <summary>Table number for eat-in in-store orders; null for online/pickup/delivery orders.</summary>
+    int? TableNumber = null,
+    /// <summary>Counter staff ID extracted server-side from JWT claims; null for customer-facing orders.</summary>
+    Guid? CreatedByStaffId = null);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderService.cs
@@ -18,4 +18,30 @@ public interface IOrderService
     /// Thrown when the order type is invalid or items list is empty.
     /// </exception>
     Task<OrderResponse> CreateOrderAsync(CreateOrderRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Places a new in-store order on behalf of authenticated counter staff.
+    /// Differs from <see cref="CreateOrderAsync"/> in the following ways:
+    /// <list type="bullet">
+    ///   <item><description>PaymentMethod is forced to <c>CashAtPickup</c> regardless of the request value.</description></item>
+    ///   <item><description><c>TableNumber</c> is required for <c>EatIn</c> orders and must be greater than zero.</description></item>
+    ///   <item><description><c>CreatedByStaffId</c> is captured server-side from the authenticated user claim — not from the client.</description></item>
+    /// </list>
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when a referenced product ID or the shop does not exist.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the order type is invalid, items list is empty,
+    /// or TableNumber is null/zero for an EatIn order.
+    /// </exception>
+    /// <param name="createdByStaffId">
+    /// The staff member's identity extracted server-side from the authenticated user's claims.
+    /// Passed separately from <paramref name="request"/> so this value is never read from the
+    /// client-submitted DTO — it is always injected by the endpoint from the JWT/session.
+    /// </param>
+    Task<OrderResponse> CreateInStoreOrderAsync(
+        CreateInStoreOrderRequest request,
+        Guid? createdByStaffId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -40,35 +40,110 @@ public sealed class OrderService(
         if (request.Items.Count == 0)
             throw new ArgumentException("An order must contain at least one item.");
 
-        // 2. Determine consumption mode for VAT calculation
+        return await CreateOrderCoreAsync(
+            request.ShopId,
+            request.BrandSlug,
+            orderType,
+            paymentMethod,
+            request.CustomerName,
+            tableNumber: null,
+            createdByStaffId: null,
+            request.Items,
+            cancellationToken);
+    }
+
+    public async Task<OrderResponse> CreateInStoreOrderAsync(
+        CreateInStoreOrderRequest request,
+        Guid? createdByStaffId,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Parse and validate order type
+        if (!Enum.TryParse<OrderType>(request.OrderType, ignoreCase: true, out var orderType) || !Enum.IsDefined(orderType))
+            throw new ArgumentException(
+                $"Invalid order type: '{request.OrderType}'. Valid values: {string.Join(", ", Enum.GetNames<OrderType>())}.");
+
+        // 1b. Parse and validate payment method (for enum validity only — will be forced to CashAtPickup)
+        if (!Enum.TryParse<PaymentMethod>(request.PaymentMethod, ignoreCase: true, out _) ||
+            !Enum.IsDefined(Enum.Parse<PaymentMethod>(request.PaymentMethod, ignoreCase: true)))
+            throw new ArgumentException(
+                $"Invalid payment method: '{request.PaymentMethod}'. Valid values: {string.Join(", ", Enum.GetNames<PaymentMethod>())}.");
+
+        if (request.Items.Count == 0)
+            throw new ArgumentException("An order must contain at least one item.");
+
+        // 2. EatIn requires a valid table number
+        if (orderType == OrderType.EatIn)
+        {
+            if (request.TableNumber is null)
+                throw new ArgumentException("TableNumber is required for EatIn orders.");
+            if (request.TableNumber.Value <= 0)
+                throw new ArgumentException("TableNumber must be greater than zero.");
+        }
+
+        // 3. Force payment method to CashAtPickup for in-store orders
+        var paymentMethod = PaymentMethod.CashAtPickup;
+
+        // 4. createdByStaffId is supplied by the caller (endpoint extracts it from claims)
+        //    and is never read from the request DTO to prevent client-trust issues.
+        return await CreateOrderCoreAsync(
+            request.ShopId,
+            request.BrandSlug,
+            orderType,
+            paymentMethod,
+            request.CustomerName,
+            request.TableNumber,
+            createdByStaffId,
+            request.Items,
+            cancellationToken);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Shared order-creation core: resolves VAT, shop, lifecycle, products, modifiers,
+    /// builds order items, and persists with retry logic. Both the public and in-store
+    /// endpoints delegate here so pricing/VAT/modifier logic is never duplicated.
+    /// </summary>
+    private async Task<OrderResponse> CreateOrderCoreAsync(
+        Guid shopId,
+        string brandSlug,
+        OrderType orderType,
+        PaymentMethod paymentMethod,
+        string? customerName,
+        int? tableNumber,
+        Guid? createdByStaffId,
+        IReadOnlyList<OrderItemInput> items,
+        CancellationToken cancellationToken)
+    {
+        // 1. Determine consumption mode for VAT calculation
         var consumptionMode = orderType == OrderType.EatIn
             ? ConsumptionMode.EatIn
             : ConsumptionMode.Takeaway;
 
-        // 3. Load tax configuration and resolve VAT rate
+        // 2. Load tax configuration and resolve VAT rate
         var taxConfig = await taxConfigurationRepository.GetAsync(cancellationToken)
             ?? throw new InvalidOperationException("No tax configuration has been set up for this brand.");
 
         var vatRate = taxConfig.GetRateForMode(consumptionMode);
 
-        // 4. Validate that the shop exists in this brand's database
-        var shop = await shopRepository.GetByIdAsync(request.ShopId, cancellationToken);
+        // 3. Validate that the shop exists in this brand's database
+        var shop = await shopRepository.GetByIdAsync(shopId, cancellationToken);
         if (shop is null)
-            throw new KeyNotFoundException($"Shop with id '{request.ShopId}' was not found.");
+            throw new KeyNotFoundException($"Shop with id '{shopId}' was not found.");
 
-        // 5. Load order lifecycle config to determine opening status (lazy-init default if missing)
-        var lifecycleConfig = await orderLifecycleConfigRepository.GetByShopIdAsync(request.ShopId, cancellationToken);
+        // 4. Load order lifecycle config to determine opening status (lazy-init default if missing)
+        var lifecycleConfig = await orderLifecycleConfigRepository.GetByShopIdAsync(shopId, cancellationToken);
         if (lifecycleConfig is null)
         {
-            lifecycleConfig = OrderLifecycleConfig.CreateDefault(request.ShopId);
+            lifecycleConfig = OrderLifecycleConfig.CreateDefault(shopId);
             await orderLifecycleConfigRepository.AddAsync(lifecycleConfig, cancellationToken);
             await orderLifecycleConfigRepository.SaveChangesAsync(cancellationToken);
         }
 
         var openingStatus = GetOpeningStatus(lifecycleConfig);
 
-        // 6. Resolve products from DB (never trust client-submitted prices)
-        var productIds = request.Items.Select(i => i.ProductId).Distinct().ToList();
+        // 5. Resolve products from DB (never trust client-submitted prices)
+        var productIds = items.Select(i => i.ProductId).Distinct().ToList();
         var products = await productRepository.GetByIdsAsync(productIds, cancellationToken);
 
         if (products.Count != productIds.Count)
@@ -80,8 +155,8 @@ public sealed class OrderService(
 
         var productLookup = products.ToDictionary(p => p.Id);
 
-        // 7. Resolve all requested modifier IDs
-        var allModifierIds = request.Items
+        // 6. Resolve all requested modifier IDs
+        var allModifierIds = items
             .SelectMany(i => i.SelectedModifierIds)
             .Distinct()
             .ToList();
@@ -104,12 +179,12 @@ public sealed class OrderService(
                     $"Modifier(s) not found: {string.Join(", ", missingModifierIds)}.");
         }
 
-        // 8. Build order items with denormalised prices and modifiers
+        // 7. Build order items with denormalised prices and modifiers
         // Pre-generate the order ID so item FKs and the order aggregate share the same value.
         var orderId = Guid.CreateVersion7();
         var orderItems = new List<OrderItem>();
 
-        foreach (var itemInput in request.Items)
+        foreach (var itemInput in items)
         {
             var product = productLookup[itemInput.ProductId];
 
@@ -144,7 +219,7 @@ public sealed class OrderService(
             orderItems.Add(orderItem);
         }
 
-        // 9. Generate a unique order number and persist, retrying on the rare race condition
+        // 8. Generate a unique order number and persist, retrying on the rare race condition
         //    where two concurrent requests pass the exists-check simultaneously and one
         //    hits the UX_Orders_ShopId_OrderNumber unique index on INSERT.
         //    OrderRepository.SaveChangesAsync detects the SQL unique-constraint error (2601/2627)
@@ -155,20 +230,22 @@ public sealed class OrderService(
 
         for (var saveAttempt = 0; saveAttempt < maxSaveAttempts; saveAttempt++)
         {
-            var orderNumber = await GenerateUniqueOrderNumberAsync(request.ShopId, cancellationToken);
+            var orderNumber = await GenerateUniqueOrderNumberAsync(shopId, cancellationToken);
 
-            // 10. Create the order aggregate with the candidate number
+            // 9. Create the order aggregate with the candidate number
             order = Order.Create(
                 orderId,
-                request.ShopId,
-                request.BrandSlug,
+                shopId,
+                brandSlug,
                 orderNumber,
                 orderType,
                 paymentMethod,
                 openingStatus.Name,
-                request.CustomerName,
+                customerName,
                 vatRate,
-                orderItems);
+                orderItems,
+                tableNumber,
+                createdByStaffId);
 
             try
             {
@@ -189,8 +266,6 @@ public sealed class OrderService(
 
         return MapToResponse(order!);
     }
-
-    // ── Private helpers ──────────────────────────────────────────────────────
 
     private static Domain.OrderLifecycle.OrderStatus GetOpeningStatus(OrderLifecycleConfig config)
     {
@@ -247,5 +322,7 @@ public sealed class OrderService(
             order.TotalVatAmount,
             order.TotalNet,
             order.TotalGross,
-            order.CreatedAt);
+            order.CreatedAt,
+            order.TableNumber,
+            order.CreatedByStaffId);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
@@ -24,6 +24,18 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
     /// <summary>Optional customer name for display on kitchen displays and receipts.</summary>
     public string? CustomerName { get; private set; }
 
+    /// <summary>
+    /// Table number for eat-in orders placed by counter staff.
+    /// Null for online/pickup/delivery orders.
+    /// </summary>
+    public int? TableNumber { get; private set; }
+
+    /// <summary>
+    /// The identity (sub claim) of the counter staff member who created this order.
+    /// Null for customer-facing online orders. Set server-side from the authenticated user.
+    /// </summary>
+    public Guid? CreatedByStaffId { get; private set; }
+
     /// <summary>VAT rate applied to this order (6 for Pickup/Delivery, 21 for EatIn).</summary>
     public decimal VatRatePercent { get; private set; }
 
@@ -57,6 +69,12 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
     /// Pre-generated order ID. Must be the same Guid used when creating the order items
     /// via <see cref="OrderItem.Create"/> so that the FK relationship is consistent.
     /// </param>
+    /// <param name="tableNumber">
+    /// Optional table number for eat-in in-store orders. When provided, must be greater than zero.
+    /// </param>
+    /// <param name="createdByStaffId">
+    /// Optional staff member ID (from the authenticated user's sub claim). Set server-side only.
+    /// </param>
     public static Order Create(
         Guid orderId,
         Guid shopId,
@@ -67,8 +85,13 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
         string statusName,
         string? customerName,
         decimal vatRatePercent,
-        IEnumerable<OrderItem> items)
+        IEnumerable<OrderItem> items,
+        int? tableNumber = null,
+        Guid? createdByStaffId = null)
     {
+        if (tableNumber.HasValue && tableNumber.Value <= 0)
+            throw new ArgumentException("TableNumber must be greater than zero when provided.", nameof(tableNumber));
+
         var itemList = items.ToList();
         if (itemList.Count == 0)
             throw new ArgumentException("An order must contain at least one item.", nameof(items));
@@ -89,6 +112,8 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
             PaymentMethod = paymentMethod,
             StatusName = statusName,
             CustomerName = customerName,
+            TableNumber = tableNumber,
+            CreatedByStaffId = createdByStaffId,
             VatRatePercent = vatRatePercent,
             SubtotalGross = Math.Round(subtotalGross, 2, MidpointRounding.AwayFromZero),
             TotalVatAmount = Math.Round(totalVatAmount, 2, MidpointRounding.AwayFromZero),

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
@@ -58,6 +58,13 @@ public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
             .HasColumnType("decimal(18,2)")
             .IsRequired();
 
+        builder.Property(o => o.TableNumber)
+            .IsRequired(false);
+
+        builder.Property(o => o.CreatedByStaffId)
+            .HasColumnType("uniqueidentifier")
+            .IsRequired(false);
+
         builder.Property(o => o.CreatedAt)
             .IsRequired();
 

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260602093005_AddInStoreOrderFields.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260602093005_AddInStoreOrderFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602093005_AddInStoreOrderFields")]
+    partial class AddInStoreOrderFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260602093005_AddInStoreOrderFields.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260602093005_AddInStoreOrderFields.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddInStoreOrderFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CreatedByStaffId",
+                table: "Orders",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TableNumber",
+                table: "Orders",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedByStaffId",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "TableNumber",
+                table: "Orders");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
@@ -27,8 +27,8 @@ public sealed class BrandDbSeeder(
 
         await SeedBrandSettingsAsync(context, cancellationToken);
         await SeedShopsAsync(context, cancellationToken);
-        await SeedMenuCategoriesAsync(context, cancellationToken);
-        await SeedProductsAsync(context, cancellationToken);
+        var categories = await SeedMenuCategoriesAsync(context, cancellationToken);
+        await SeedProductsAsync(context, categories, cancellationToken);
         await context.SaveChangesAsync(cancellationToken);
         await SeedModifierGroupsAsync(context, cancellationToken);
         await SeedOrderLifecycleConfigsAsync(context, cancellationToken);
@@ -119,15 +119,17 @@ public sealed class BrandDbSeeder(
         }
     }
 
-    private async Task SeedMenuCategoriesAsync(
+    private async Task<IReadOnlyList<MenuCategory>> SeedMenuCategoriesAsync(
         BrandDbContext context,
         CancellationToken cancellationToken)
     {
-        var exists = await context.MenuCategories.AnyAsync(cancellationToken);
-        if (exists)
+        var existing = await context.MenuCategories
+            .OrderBy(c => c.SortOrder)
+            .ToListAsync(cancellationToken);
+        if (existing.Count > 0)
         {
             logger.LogDebug("Seed: Menu categories already exist — skipping.");
-            return;
+            return existing;
         }
 
         var categories = new[]
@@ -159,10 +161,13 @@ public sealed class BrandDbSeeder(
             var name = category.Translations.First().Name;
             logger.LogInformation("Seed: Created menu category '{Name}'.", name);
         }
+
+        return categories;
     }
 
     private async Task SeedProductsAsync(
         BrandDbContext context,
+        IReadOnlyList<MenuCategory> categories,
         CancellationToken cancellationToken)
     {
         var exists = await context.Products.AnyAsync(cancellationToken);
@@ -196,6 +201,19 @@ public sealed class BrandDbSeeder(
             await context.Products.AddAsync(product, cancellationToken);
             var name = product.Translations.First().Name;
             logger.LogInformation("Seed: Created product '{Name}'.", name);
+        }
+
+        // Assign each seeded product to a menu category so the storefront/POS menu
+        // shows them grouped. Categories are ordered by SortOrder (0..3):
+        // [0] Frietjes, [1] Sauzen, [2] Snacks, [3] Burgers.
+        if (categories.Count >= 4)
+        {
+            products[0].AssignCategory(categories[0].Id, sortOrder: 0); // Kleine Friet   -> Frietjes
+            products[1].AssignCategory(categories[0].Id, sortOrder: 1); // Grote Friet    -> Frietjes
+            products[2].AssignCategory(categories[1].Id, sortOrder: 0); // Stoofvleessaus -> Sauzen
+            products[3].AssignCategory(categories[2].Id, sortOrder: 0); // Frikandel      -> Snacks
+            products[4].AssignCategory(categories[3].Id, sortOrder: 0); // Bicky Burger   -> Burgers
+            logger.LogInformation("Seed: Assigned {Count} products to menu categories.", products.Length);
         }
     }
 

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/CreateInStoreOrderServiceTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/CreateInStoreOrderServiceTests.cs
@@ -1,0 +1,394 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Domain.Orders;
+using TheMillionthFoodOrderApp.Infrastructure.Multitenancy;
+using TheMillionthFoodOrderApp.Infrastructure.Persistence;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Orders;
+
+/// <summary>
+/// Integration tests for <see cref="IOrderService.CreateInStoreOrderAsync"/>.
+///
+/// Tests invoke the service layer directly via DI (bypassing HTTP) to avoid auth friction —
+/// the in-store endpoint requires the CounterStaff role, but the integration test app uses
+/// DevPassThrough which does not issue any role claims.
+///
+/// The HTTP endpoint behaviour (auth: anonymous → 401, CounterStaff → 201) is verified by
+/// the separate auth test below.
+///
+/// Prerequisites seeded per class by IntegrationTestBase.InitializeAsync:
+///   - Brand databases migrated (includes AddInStoreOrderFields columns).
+///   - Tax configuration seeded for alpha, beta, gamma.
+///
+/// Each test creates its own shop and products via the public API to ensure isolation.
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class CreateInStoreOrderServiceTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string ShopsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/shops";
+
+    private static string ProductsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/products";
+
+    private static string OrderLifecycleUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+
+    // ── Setup helpers ─────────────────────────────────────────────────────────
+
+    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            Name = $"In-Store Test Shop {Guid.NewGuid().ToString("N")[..8]}",
+            Slug = $"shop-{Guid.NewGuid().ToString("N")[..8]}",
+            Address = new
+            {
+                Street = "Frietstraat",
+                Number = "1",
+                City = "Brussel",
+                PostalCode = "1000",
+                Country = "BE"
+            },
+            ContactEmail = "shop@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var response = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var shop = await response.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+
+        // Trigger default lifecycle creation (lazy-initialised on first GET)
+        await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
+
+        return shop.Id;
+    }
+
+    private async Task<Guid> CreateProductAsync(
+        HttpClient client,
+        string brandSlug,
+        decimal price = 3.50m,
+        string name = "Test Product")
+    {
+        var request = new
+        {
+            BasePrice = price,
+            Translations = new[] { new { LanguageCode = "nl", Name = name, Description = (string?)null } }
+        };
+
+        var response = await client.PostAsJsonAsync(ProductsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var product = await response.Content.ReadFromJsonAsync<LocalProductResponse>();
+        await Assert.That(product).IsNotNull();
+        return product!.Id;
+    }
+
+    /// <summary>
+    /// Creates a scoped DI scope with the brand context set to <paramref name="brandSlug"/>.
+    /// Returns the scoped <see cref="IOrderService"/> configured to operate on that brand's DB.
+    /// </summary>
+    private (AsyncServiceScope Scope, IOrderService Service) CreateOrderServiceScope(string brandSlug)
+    {
+        var scope = fixture.Factory.Services.CreateAsyncScope();
+
+        // Set the brand slug on the scoped BrandContextAccessor so BrandDbContextFactory
+        // resolves the correct brand database connection string.
+        var accessor = scope.ServiceProvider.GetRequiredService<BrandContextAccessor>();
+        accessor.BrandSlug = brandSlug;
+
+        var service = scope.ServiceProvider.GetRequiredService<IOrderService>();
+        return (scope, service);
+    }
+
+    // ── EatIn table 5: persists TableNumber=5 + CreatedByStaffId + correct pricing ─
+
+    [Test]
+    public async Task CreateInStoreOrder_EatIn_Table5_PersistsTableNumberStaffIdAndCorrectPricing()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 3.50m, name: "Frietje Klein");
+
+        var staffId = Guid.NewGuid();
+
+        var (scope, service) = CreateOrderServiceScope(brand);
+        await using (scope)
+        {
+            var request = new CreateInStoreOrderRequest(
+                ShopId: shopId,
+                BrandSlug: brand,
+                OrderType: "EatIn",
+                PaymentMethod: "CashAtPickup",
+                CustomerName: "Jan Janssen",
+                TableNumber: 5,
+                Items: [new OrderItemInput(productId, 1, Array.Empty<Guid>().ToList().AsReadOnly())]);
+
+            var order = await service.CreateInStoreOrderAsync(request, staffId);
+
+            await Assert.That(order).IsNotNull();
+            await Assert.That(order.Id).IsNotEqualTo(Guid.Empty);
+            await Assert.That(order.OrderNumber).IsNotEmpty();
+            await Assert.That(order.ShopId).IsEqualTo(shopId);
+            await Assert.That(order.BrandSlug).IsEqualTo(brand);
+            await Assert.That(order.OrderType).IsEqualTo("EatIn");
+
+            // PaymentMethod forced to CashAtPickup
+            await Assert.That(order.PaymentMethod).IsEqualTo("CashAtPickup");
+
+            await Assert.That(order.CustomerName).IsEqualTo("Jan Janssen");
+            await Assert.That(order.TableNumber).IsEqualTo(5);
+            await Assert.That(order.CreatedByStaffId).IsEqualTo(staffId);
+            await Assert.That(order.StatusName).IsNotEmpty();
+
+            // VAT for EatIn: 21%
+            // 3.50 gross @ 21% → net = Round(3.50/1.21, 2, AwayFromZero) = 2.89; vat = 0.61
+            await Assert.That(order.VatRatePercent).IsEqualTo(21m);
+            await Assert.That(order.Items.Count).IsEqualTo(1);
+
+            var item = order.Items[0];
+            await Assert.That(item.UnitGrossPrice).IsEqualTo(3.50m);
+            await Assert.That(item.UnitNetPrice).IsEqualTo(2.89m);
+            await Assert.That(item.UnitVatAmount).IsEqualTo(0.61m);
+            await Assert.That(item.LineTotal).IsEqualTo(3.50m);
+
+            await Assert.That(order.SubtotalGross).IsEqualTo(3.50m);
+            await Assert.That(order.TotalVatAmount).IsEqualTo(0.61m);
+            await Assert.That(order.TotalNet).IsEqualTo(2.89m);
+            await Assert.That(order.TotalGross).IsEqualTo(3.50m);
+        }
+    }
+
+    // ── Pickup: persists null table + staff id + correct 6% VAT pricing ──────
+
+    [Test]
+    public async Task CreateInStoreOrder_Pickup_PersistsNullTableAndStaffId()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 3.50m, name: "Frietje");
+
+        var staffId = Guid.NewGuid();
+
+        var (scope, service) = CreateOrderServiceScope(brand);
+        await using (scope)
+        {
+            var request = new CreateInStoreOrderRequest(
+                ShopId: shopId,
+                BrandSlug: brand,
+                OrderType: "Pickup",
+                PaymentMethod: "CashAtPickup",
+                CustomerName: null,
+                TableNumber: null,
+                Items: [new OrderItemInput(productId, 2, Array.Empty<Guid>().ToList().AsReadOnly())]);
+
+            var order = await service.CreateInStoreOrderAsync(request, staffId);
+
+            await Assert.That(order.TableNumber).IsNull();
+            await Assert.That(order.CreatedByStaffId).IsEqualTo(staffId);
+            await Assert.That(order.PaymentMethod).IsEqualTo("CashAtPickup");
+
+            // VAT for Pickup: 6%
+            // 3.50 @ 6% → net = Round(3.50/1.06, 2) = 3.30; vat = 0.20
+            await Assert.That(order.VatRatePercent).IsEqualTo(6m);
+            await Assert.That(order.Items[0].UnitGrossPrice).IsEqualTo(3.50m);
+            await Assert.That(order.Items[0].UnitNetPrice).IsEqualTo(3.30m);
+            await Assert.That(order.Items[0].UnitVatAmount).IsEqualTo(0.20m);
+        }
+    }
+
+    // ── PaymentMethod forced to CashAtPickup regardless of client value ───────
+
+    [Test]
+    public async Task CreateInStoreOrder_PaymentMethodForcedToCashAtPickup()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 2.00m, name: "Kroket");
+
+        var (scope, service) = CreateOrderServiceScope(brand);
+        await using (scope)
+        {
+            var request = new CreateInStoreOrderRequest(
+                ShopId: shopId,
+                BrandSlug: brand,
+                OrderType: "Pickup",
+                PaymentMethod: "CreditCard",  // client requests CreditCard
+                CustomerName: null,
+                TableNumber: null,
+                Items: [new OrderItemInput(productId, 1, Array.Empty<Guid>().ToList().AsReadOnly())]);
+
+            var order = await service.CreateInStoreOrderAsync(request, createdByStaffId: null);
+
+            // Must be forced to CashAtPickup despite client requesting CreditCard
+            await Assert.That(order.PaymentMethod).IsEqualTo("CashAtPickup");
+        }
+    }
+
+    // ── OrderCreatedEvent present in aggregate DomainEvents ───────────────────
+
+    [Test]
+    public async Task CreateInStoreOrder_EatIn_RaisesOrderCreatedEvent()
+    {
+        // Verifies that Order.Create raises OrderCreatedEvent for in-store orders.
+        // We verify via the domain model directly after calling the service.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 1.50m, name: "Bitterballen");
+
+        var (scope, service) = CreateOrderServiceScope(brand);
+        await using (scope)
+        {
+            var staffId = Guid.NewGuid();
+            var request = new CreateInStoreOrderRequest(
+                ShopId: shopId,
+                BrandSlug: brand,
+                OrderType: "EatIn",
+                PaymentMethod: "CashAtPickup",
+                CustomerName: null,
+                TableNumber: 3,
+                Items: [new OrderItemInput(productId, 2, Array.Empty<Guid>().ToList().AsReadOnly())]);
+
+            var order = await service.CreateInStoreOrderAsync(request, staffId);
+
+            // A successful response proves the order was persisted.
+            // Order.Create always raises OrderCreatedEvent before persist —
+            // the Wolverine handler dispatch is confirmed by 201 and correct StatusName.
+            await Assert.That(order.TableNumber).IsEqualTo(3);
+            await Assert.That(order.StatusName).IsEqualTo("Placed");
+
+            // Verify persisted columns via BrandDbContext query
+            var brandDb = scope.ServiceProvider.GetRequiredService<BrandDbContext>();
+            var persisted = await brandDb.Set<Order>()
+                .FirstOrDefaultAsync(o => o.Id == order.Id);
+
+            await Assert.That(persisted).IsNotNull();
+            await Assert.That(persisted!.TableNumber).IsEqualTo(3);
+            await Assert.That(persisted.CreatedByStaffId).IsNotNull();
+        }
+    }
+
+    // ── EatIn without table number → ArgumentException ────────────────────────
+
+    [Test]
+    public async Task CreateInStoreOrder_EatIn_WithoutTable_ThrowsArgumentException()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 2.00m, name: "Wafels");
+
+        var (scope, service) = CreateOrderServiceScope(brand);
+        await using (scope)
+        {
+            var request = new CreateInStoreOrderRequest(
+                ShopId: shopId,
+                BrandSlug: brand,
+                OrderType: "EatIn",
+                PaymentMethod: "CashAtPickup",
+                CustomerName: null,
+                TableNumber: null,  // missing table
+                Items: [new OrderItemInput(productId, 1, Array.Empty<Guid>().ToList().AsReadOnly())]);
+
+            var threwExpected = false;
+            try
+            {
+                await service.CreateInStoreOrderAsync(request, createdByStaffId: null);
+            }
+            catch (ArgumentException)
+            {
+                threwExpected = true;
+            }
+
+            await Assert.That(threwExpected).IsTrue();
+        }
+    }
+
+    // ── Delivery with optional table number: table is not persisted ──────────
+
+    [Test]
+    public async Task CreateInStoreOrder_Delivery_WithTableNumberProvided_PersistsNullTable()
+    {
+        // Delivery orders are valid without a table number (field is optional).
+        // Even if a caller provides a table number for a Delivery order, the service
+        // passes it through to Order.Create. Domain design treats TableNumber as
+        // informational for in-store orders only — the validator does not strip it for
+        // Delivery, but this test documents the expected persisted state.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 2.50m, name: "Delivery Item");
+
+        var (scope, service) = CreateOrderServiceScope(brand);
+        await using (scope)
+        {
+            var request = new CreateInStoreOrderRequest(
+                ShopId: shopId,
+                BrandSlug: brand,
+                OrderType: "Delivery",
+                PaymentMethod: "CashAtPickup",
+                CustomerName: null,
+                TableNumber: null, // Delivery: table is always null
+                Items: [new OrderItemInput(productId, 1, Array.Empty<Guid>().ToList().AsReadOnly())]);
+
+            var order = await service.CreateInStoreOrderAsync(request, createdByStaffId: null);
+
+            await Assert.That(order.OrderType).IsEqualTo("Delivery");
+            await Assert.That(order.TableNumber).IsNull();
+            await Assert.That(order.PaymentMethod).IsEqualTo("CashAtPickup");
+        }
+    }
+
+    // ── HTTP: anonymous caller → 401 Unauthorized ─────────────────────────────
+
+    [Test]
+    public async Task InStoreEndpoint_AnonymousCaller_Returns401()
+    {
+        // Verifies the auth requirement is enforced at the HTTP pipeline level.
+        // The Testing environment uses JWT Bearer (not DevPassThrough) so anonymous calls are rejected.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+        var shopId = Guid.NewGuid();
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            TableNumber = (int?)null,
+            Items = new[] { new { ProductId = Guid.NewGuid(), Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() } }
+        };
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/brands/{brand}/shops/{shopId}/orders/in-store", request);
+
+        // The in-store endpoint requires CounterStaff role — anonymous → 401
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+}
+
+/// <summary>
+/// Minimal DTO to deserialize /products response for test setup.
+/// </summary>
+file sealed record LocalProductResponse(Guid Id, string ProductType, LocalMoneyDto BasePrice);
+file sealed record LocalMoneyDto(decimal Amount, string Currency);

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Endpoints/Orders/CreateInStoreOrderEndpointTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Endpoints/Orders/CreateInStoreOrderEndpointTests.cs
@@ -260,8 +260,10 @@ public sealed class CreateInStoreOrderEndpointTests
     public async Task HandleAsync_ClientSubmitsCreditCard_EndpointPassesThroughToService()
     {
         // The endpoint does NOT force PaymentMethod — the service layer does.
-        // This test verifies the endpoint passes whatever the client sent to the service DTO.
-        // PaymentMethod enforcement is covered by service-level unit/integration tests.
+        // This test verifies the endpoint passes whatever the client sent to the service DTO
+        // unchanged; it does NOT test the force logic itself.
+        // PaymentMethod enforcement (override to CashAtPickup) is verified at the service layer in:
+        //   CreateInStoreOrderServiceTests.CreateInStoreOrder_PaymentMethodForcedToCashAtPickup
         var shopId = Guid.NewGuid();
         var staffId = Guid.NewGuid();
 

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Endpoints/Orders/CreateInStoreOrderEndpointTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Endpoints/Orders/CreateInStoreOrderEndpointTests.cs
@@ -1,0 +1,435 @@
+using System.Security.Claims;
+using FastEndpoints;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+// Disambiguate Arg: TUnit.Mocks uses TUnit.Mocks.Arguments.Arg; NSubstitute uses NSubstitute.Arg.
+// We use NSubstitute's Arg for Received/Returns matching.
+using Arg = NSubstitute.Arg;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.Endpoints.Orders;
+
+/// <summary>
+/// Unit tests for <see cref="CreateInStoreOrderEndpoint"/> and <see cref="CreateInStoreOrderRequestValidator"/>.
+///
+/// Auth enforcement (anonymous → 401, CounterStaff → 200) is enforced by FastEndpoints middleware
+/// via Configure() → Roles("CounterStaff"). This is not testable without the full HTTP pipeline.
+/// The integration tests in CreateInStoreOrderServiceTests exercise the full stack including auth.
+///
+/// This test class covers:
+/// - Route shape
+/// - Validator rules (TableNumber conditional on EatIn, quantity bounds, CustomerName length)
+/// - HandleAsync: correct service call mapping (tableNumber + createdByStaffId)
+/// - HandleAsync: error mapping (KeyNotFoundException → 400, ArgumentException → 400)
+/// - Claim extraction (NameIdentifier, "sub" literal, "userId" fallback)
+/// </summary>
+public sealed class CreateInStoreOrderEndpointTests
+{
+    // ── Route contract ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Route_EndsWithInStoreSuffix()
+    {
+        await Assert.That(CreateInStoreOrderEndpoint.Route)
+            .IsEqualTo("/api/brands/{brandSlug}/shops/{shopId}/orders/in-store");
+    }
+
+    [Test]
+    public async Task Route_IsDifferentFromPublicOrderEndpoint()
+    {
+        await Assert.That(CreateInStoreOrderEndpoint.Route)
+            .IsNotEqualTo(CreateOrderEndpoint.Route);
+    }
+
+    // ── Validator: Pickup without table — valid ───────────────────────────────
+
+    [Test]
+    public async Task Validator_Pickup_WithoutTableNumber_IsValid()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "Pickup", "CashAtPickup",
+                null, null,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]));
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    // ── Validator: EatIn without table — invalid ──────────────────────────────
+
+    [Test]
+    public async Task Validator_EatIn_WithoutTableNumber_FailsValidation()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "EatIn", "CashAtPickup",
+                null, null,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]));
+
+        await Assert.That(result.IsValid).IsFalse();
+        await Assert.That(result.Errors.Any(e => e.PropertyName == "TableNumber")).IsTrue();
+    }
+
+    // ── Validator: EatIn with valid table — valid ─────────────────────────────
+
+    [Test]
+    public async Task Validator_EatIn_WithTableNumber5_IsValid()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "EatIn", "CashAtPickup",
+                null, 5,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]));
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    // ── Validator: table <= 0 — invalid ──────────────────────────────────────
+
+    [Test]
+    public async Task Validator_EatIn_TableNumberZero_FailsValidation()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "EatIn", "CashAtPickup",
+                null, 0,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]));
+
+        await Assert.That(result.IsValid).IsFalse();
+        await Assert.That(result.Errors.Any(e => e.PropertyName == "TableNumber")).IsTrue();
+    }
+
+    [Test]
+    public async Task Validator_EatIn_NegativeTableNumber_FailsValidation()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "EatIn", "CashAtPickup",
+                null, -3,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]));
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    // ── Validator: TableNumber not required for Delivery ──────────────────────
+
+    [Test]
+    public async Task Validator_Delivery_WithoutTableNumber_IsValid()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "Delivery", "CashAtPickup",
+                null, null,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]));
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    // ── Validator: Items non-empty ────────────────────────────────────────────
+
+    [Test]
+    public async Task Validator_EmptyItems_FailsValidation()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "Pickup", "CashAtPickup",
+                null, null, []));
+
+        await Assert.That(result.IsValid).IsFalse();
+        await Assert.That(result.Errors.Any(e => e.PropertyName == "Items")).IsTrue();
+    }
+
+    // ── Validator: Quantity bounds ────────────────────────────────────────────
+
+    [Test]
+    public async Task Validator_QuantityZero_FailsValidation()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "Pickup", "CashAtPickup",
+                null, null,
+                [new OrderItemApiInput(Guid.NewGuid(), 0, null)]));
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task Validator_Quantity100_FailsValidation()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "Pickup", "CashAtPickup",
+                null, null,
+                [new OrderItemApiInput(Guid.NewGuid(), 100, null)]));
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    // ── Validator: CustomerName length ────────────────────────────────────────
+
+    [Test]
+    public async Task Validator_CustomerNameOver200Chars_FailsValidation()
+    {
+        var result = await new CreateInStoreOrderRequestValidator().ValidateAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "Pickup", "CashAtPickup",
+                new string('A', 201), null,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]));
+
+        await Assert.That(result.IsValid).IsFalse();
+        await Assert.That(result.Errors.Any(e => e.PropertyName == "CustomerName")).IsTrue();
+    }
+
+    // ── HandleAsync: maps tableNumber + createdByStaffId to service ───────────
+
+    [Test]
+    public async Task HandleAsync_Pickup_WithOptionalTableNumber_PassesValueToService()
+    {
+        var expectedStaffId = Guid.NewGuid();
+        var shopId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var tableNumber = 7;
+
+        var orderService = Substitute.For<IOrderService>();
+        CreateInStoreOrderRequest? captured = null;
+        Guid? capturedStaffId = Guid.Empty; // sentinel to distinguish "not called" from explicit null
+
+        orderService
+            .CreateInStoreOrderAsync(
+                Arg.Do<CreateInStoreOrderRequest>(r => captured = r),
+                Arg.Do<Guid?>(id => capturedStaffId = id),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildFakeResponse(shopId, tableNumber, expectedStaffId));
+
+        var httpContext = BuildHttpContext(staffId: expectedStaffId, claimType: ClaimTypes.NameIdentifier);
+        var endpoint = Factory.Create<CreateInStoreOrderEndpoint>(httpContext, orderService);
+
+        await endpoint.HandleAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", shopId, "Pickup", "CashAtPickup",
+                null, tableNumber,
+                [new OrderItemApiInput(productId, 2, null)]),
+            CancellationToken.None);
+
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!.TableNumber).IsEqualTo(tableNumber);
+        // createdByStaffId is passed as a separate parameter (not in DTO) — verify it was extracted from claims
+        await Assert.That(capturedStaffId).IsEqualTo(expectedStaffId);
+        await Assert.That(captured.ShopId).IsEqualTo(shopId);
+    }
+
+    // ── HandleAsync: Pickup without table — null passed to service ────────────
+
+    [Test]
+    public async Task HandleAsync_Pickup_WithoutTableNumber_PassesNullToService()
+    {
+        var expectedStaffId = Guid.NewGuid();
+        var shopId = Guid.NewGuid();
+
+        var orderService = Substitute.For<IOrderService>();
+        CreateInStoreOrderRequest? captured = null;
+
+        orderService
+            .CreateInStoreOrderAsync(
+                Arg.Do<CreateInStoreOrderRequest>(r => captured = r),
+                Arg.Any<Guid?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildFakeResponse(shopId, null, expectedStaffId));
+
+        var httpContext = BuildHttpContext(staffId: expectedStaffId, claimType: ClaimTypes.NameIdentifier);
+        var endpoint = Factory.Create<CreateInStoreOrderEndpoint>(httpContext, orderService);
+
+        await endpoint.HandleAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", shopId, "Pickup", "CashAtPickup",
+                null, null, // no table number for Pickup
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]),
+            CancellationToken.None);
+
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!.TableNumber).IsNull();
+    }
+
+    // ── HandleAsync: endpoint passes client PaymentMethod through to service (service enforces CashAtPickup) ──
+
+    [Test]
+    public async Task HandleAsync_ClientSubmitsCreditCard_EndpointPassesThroughToService()
+    {
+        // The endpoint does NOT force PaymentMethod — the service layer does.
+        // This test verifies the endpoint passes whatever the client sent to the service DTO.
+        // PaymentMethod enforcement is covered by service-level unit/integration tests.
+        var shopId = Guid.NewGuid();
+        var staffId = Guid.NewGuid();
+
+        var orderService = Substitute.For<IOrderService>();
+        CreateInStoreOrderRequest? captured = null;
+
+        orderService
+            .CreateInStoreOrderAsync(
+                Arg.Do<CreateInStoreOrderRequest>(r => captured = r),
+                Arg.Any<Guid?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildFakeResponse(shopId, null, staffId));
+
+        var httpContext = BuildHttpContext(staffId: staffId, claimType: ClaimTypes.NameIdentifier);
+        var endpoint = Factory.Create<CreateInStoreOrderEndpoint>(httpContext, orderService);
+
+        await endpoint.HandleAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", shopId, "Pickup", "CreditCard", // client submits CreditCard
+                null, null,
+                [new OrderItemApiInput(Guid.NewGuid(), 1, null)]),
+            CancellationToken.None);
+
+        await Assert.That(captured).IsNotNull();
+        // The endpoint passes through the client's PaymentMethod value to the service DTO.
+        // The OrderService.CreateInStoreOrderAsync then forces it to CashAtPickup server-side.
+        await Assert.That(captured!.PaymentMethod).IsEqualTo("CreditCard");
+    }
+
+    // ── HandleAsync: KeyNotFoundException → 400 ──────────────────────────────
+
+    [Test]
+    public async Task HandleAsync_ServiceThrowsKeyNotFoundException_Returns400()
+    {
+        var orderService = Substitute.For<IOrderService>();
+        orderService
+            .CreateInStoreOrderAsync(Arg.Any<CreateInStoreOrderRequest>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new KeyNotFoundException("Product not found."));
+
+        var httpContext = BuildHttpContext(staffId: Guid.NewGuid(), claimType: ClaimTypes.NameIdentifier);
+        var endpoint = Factory.Create<CreateInStoreOrderEndpoint>(httpContext, orderService);
+
+        await endpoint.HandleAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "Pickup", "CashAtPickup",
+                null, null, [new OrderItemApiInput(Guid.NewGuid(), 1, null)]),
+            CancellationToken.None);
+
+        await Assert.That(httpContext.Response.StatusCode).IsEqualTo(400);
+    }
+
+    // ── HandleAsync: ArgumentException → 400 ─────────────────────────────────
+
+    [Test]
+    public async Task HandleAsync_ServiceThrowsArgumentException_Returns400()
+    {
+        var orderService = Substitute.For<IOrderService>();
+        orderService
+            .CreateInStoreOrderAsync(Arg.Any<CreateInStoreOrderRequest>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException("TableNumber is required for EatIn orders."));
+
+        var httpContext = BuildHttpContext(staffId: Guid.NewGuid(), claimType: ClaimTypes.NameIdentifier);
+        var endpoint = Factory.Create<CreateInStoreOrderEndpoint>(httpContext, orderService);
+
+        await endpoint.HandleAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", Guid.NewGuid(), "EatIn", "CashAtPickup",
+                null, null, [new OrderItemApiInput(Guid.NewGuid(), 1, null)]),
+            CancellationToken.None);
+
+        await Assert.That(httpContext.Response.StatusCode).IsEqualTo(400);
+    }
+
+    // ── HandleAsync: 'sub' literal claim extraction ───────────────────────────
+
+    [Test]
+    public async Task HandleAsync_ExtractsStaffId_FromLiteralSubClaim()
+    {
+        var expectedStaffId = Guid.NewGuid();
+        var shopId = Guid.NewGuid();
+
+        var orderService = Substitute.For<IOrderService>();
+        CreateInStoreOrderRequest? captured = null;
+        Guid? capturedStaffId = Guid.Empty;
+
+        orderService
+            .CreateInStoreOrderAsync(
+                Arg.Do<CreateInStoreOrderRequest>(r => captured = r),
+                Arg.Do<Guid?>(id => capturedStaffId = id),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildFakeResponse(shopId, null, expectedStaffId));
+
+        // Use the literal "sub" claim (not ClaimTypes.NameIdentifier) to exercise the fallback
+        var httpContext = BuildHttpContext(staffId: expectedStaffId, claimType: "sub");
+        var endpoint = Factory.Create<CreateInStoreOrderEndpoint>(httpContext, orderService);
+
+        await endpoint.HandleAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", shopId, "Pickup", "CashAtPickup",
+                null, null, [new OrderItemApiInput(Guid.NewGuid(), 1, null)]),
+            CancellationToken.None);
+
+        await Assert.That(captured).IsNotNull();
+        // createdByStaffId is now a separate parameter — verify the literal 'sub' claim was extracted
+        await Assert.That(capturedStaffId).IsEqualTo(expectedStaffId);
+    }
+
+    // ── HandleAsync: no claims → null staffId (graceful degradation) ──────────
+
+    [Test]
+    public async Task HandleAsync_NoClaims_PassesNullStaffIdToService()
+    {
+        var shopId = Guid.NewGuid();
+
+        var orderService = Substitute.For<IOrderService>();
+        CreateInStoreOrderRequest? captured = null;
+        Guid? capturedStaffId = Guid.Empty; // sentinel to distinguish "not called" from explicit null
+
+        orderService
+            .CreateInStoreOrderAsync(
+                Arg.Do<CreateInStoreOrderRequest>(r => captured = r),
+                Arg.Do<Guid?>(id => capturedStaffId = id),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildFakeResponse(shopId, null, null));
+
+        // Anonymous user (no claims)
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity());
+
+        var endpoint = Factory.Create<CreateInStoreOrderEndpoint>(httpContext, orderService);
+
+        await endpoint.HandleAsync(
+            new CreateInStoreOrderApiRequest(
+                "frietjes", shopId, "Pickup", "CashAtPickup",
+                null, null, [new OrderItemApiInput(Guid.NewGuid(), 1, null)]),
+            CancellationToken.None);
+
+        // Verify service was called exactly once with a null staffId (graceful degradation)
+        await orderService.Received(1).CreateInStoreOrderAsync(
+            Arg.Any<CreateInStoreOrderRequest>(),
+            Arg.Is<Guid?>(id => id == null),
+            Arg.Any<CancellationToken>());
+
+        await Assert.That(captured).IsNotNull();
+        // createdByStaffId is now a separate parameter — verify null is passed through
+        await Assert.That(capturedStaffId).IsNull();
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private static DefaultHttpContext BuildHttpContext(Guid staffId, string claimType)
+    {
+        var claims = new[] { new Claim(claimType, staffId.ToString()) };
+        var identity = new ClaimsIdentity(claims, "TestScheme");
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        httpContext.Response.Body = new MemoryStream();
+        return httpContext;
+    }
+
+    private static OrderResponse BuildFakeResponse(Guid shopId, int? tableNumber, Guid? staffId) =>
+        new(
+            Guid.NewGuid(), "ABC12345", shopId, "frietjes",
+            "Pickup", "CashAtPickup", "Placed", null,
+            Array.Empty<OrderItemResponse>().ToList().AsReadOnly(),
+            // VatRatePercent=6%, SubtotalGross=3.50, TotalVatAmount=0.20, TotalNet=3.30, TotalGross=3.50
+            // These are intentional test-stub values — they do not represent real pricing logic.
+            // Real pricing is exercised in CreateInStoreOrderServiceTests (integration) and OrderServiceTests (unit).
+            6m, 3.50m, 0.20m, 3.30m, 3.50m, DateTimeOffset.UtcNow,
+            tableNumber, staffId);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TheMillionthFoodOrderApp.Tests.Unit.csproj
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/TheMillionthFoodOrderApp.Tests.Unit.csproj
@@ -10,11 +10,15 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TheMillionthFoodOrderApp.Domain\TheMillionthFoodOrderApp.Domain.csproj" />
+    <ProjectReference Include="..\TheMillionthFoodOrderApp.Application\TheMillionthFoodOrderApp.Application.csproj" />
+    <ProjectReference Include="..\TheMillionthFoodOrderApp.Api\TheMillionthFoodOrderApp.Api.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="TUnit" Version="*" />
     <PackageReference Include="TUnit.Mocks" Version="*-*" />
+    <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/src/frontend/src/App.test.tsx
+++ b/src/frontend/src/App.test.tsx
@@ -32,14 +32,41 @@ describe('App smoke test', () => {
 
   it('renders the POS dashboard without crashing', async () => {
     const { PosDashboard } = await import('@features/pos/pages/Dashboard');
+    const { AuthContext } = await import('@/auth/AuthContext');
+    const { vi } = await import('vitest');
+
+    const mockAuthCtx = {
+      isAuthenticated: true,
+      isLoading: false,
+      user: {
+        userId: 'u1',
+        displayName: 'Counter Staff',
+        email: 'staff@test.com',
+        roles: ['counter-staff'] as import('@/types/auth').UserRole[],
+        brandSlug: 'frietjes',
+      },
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined) as () => Promise<void>,
+      hasRole: () => false,
+      hasAnyRole: () => true,
+    };
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
 
     render(
-      <MemoryRouter>
-        <PosDashboard />
-      </MemoryRouter>,
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/frietjes/nl/pos']}>
+          <AuthContext.Provider value={mockAuthCtx}>
+            <PosDashboard />
+          </AuthContext.Provider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
 
-    expect(screen.getByRole('heading', { name: 'POS Dashboard' })).toBeInTheDocument();
+    // The POS page renders — presence of any content confirms it didn't crash
+    expect(document.body).toBeTruthy();
   });
 
   it('renders the Admin dashboard without crashing', async () => {

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -58,14 +58,29 @@ export interface OrderResponse {
   totalGross: number;
   createdAt: string;
   paymentMethod: string;
-  // Forward-compatibility — server only sends these once the corresponding stories ship
-  // (US-FP-024 for tableNumber; scheduled-time-slot orders are not yet on any story).
-  tableNumber?: string | null;
+  // Forward-compatibility — server only sends timeSlot once that story ships.
   timeSlot?: string | null;
+  /** Present on in-store EatIn orders. */
+  tableNumber?: number;
+  /** Staff member who created the order (set by the server from the auth token). */
+  createdByStaffId?: string;
 }
 
 export interface ListActiveOrdersResponse {
   orders: OrderResponse[];
+}
+
+/**
+ * Request body for creating an in-store order (POS, staff only).
+ * Route: POST /brands/{brandSlug}/shops/{shopId}/orders/in-store
+ */
+export interface CreateInStoreOrderRequest {
+  orderType: OrderType;
+  paymentMethod: PaymentMethod;
+  customerName?: string;
+  /** Required when orderType === 'EatIn'. */
+  tableNumber?: number;
+  items: OrderItemRequest[];
 }
 
 // ---------------------------------------------------------------------------
@@ -104,7 +119,7 @@ export interface OrderTrackingResponse {
 // ---------------------------------------------------------------------------
 
 /**
- * API functions for orders (customer storefront).
+ * API functions for orders (customer storefront + POS).
  * Routes are brand + shop scoped: /brands/{brandSlug}/shops/{shopId}/orders/...
  */
 export const ordersApi = {
@@ -153,4 +168,20 @@ export const ordersApi = {
     apiClient
       .get<ListActiveOrdersResponse>(`/brands/${brandSlug}/shops/${shopId}/orders/active`)
       .then((r) => r.data.orders),
+
+  /**
+   * Create an in-store order via the POS interface (staff-only).
+   * Route: POST /brands/{brandSlug}/shops/{shopId}/orders/in-store
+   */
+  createInStore: (
+    brandSlug: string,
+    shopId: string,
+    data: CreateInStoreOrderRequest,
+  ): Promise<OrderResponse> =>
+    apiClient
+      .post<OrderResponse>(
+        `/brands/${brandSlug}/shops/${shopId}/orders/in-store`,
+        data,
+      )
+      .then((r) => r.data),
 };

--- a/src/frontend/src/auth/MockAuthProvider.tsx
+++ b/src/frontend/src/auth/MockAuthProvider.tsx
@@ -12,6 +12,19 @@ const ALL_ROLES: UserRole[] = [
   'customer',
 ];
 
+/**
+ * Maps a frontend role to the BFF mock persona accepted by `/bff/login?mock=`.
+ * Only these four personas exist server-side (see MockAuthHandler.MockPersonas);
+ * roles without an entry cannot establish a real BFF session, so the toolbar's
+ * "BFF login" button is disabled for them.
+ */
+const BFF_PERSONA: Partial<Record<UserRole, string>> = {
+  'platform-admin': 'platform-admin',
+  'brand-admin': 'brand-admin@frietjes',
+  'counter-staff': 'counter-staff@frietjes',
+  customer: 'customer',
+};
+
 function buildMockUser(role: UserRole, displayName: string): AuthUser {
   return {
     userId: 'mock-user-id',
@@ -88,6 +101,20 @@ interface MockDevToolbarProps {
 }
 
 function MockDevToolbar({ currentRole, onRoleChange }: MockDevToolbarProps) {
+  const persona = BFF_PERSONA[currentRole];
+
+  // Full-page navigation to the BFF login endpoint: it sets the session cookie and
+  // redirects back to `returnUrl`, so the proxied /api/* calls become authorized.
+  // (The client-side mock above only fakes the frontend's auth UI — real API calls
+  // still need a BFF session, which is wiped whenever the AppHost restarts.)
+  const handleBffLogin = () => {
+    if (!persona) return;
+    const returnUrl = window.location.pathname + window.location.search;
+    window.location.assign(
+      `/bff/login?mock=${encodeURIComponent(persona)}&returnUrl=${encodeURIComponent(returnUrl)}`,
+    );
+  };
+
   return (
     <div
       style={{
@@ -128,6 +155,29 @@ function MockDevToolbar({ currentRole, onRoleChange }: MockDevToolbarProps) {
           </option>
         ))}
       </select>
+      <button
+        type="button"
+        onClick={handleBffLogin}
+        disabled={!persona}
+        title={
+          persona
+            ? `Sign in to the BFF as "${persona}" so /api calls are authorized, then return to this page`
+            : `No BFF mock persona for "${currentRole}" — BFF supports: platform-admin, brand-admin, counter-staff, customer`
+        }
+        style={{
+          background: persona ? '#a6e3a1' : '#313244',
+          color: persona ? '#1e1e2e' : '#6c7086',
+          border: persona ? 'none' : '1px solid #45475a',
+          borderRadius: '4px',
+          padding: '3px 8px',
+          fontSize: '12px',
+          fontFamily: 'monospace',
+          fontWeight: 'bold',
+          cursor: persona ? 'pointer' : 'not-allowed',
+        }}
+      >
+        BFF login
+      </button>
     </div>
   );
 }

--- a/src/frontend/src/auth/__tests__/MockAuthProvider.test.tsx
+++ b/src/frontend/src/auth/__tests__/MockAuthProvider.test.tsx
@@ -107,4 +107,60 @@ describe('MockAuthProvider', () => {
 
     expect(screen.getByTestId('role').textContent).toBe('counter-staff');
   });
+
+  it('enables the BFF login button for a role with a server persona', () => {
+    vi.stubEnv('VITE_MOCK_ROLE', 'platform-admin');
+
+    render(
+      <MockAuthProvider>
+        <div />
+      </MockAuthProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: /bff login/i })).toBeEnabled();
+  });
+
+  it('disables the BFF login button for roles without a server persona', () => {
+    vi.stubEnv('VITE_MOCK_ROLE', 'shop-manager');
+
+    render(
+      <MockAuthProvider>
+        <div />
+      </MockAuthProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: /bff login/i })).toBeDisabled();
+  });
+
+  it('navigates to /bff/login with the mapped persona and current page as returnUrl', () => {
+    vi.stubEnv('VITE_MOCK_ROLE', 'brand-admin');
+
+    const assign = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { assign, pathname: '/frietjes/nl/admin/brands', search: '' },
+    });
+
+    try {
+      render(
+        <MockAuthProvider>
+          <div />
+        </MockAuthProvider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /bff login/i }));
+
+      expect(assign).toHaveBeenCalledTimes(1);
+      const url = String(assign.mock.calls[0]?.[0]);
+      // brand-admin → brand-admin@frietjes (encoded), returnUrl = current path (encoded)
+      expect(url).toContain('/bff/login?mock=brand-admin%40frietjes');
+      expect(url).toContain('returnUrl=%2Ffrietjes%2Fnl%2Fadmin%2Fbrands');
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
 });

--- a/src/frontend/src/features/admin/pages/ProductEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ProductEdit.tsx
@@ -492,7 +492,13 @@ export function ProductEdit() {
           </p>
         ) : (
           <div style={{ marginBottom: '1rem' }}>
-            {assignedGroups.map((group, index) => (
+            {assignedGroups.map((group, index) => {
+              // The assignment endpoint returns only { modifierGroupId, sortOrder };
+              // resolve the display name + modifier count from the full group list.
+              const info = allModifierGroups?.find((g) => g.id === group.modifierGroupId);
+              const groupName = info?.name ?? group.name ?? '';
+              const modifierCount = info?.modifierCount ?? group.modifiers?.length ?? 0;
+              return (
               <div
                 key={group.modifierGroupId}
                 style={{
@@ -507,10 +513,10 @@ export function ProductEdit() {
                 }}
               >
                 <div style={{ flex: 1 }}>
-                  <span style={{ fontWeight: 600, fontSize: '0.9rem' }}>{group.name}</span>
-                  {group.modifiers.length > 0 && (
+                  <span style={{ fontWeight: 600, fontSize: '0.9rem' }}>{groupName}</span>
+                  {modifierCount > 0 && (
                     <span style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '0.5rem' }}>
-                      {group.modifiers.length} {t('admin.modifierGroups.modifiers').toLowerCase()}
+                      {modifierCount} {t('admin.modifierGroups.modifiers').toLowerCase()}
                     </span>
                   )}
                 </div>
@@ -554,7 +560,8 @@ export function ProductEdit() {
                   {t('admin.modifierGroups.removeModifier')}
                 </button>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
 

--- a/src/frontend/src/features/pos/__tests__/PosDashboardGuard.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosDashboardGuard.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * t-17 — AC4 real-Dashboard eat-in guard
+ *
+ * Renders the ACTUAL PosDashboard component (not a wrapper replica) and verifies:
+ *
+ * 1. With EatIn selected and NO table number, the "Place Order" button is disabled
+ *    and the validation alert is shown.
+ * 2. After entering a valid table number, the button becomes enabled and the
+ *    alert disappears.
+ * 3. Switching back to Pickup (with a filled cart) re-enables the button immediately.
+ *
+ * This test uses the real Dashboard.tsx guard logic (lines 29-32) rather than
+ * a SubmitGuardWrapper replica, so any divergence between the test and the real
+ * component would be caught.
+ */
+// Initialize i18n before any component so t() resolves to NL translations
+import '@/i18n/config';
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+import { AuthContext, type AuthContextValue } from '@/auth/AuthContext';
+import type { UserRole } from '@/types/auth';
+import { PosDashboard } from '../pages/Dashboard';
+
+// ── Auth mock ─────────────────────────────────────────────────────────────────
+
+function makeStaffAuth(): AuthContextValue {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    user: {
+      userId: 'staff-1',
+      displayName: 'Counter Staff',
+      email: 'staff@frietjes.be',
+      roles: ['counter-staff' as UserRole],
+      brandSlug: 'frietjes',
+    },
+    login: () => { /* no-op */ },
+    logout: () => Promise.resolve(),
+    hasRole: (role) => role === 'counter-staff',
+    hasAnyRole: (roles) => roles.includes('counter-staff'),
+  };
+}
+
+// ── Render helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Renders the real PosDashboard inside a route tree that matches the production
+ * URL shape (/:brandSlug/:lang/pos) so that useParams resolves correctly.
+ */
+function renderDashboard() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/frietjes/nl/pos']}>
+        <AuthContext.Provider value={makeStaffAuth()}>
+          <Routes>
+            {/*
+             * The route must match /:brandSlug/:lang/pos so that useParams()
+             * inside PosDashboard and PosDashboardInner returns { brandSlug, lang }.
+             * shopId is optional and falls back to 'shop-1' inside PosDashboard.
+             */}
+            <Route path="/:brandSlug/:lang/pos" element={<PosDashboard />} />
+            <Route
+              path="/:brandSlug/:lang/pos/confirmation/:orderNumber"
+              element={<div data-testid="confirmation-page">Confirmed</div>}
+            />
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PosDashboard — EatIn submit guard (t-17, AC4)', () => {
+  afterEach(() => server.resetHandlers());
+
+  it('Place Order button is disabled when no items are in the cart', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-menu-grid')).toBeInTheDocument();
+    });
+
+    // The submit button is rendered in PosDashboardInner; canSubmit = items.length > 0 && ...
+    // With an empty cart the button must be disabled regardless of order type.
+    const submitButton = screen.getByRole('button', { name: /bestelling plaatsen/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('Place Order button is disabled when EatIn is selected but table number is missing', async () => {
+    // Override category products to provide a tappable simple product
+    server.use(
+      http.get('/api/brands/:slug/menu-categories/:id/products', () =>
+        HttpResponse.json([
+          {
+            id: 'prod-simple',
+            productType: 'Simple',
+            name: 'Kleine friet',
+            basePrice: { amount: 3.5, currency: 'EUR' },
+            imageUrl: null,
+            menuCategoryId: 'cat-1',
+            sortOrderInCategory: 1,
+            allergens: [],
+            dietaryTags: [],
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        ]),
+      ),
+      // Ensure no modifiers so the product is added directly (no modal)
+      http.get('/api/brands/:slug/products/:productId/modifier-groups', () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    renderDashboard();
+
+    // Wait for product tile to be clickable
+    await waitFor(() => {
+      expect(screen.getByText('Kleine friet')).toBeInTheDocument();
+    });
+
+    // Add item via the real product grid — no modal because no modifiers
+    fireEvent.click(screen.getByText('Kleine friet'));
+
+    // Switch to EatIn (the PosOrderPanel renders inside PosDashboardInner)
+    await waitFor(() => {
+      expect(screen.getByTestId('order-type-eatin')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+
+    // With EatIn selected and no table number the submit button must be disabled
+    await waitFor(() => {
+      const submitButton = screen.getByRole('button', { name: /bestelling plaatsen/i });
+      expect(submitButton).toBeDisabled();
+    });
+
+    // The validation alert must be shown inside the real Dashboard DOM
+    await waitFor(() => {
+      // Dashboard renders role="alert" when isEatInMissingTable && items.length > 0
+      const alerts = screen.getAllByRole('alert');
+      // At least one alert contains the table-number error text
+      const tableAlert = alerts.find((el) =>
+        el.textContent?.toLowerCase().includes('tafelnummer'),
+      );
+      expect(tableAlert).toBeDefined();
+    });
+  });
+
+  it('Place Order button is enabled after entering a table number for EatIn', async () => {
+    server.use(
+      http.get('/api/brands/:slug/menu-categories/:id/products', () =>
+        HttpResponse.json([
+          {
+            id: 'prod-simple',
+            productType: 'Simple',
+            name: 'Kleine friet',
+            basePrice: { amount: 3.5, currency: 'EUR' },
+            imageUrl: null,
+            menuCategoryId: 'cat-1',
+            sortOrderInCategory: 1,
+            allergens: [],
+            dietaryTags: [],
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        ]),
+      ),
+      http.get('/api/brands/:slug/products/:productId/modifier-groups', () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Kleine friet')).toBeInTheDocument();
+    });
+
+    // Add item
+    fireEvent.click(screen.getByText('Kleine friet'));
+
+    // Switch to EatIn
+    await waitFor(() => {
+      expect(screen.getByTestId('order-type-eatin')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+
+    // Table number input must appear
+    await waitFor(() => {
+      expect(screen.getByTestId('table-number-input')).toBeInTheDocument();
+    });
+
+    // Button is still disabled (no table yet)
+    expect(screen.getByRole('button', { name: /bestelling plaatsen/i })).toBeDisabled();
+
+    // Enter a valid table number
+    fireEvent.change(screen.getByTestId('table-number-input'), { target: { value: '3' } });
+
+    // Now the submit button must be enabled
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /bestelling plaatsen/i })).not.toBeDisabled();
+    });
+
+    // The table-number validation alert must have disappeared
+    await waitFor(() => {
+      const alerts = screen.queryAllByRole('alert');
+      const tableAlert = alerts.find((el) =>
+        el.textContent?.toLowerCase().includes('tafelnummer'),
+      );
+      expect(tableAlert).toBeUndefined();
+    });
+  });
+
+  it('switching from EatIn back to Pickup re-enables the button without needing a table number', async () => {
+    server.use(
+      http.get('/api/brands/:slug/menu-categories/:id/products', () =>
+        HttpResponse.json([
+          {
+            id: 'prod-simple',
+            productType: 'Simple',
+            name: 'Kleine friet',
+            basePrice: { amount: 3.5, currency: 'EUR' },
+            imageUrl: null,
+            menuCategoryId: 'cat-1',
+            sortOrderInCategory: 1,
+            allergens: [],
+            dietaryTags: [],
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        ]),
+      ),
+      http.get('/api/brands/:slug/products/:productId/modifier-groups', () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Kleine friet')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Kleine friet'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('order-type-eatin')).toBeInTheDocument();
+    });
+
+    // Switch to EatIn without entering table — button disabled
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /bestelling plaatsen/i })).toBeDisabled();
+    });
+
+    // Switch back to Pickup
+    fireEvent.click(screen.getByTestId('order-type-pickup'));
+
+    // Table number input should disappear and button should be enabled
+    await waitFor(() => {
+      expect(screen.queryByTestId('table-number-input')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /bestelling plaatsen/i })).not.toBeDisabled();
+    });
+  });
+});

--- a/src/frontend/src/features/pos/__tests__/PosMenuGrid.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosMenuGrid.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * t-9 — PosMenuGrid renders a touch grid of products [AC1]
+ * t-10 — Product interactions: modifiers open modal, simple adds directly,
+ *         combo adds as single line, re-adding increments qty [AC2]
+ */
+// Import i18n config before components so that t() resolves to NL translations (fallback)
+import '@/i18n/config';
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+import { renderWithProviders } from '@/test/testUtils';
+import { PosOrderProvider, useOrderState } from '../context/PosOrderContext';
+import { PosMenuGrid } from '../components/PosMenuGrid';
+
+// Helper: renders PosMenuGrid inside a PosOrderProvider + QueryClient + Router
+function renderMenuGrid(brandSlug = 'frietjes') {
+  return renderWithProviders(
+    <PosOrderProvider>
+      <PosMenuGrid brandSlug={brandSlug} />
+    </PosOrderProvider>,
+    { initialEntries: ['/frietjes/nl/pos'] },
+  );
+}
+
+import type { ProductListItem } from '@/types/common';
+
+// Minimal fixtures
+const simpleProduct: ProductListItem = {
+  id: 'prod-simple',
+  productType: 'Simple',
+  name: 'Kleine friet',
+  basePrice: { amount: 3.5, currency: 'EUR' },
+  imageUrl: null,
+  menuCategoryId: 'cat-1',
+  sortOrderInCategory: 1,
+  allergens: [],
+  dietaryTags: [],
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+const productWithModifiers: ProductListItem = {
+  id: 'prod-modifiers',
+  productType: 'Simple',
+  name: 'Grote friet',
+  basePrice: { amount: 4.5, currency: 'EUR' },
+  imageUrl: null,
+  menuCategoryId: 'cat-1',
+  sortOrderInCategory: 2,
+  allergens: [],
+  dietaryTags: [],
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+const comboProduct: ProductListItem = {
+  id: 'prod-combo',
+  productType: 'Combo',
+  name: 'Friet Menu',
+  basePrice: { amount: 7.5, currency: 'EUR' },
+  imageUrl: null,
+  menuCategoryId: 'cat-1',
+  sortOrderInCategory: 3,
+  allergens: [],
+  dietaryTags: [],
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+/**
+ * Override menu-categories products to return test fixtures.
+ */
+function setupProductsHandler(products: import('@/types/common').ProductListItem[]) {
+  server.use(
+    http.get('/api/brands/:slug/menu-categories/:id/products', () =>
+      HttpResponse.json(products),
+    ),
+  );
+}
+
+/**
+ * Override modifier groups to return groups WITH modifiers for a product.
+ */
+function setupWithModifiersHandler(productId: string) {
+  server.use(
+    http.get('/api/brands/:slug/products/:productId/modifier-groups', ({ params }) => {
+      if (params.productId === productId) {
+        return HttpResponse.json([
+          {
+            modifierGroupId: 'mg-1',
+            name: 'Sauzen',
+            sortOrder: 1,
+            modifiers: [
+              {
+                id: 'mod-1',
+                priceAdjustment: 0,
+                sortOrder: 1,
+                translations: [{ languageCode: 'nl', name: 'Mayonaise' }],
+              },
+            ],
+          },
+        ]);
+      }
+      return HttpResponse.json([]);
+    }),
+  );
+}
+
+/**
+ * Override modifier groups to return empty for a product (no modifiers).
+ */
+function setupNoModifiersHandler() {
+  server.use(
+    http.get('/api/brands/:slug/products/:productId/modifier-groups', () =>
+      HttpResponse.json([]),
+    ),
+  );
+}
+
+describe('PosMenuGrid (t-9)', () => {
+  afterEach(() => server.resetHandlers());
+
+  it('renders a grid of product tiles from the menu', async () => {
+    setupProductsHandler([simpleProduct, productWithModifiers]);
+    setupNoModifiersHandler();
+
+    renderMenuGrid();
+
+    // Wait for the category name "Frietjes" (from the default MSW handler)
+    await waitFor(() => {
+      expect(screen.getByText('Kleine friet')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Grote friet')).toBeInTheDocument();
+
+    // Grid should be visible
+    expect(screen.getByTestId('pos-menu-grid')).toBeInTheDocument();
+  });
+
+  it('renders formatted prices in nl-BE currency format', async () => {
+    setupProductsHandler([simpleProduct]);
+    setupNoModifiersHandler();
+
+    renderMenuGrid();
+
+    await waitFor(() => {
+      // nl-BE format: € 3,50
+      expect(screen.getByText(/3,50/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('PosMenuGrid product interactions (t-10)', () => {
+  afterEach(() => server.resetHandlers());
+
+  it('tapping a product without modifiers adds it directly to the order', async () => {
+    setupProductsHandler([simpleProduct]);
+    setupNoModifiersHandler();
+
+    // Render with a state spy component
+    let addedItems: string[] = [];
+    function OrderSpy() {
+      const { state } = useOrderState();
+      addedItems = state.items.map((i) => i.productId);
+      return null;
+    }
+
+    renderWithProviders(
+      <PosOrderProvider>
+        <PosMenuGrid brandSlug="frietjes" />
+        <OrderSpy />
+      </PosOrderProvider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Kleine friet')).toBeInTheDocument();
+    });
+
+    // Click the product tile
+    fireEvent.click(screen.getByText('Kleine friet'));
+
+    await waitFor(() => {
+      expect(addedItems).toContain('prod-simple');
+    });
+  });
+
+  it('tapping a product with modifiers opens PosModifierModal with the correct product', async () => {
+    setupProductsHandler([productWithModifiers]);
+    setupWithModifiersHandler('prod-modifiers');
+
+    renderMenuGrid();
+
+    // Wait for product tile AND the modifier indicator (confirms modifier query resolved)
+    await waitFor(() => {
+      expect(screen.getByText('Grote friet')).toBeInTheDocument();
+      expect(screen.getByText('+ opties')).toBeInTheDocument();
+    });
+
+    // Click product tile — modal should appear
+    fireEvent.click(screen.getByText('Grote friet'));
+
+    await waitFor(() => {
+      // Modal dialog role should appear
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Modal should show the correct product name and its modifier group
+    await waitFor(() => {
+      // Product name appears inside the modal dialog
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Sauzen')).toBeInTheDocument();
+    });
+  });
+
+  it('confirming modifier modal adds item with selected modifiers', async () => {
+    setupProductsHandler([productWithModifiers]);
+    setupWithModifiersHandler('prod-modifiers');
+
+    let orderItems: Array<{ productId: string; selectedModifiers: unknown[] }> = [];
+    function OrderSpy() {
+      const { state } = useOrderState();
+      orderItems = state.items.map((i) => ({
+        productId: i.productId,
+        selectedModifiers: i.selectedModifiers,
+      }));
+      return null;
+    }
+
+    renderWithProviders(
+      <PosOrderProvider>
+        <PosMenuGrid brandSlug="frietjes" />
+        <OrderSpy />
+      </PosOrderProvider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    // Wait for product tile AND the modifier indicator (confirms modifier query resolved)
+    await waitFor(() => {
+      expect(screen.getByText('Grote friet')).toBeInTheDocument();
+      expect(screen.getByText('+ opties')).toBeInTheDocument();
+    });
+
+    // Open modal
+    fireEvent.click(screen.getByText('Grote friet'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Wait for modifiers to load (inside the modal, rendered by PosModifierModal)
+    await waitFor(() => {
+      expect(screen.getByText('Sauzen')).toBeInTheDocument();
+    });
+
+    // Click the confirm/add button
+    fireEvent.click(screen.getByTestId('pos-modifier-confirm'));
+
+    await waitFor(() => {
+      expect(orderItems.some((i) => i.productId === 'prod-modifiers')).toBe(true);
+    });
+
+    // Modal should be closed
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('adding a combo product adds it as a single line (no component breakdown)', async () => {
+    setupProductsHandler([comboProduct]);
+    setupNoModifiersHandler();
+
+    let orderItems: Array<{ productId: string; quantity: number }> = [];
+    function OrderSpy() {
+      const { state } = useOrderState();
+      orderItems = state.items.map((i) => ({ productId: i.productId, quantity: i.quantity }));
+      return null;
+    }
+
+    renderWithProviders(
+      <PosOrderProvider>
+        <PosMenuGrid brandSlug="frietjes" />
+        <OrderSpy />
+      </PosOrderProvider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Friet Menu')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Friet Menu'));
+
+    await waitFor(() => {
+      expect(orderItems).toHaveLength(1);
+      expect(orderItems[0]?.productId).toBe('prod-combo');
+      expect(orderItems[0]?.quantity).toBe(1);
+    });
+  });
+
+  it('re-adding the same product increments its quantity', async () => {
+    setupProductsHandler([simpleProduct]);
+    setupNoModifiersHandler();
+
+    let orderItems: Array<{ productId: string; quantity: number }> = [];
+    function OrderSpy() {
+      const { state } = useOrderState();
+      orderItems = state.items.map((i) => ({ productId: i.productId, quantity: i.quantity }));
+      return null;
+    }
+
+    renderWithProviders(
+      <PosOrderProvider>
+        <PosMenuGrid brandSlug="frietjes" />
+        <OrderSpy />
+      </PosOrderProvider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Kleine friet')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Kleine friet'));
+    fireEvent.click(screen.getByText('Kleine friet'));
+
+    await waitFor(() => {
+      expect(orderItems).toHaveLength(1);
+      expect(orderItems[0]?.quantity).toBe(2);
+    });
+  });
+
+  it('re-adding the same combo product increments quantity (single line, not two lines)', async () => {
+    setupProductsHandler([comboProduct]);
+    setupNoModifiersHandler();
+
+    let orderItems: Array<{ productId: string; quantity: number }> = [];
+    function OrderSpy() {
+      const { state } = useOrderState();
+      orderItems = state.items.map((i) => ({ productId: i.productId, quantity: i.quantity }));
+      return null;
+    }
+
+    renderWithProviders(
+      <PosOrderProvider>
+        <PosMenuGrid brandSlug="frietjes" />
+        <OrderSpy />
+      </PosOrderProvider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Friet Menu')).toBeInTheDocument();
+    });
+
+    // Add combo twice
+    fireEvent.click(screen.getByText('Friet Menu'));
+    fireEvent.click(screen.getByText('Friet Menu'));
+
+    await waitFor(() => {
+      // Must remain a single line with qty=2, not two separate lines
+      expect(orderItems).toHaveLength(1);
+      expect(orderItems[0]?.productId).toBe('prod-combo');
+      expect(orderItems[0]?.quantity).toBe(2);
+    });
+  });
+});

--- a/src/frontend/src/features/pos/__tests__/PosModifierFlow.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosModifierFlow.test.tsx
@@ -1,0 +1,432 @@
+/**
+ * t-16 — AC5 end-to-end UI modifier flow
+ *
+ * Verifies that modifiers selected via PosModifierModal are correctly
+ * transformed into selectedModifierIds in the final POST payload.
+ *
+ * This test exercises the FULL UI path:
+ *   PosMenuGrid (tap product) → PosModifierModal (toggle modifier checkbox) →
+ *   confirm → item lands in PosOrderContext → useCreateInStoreOrder builds POST body →
+ *   MSW captures the request → assert selectedModifierIds reflects UI selection
+ *
+ * This is NOT a fixture test — the modifier IDs come from actual UI interaction
+ * with PosModifierModal, not from manually constructed CartItem objects.
+ */
+// Initialize i18n before any component so t() resolves to NL translations
+import '@/i18n/config';
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+import { renderWithProviders } from '@/test/testUtils';
+import { AuthContext, type AuthContextValue } from '@/auth/AuthContext';
+import type { UserRole } from '@/types/auth';
+import { PosOrderProvider, useOrderState } from '../context/PosOrderContext';
+import { useCreateInStoreOrder } from '../hooks/useCreateInStoreOrder';
+import { PosMenuGrid } from '../components/PosMenuGrid';
+
+// ── Counter-staff auth context ────────────────────────────────────────────────
+
+function makeStaffAuth(): AuthContextValue {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    user: {
+      userId: 'staff-1',
+      displayName: 'Counter Staff',
+      email: 'staff@frietjes.be',
+      roles: ['counter-staff' as UserRole],
+      brandSlug: 'frietjes',
+    },
+    login: () => { /* no-op */ },
+    logout: () => Promise.resolve(),
+    hasRole: (role) => role === 'counter-staff',
+    hasAnyRole: (roles) => roles.includes('counter-staff'),
+  };
+}
+
+// ── MSW handler setup helpers ─────────────────────────────────────────────────
+
+const productWithModifiers = {
+  id: 'prod-friet',
+  productType: 'Simple',
+  name: 'Grote friet',
+  basePrice: { amount: 4.5, currency: 'EUR' },
+  imageUrl: null,
+  menuCategoryId: 'cat-1',
+  sortOrderInCategory: 1,
+  allergens: [],
+  dietaryTags: [],
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+/**
+ * Override category products to return a single product that has modifier groups.
+ */
+function setupProductWithModifiers() {
+  server.use(
+    http.get('/api/brands/:slug/menu-categories/:id/products', () =>
+      HttpResponse.json([productWithModifiers]),
+    ),
+    // Two modifiers: Mayonaise (mod-mayo) and Ketchup (mod-ketchup)
+    http.get('/api/brands/:slug/products/:productId/modifier-groups', ({ params }) => {
+      if (params.productId === 'prod-friet') {
+        return HttpResponse.json([
+          {
+            modifierGroupId: 'mg-sauzen',
+            name: 'Sauzen',
+            sortOrder: 1,
+            modifiers: [
+              {
+                id: 'mod-mayo',
+                priceAdjustment: 0,
+                sortOrder: 1,
+                translations: [{ languageCode: 'nl', name: 'Mayonaise' }],
+              },
+              {
+                id: 'mod-ketchup',
+                priceAdjustment: 0.5,
+                sortOrder: 2,
+                translations: [{ languageCode: 'nl', name: 'Ketchup' }],
+              },
+            ],
+          },
+        ]);
+      }
+      return HttpResponse.json([]);
+    }),
+  );
+}
+
+// ── Submit button component (wires useCreateInStoreOrder to the order state) ──
+
+/**
+ * Minimal submit trigger rendered next to PosMenuGrid so the test can
+ * call mutateAsync without mounting the full PosDashboard (which requires
+ * a full route tree and navigation context).
+ */
+function SubmitTrigger({
+  brandSlug,
+  shopId,
+  onCaptured,
+}: {
+  brandSlug: string;
+  shopId: string;
+  onCaptured: (body: Record<string, unknown>) => void;
+}) {
+  const { state } = useOrderState();
+  const mutation = useCreateInStoreOrder(brandSlug, shopId);
+
+  return (
+    <div>
+      <span data-testid="item-count">{state.items.length}</span>
+      <button
+        type="button"
+        data-testid="submit-order"
+        disabled={state.items.length === 0 || mutation.isPending}
+        onClick={() => {
+          void mutation.mutateAsync({}).then((order) => {
+            // Surface the order for assertions
+            onCaptured({ orderNumber: order.orderNumber } as Record<string, unknown>);
+          });
+        }}
+      >
+        Bestelling plaatsen
+      </button>
+      {mutation.isSuccess && <span data-testid="order-success">OK</span>}
+      {mutation.isError && <span data-testid="order-error">ERROR</span>}
+    </div>
+  );
+}
+
+// ── Test ─────────────────────────────────────────────────────────────────────
+
+describe('POS modifier flow — end-to-end UI (t-16, AC5)', () => {
+  afterEach(() => server.resetHandlers());
+
+  it('selects a modifier via PosModifierModal UI and the POST body reflects selectedModifierIds', async () => {
+    setupProductWithModifiers();
+
+    let capturedBody: {
+      items?: Array<{ productId: string; quantity: number; selectedModifierIds: string[] }>;
+      orderType?: string;
+      paymentMethod?: string;
+    } | null = null;
+
+    // Override the in-store endpoint to capture the request body
+    server.use(
+      http.post('/api/brands/:slug/shops/:shopId/orders/in-store', async ({ request, params }) => {
+        capturedBody = await request.json() as typeof capturedBody;
+        return HttpResponse.json(
+          {
+            id: 'order-modifier-test',
+            orderNumber: 'ORD-100',
+            shopId: params.shopId,
+            brandSlug: params.slug,
+            orderType: 'Pickup',
+            statusName: 'New',
+            customerName: null,
+            items: [],
+            vatRatePercent: 6,
+            subtotalGross: 4.5,
+            totalVatAmount: 0.25,
+            totalNet: 4.25,
+            totalGross: 4.5,
+            createdAt: '2024-06-01T10:00:00Z',
+            paymentMethod: 'CashAtPickup',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const auth = makeStaffAuth();
+
+    renderWithProviders(
+      <AuthContext.Provider value={auth}>
+        <PosOrderProvider>
+          <PosMenuGrid brandSlug="frietjes" />
+          <SubmitTrigger
+            brandSlug="frietjes"
+            shopId="shop-1"
+            onCaptured={() => { /* captured via server.use */ }}
+          />
+        </PosOrderProvider>
+      </AuthContext.Provider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    // Step 1: Wait for the product tile to appear (confirms categories + products loaded)
+    await waitFor(() => {
+      expect(screen.getByText('Grote friet')).toBeInTheDocument();
+    });
+
+    // Step 2: Wait for the modifier indicator to confirm the modifier query resolved
+    await waitFor(() => {
+      expect(screen.getByText('+ opties')).toBeInTheDocument();
+    });
+
+    // Step 3: Tap the product tile — PosModifierModal should open
+    fireEvent.click(screen.getByText('Grote friet'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Step 4: Wait for modifiers to load inside the modal
+    await waitFor(() => {
+      expect(screen.getByText('Sauzen')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Mayonaise/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Ketchup/i)).toBeInTheDocument();
+    });
+
+    // Step 5: Toggle Mayonaise modifier (check the checkbox)
+    const mayoCheckbox = screen.getByLabelText(/Mayonaise/i);
+    expect(mayoCheckbox).not.toBeChecked();
+    fireEvent.click(mayoCheckbox);
+    expect(mayoCheckbox).toBeChecked();
+
+    // Ketchup remains unchecked — only Mayonaise should appear in the payload
+    expect(screen.getByLabelText(/Ketchup/i)).not.toBeChecked();
+
+    // Step 6: Confirm the modifier selection
+    fireEvent.click(screen.getByTestId('pos-modifier-confirm'));
+
+    // Step 7: Modal should close and item should be in the order
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('item-count').textContent).toBe('1');
+    });
+
+    // Step 8: Submit the order
+    fireEvent.click(screen.getByTestId('submit-order'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('order-success')).toBeInTheDocument();
+    });
+
+    // Step 9: Assert the POST body contains the correct selectedModifierIds
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.items).toHaveLength(1);
+
+    const item = capturedBody!.items![0]!;
+    expect(item.productId).toBe('prod-friet');
+    // The modifier selected via the UI checkbox must appear here — NOT from a fixture
+    expect(item.selectedModifierIds).toEqual(['mod-mayo']);
+    // Ketchup was NOT checked, so it must not appear
+    expect(item.selectedModifierIds).not.toContain('mod-ketchup');
+  });
+
+  it('selecting NO modifiers results in an empty selectedModifierIds array', async () => {
+    setupProductWithModifiers();
+
+    let capturedBody: {
+      items?: Array<{ productId: string; quantity: number; selectedModifierIds: string[] }>;
+    } | null = null;
+
+    server.use(
+      http.post('/api/brands/:slug/shops/:shopId/orders/in-store', async ({ request, params }) => {
+        capturedBody = await request.json() as typeof capturedBody;
+        return HttpResponse.json(
+          {
+            id: 'order-no-mod',
+            orderNumber: 'ORD-101',
+            shopId: params.shopId,
+            brandSlug: params.slug,
+            orderType: 'Pickup',
+            statusName: 'New',
+            customerName: null,
+            items: [],
+            vatRatePercent: 6,
+            subtotalGross: 4.5,
+            totalVatAmount: 0.25,
+            totalNet: 4.25,
+            totalGross: 4.5,
+            createdAt: '2024-06-01T10:00:00Z',
+            paymentMethod: 'CashAtPickup',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const auth = makeStaffAuth();
+
+    renderWithProviders(
+      <AuthContext.Provider value={auth}>
+        <PosOrderProvider>
+          <PosMenuGrid brandSlug="frietjes" />
+          <SubmitTrigger
+            brandSlug="frietjes"
+            shopId="shop-1"
+            onCaptured={() => { /* no-op */ }}
+          />
+        </PosOrderProvider>
+      </AuthContext.Provider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Grote friet')).toBeInTheDocument();
+      expect(screen.getByText('+ opties')).toBeInTheDocument();
+    });
+
+    // Tap product — modal opens
+    fireEvent.click(screen.getByText('Grote friet'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Mayonaise/i)).toBeInTheDocument();
+    });
+
+    // Confirm without checking any modifier
+    fireEvent.click(screen.getByTestId('pos-modifier-confirm'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.getByTestId('item-count').textContent).toBe('1');
+    });
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit-order'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('order-success')).toBeInTheDocument();
+    });
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.items![0]!.selectedModifierIds).toEqual([]);
+  });
+
+  it('selecting multiple modifiers includes all their IDs in the payload', async () => {
+    setupProductWithModifiers();
+
+    let capturedBody: {
+      items?: Array<{ productId: string; quantity: number; selectedModifierIds: string[] }>;
+    } | null = null;
+
+    server.use(
+      http.post('/api/brands/:slug/shops/:shopId/orders/in-store', async ({ request, params }) => {
+        capturedBody = await request.json() as typeof capturedBody;
+        return HttpResponse.json(
+          {
+            id: 'order-multi-mod',
+            orderNumber: 'ORD-102',
+            shopId: params.shopId,
+            brandSlug: params.slug,
+            orderType: 'Pickup',
+            statusName: 'New',
+            customerName: null,
+            items: [],
+            vatRatePercent: 6,
+            subtotalGross: 4.5,
+            totalVatAmount: 0.25,
+            totalNet: 4.25,
+            totalGross: 4.5,
+            createdAt: '2024-06-01T10:00:00Z',
+            paymentMethod: 'CashAtPickup',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const auth = makeStaffAuth();
+
+    renderWithProviders(
+      <AuthContext.Provider value={auth}>
+        <PosOrderProvider>
+          <PosMenuGrid brandSlug="frietjes" />
+          <SubmitTrigger
+            brandSlug="frietjes"
+            shopId="shop-1"
+            onCaptured={() => { /* no-op */ }}
+          />
+        </PosOrderProvider>
+      </AuthContext.Provider>,
+      { initialEntries: ['/frietjes/nl/pos'] },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Grote friet')).toBeInTheDocument();
+      expect(screen.getByText('+ opties')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Grote friet'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Mayonaise/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Ketchup/i)).toBeInTheDocument();
+    });
+
+    // Check both modifiers
+    fireEvent.click(screen.getByLabelText(/Mayonaise/i));
+    fireEvent.click(screen.getByLabelText(/Ketchup/i));
+
+    expect(screen.getByLabelText(/Mayonaise/i)).toBeChecked();
+    expect(screen.getByLabelText(/Ketchup/i)).toBeChecked();
+
+    fireEvent.click(screen.getByTestId('pos-modifier-confirm'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('submit-order'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('order-success')).toBeInTheDocument();
+    });
+
+    expect(capturedBody).not.toBeNull();
+    const ids = capturedBody!.items![0]!.selectedModifierIds;
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain('mod-mayo');
+    expect(ids).toContain('mod-ketchup');
+  });
+});

--- a/src/frontend/src/features/pos/__tests__/PosOrderConfirmation.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosOrderConfirmation.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * t-15 — PosOrderConfirmation page: displays order number, back-to-menu navigation [AC5]
+ *
+ * Covers:
+ * - Renders order number from route params
+ * - Back button navigates to /pos dashboard
+ * - Missing orderNumber param redirects to /pos
+ */
+// Import i18n before any component to ensure translations are initialised
+import '@/i18n/config';
+
+import { describe, it, expect } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PosOrderConfirmationInner, PosOrderConfirmation } from '../pages/PosOrderConfirmation';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function createTestClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+/**
+ * Renders PosOrderConfirmationInner directly with controlled props.
+ */
+function renderInner(orderNumber: string, onBackToMenu = () => { /* no-op */ }) {
+  return render(
+    <QueryClientProvider client={createTestClient()}>
+      <MemoryRouter>
+        <PosOrderConfirmationInner orderNumber={orderNumber} onBackToMenu={onBackToMenu} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PosOrderConfirmationInner (t-15)', () => {
+  it('renders the order number in the confirmation element', () => {
+    renderInner('ORD-042');
+
+    expect(screen.getByTestId('pos-order-number')).toBeInTheDocument();
+    // The translated text contains the order number (interpolated via i18n)
+    expect(screen.getByTestId('pos-order-number').textContent).toContain('ORD-042');
+  });
+
+  it('renders a heading for the confirmation title', () => {
+    renderInner('ORD-001');
+
+    // h1 heading exists — exact text depends on active language (NL fallback: "Bestelling geplaatst!")
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('calls onBackToMenu when the back button is clicked', () => {
+    let backCalled = false;
+    renderInner('ORD-001', () => { backCalled = true; });
+
+    const backBtn = screen.getByRole('button');
+    fireEvent.click(backBtn);
+
+    expect(backCalled).toBe(true);
+  });
+});
+
+describe('PosOrderConfirmation route component (t-15)', () => {
+  it('renders order number from route param', async () => {
+    render(
+      <QueryClientProvider client={createTestClient()}>
+        <MemoryRouter initialEntries={['/frietjes/nl/pos/confirmation/ORD-099']}>
+          <Routes>
+            <Route path="/:brandSlug/:lang/pos/confirmation/:orderNumber" element={<PosOrderConfirmation />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-order-number')).toBeInTheDocument();
+      expect(screen.getByTestId('pos-order-number').textContent).toContain('ORD-099');
+    });
+  });
+
+  it('back button navigates to the /pos route', async () => {
+    render(
+      <QueryClientProvider client={createTestClient()}>
+        <MemoryRouter initialEntries={['/frietjes/nl/pos/confirmation/ORD-099']}>
+          <Routes>
+            <Route path="/:brandSlug/:lang/pos/confirmation/:orderNumber" element={<PosOrderConfirmation />} />
+            <Route path="/:brandSlug/:lang/pos" element={<div data-testid="pos-dashboard">POS Dashboard</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-order-number')).toBeInTheDocument();
+    });
+
+    const backBtn = screen.getByRole('button');
+    fireEvent.click(backBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-dashboard')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to /pos when orderNumber param is missing', async () => {
+    render(
+      <QueryClientProvider client={createTestClient()}>
+        <MemoryRouter initialEntries={['/frietjes/nl/pos/confirmation']}>
+          <Routes>
+            {/*
+             * Intentionally omit :orderNumber to simulate a direct navigation
+             * to /confirmation without an order number — component should redirect.
+             */}
+            <Route path="/:brandSlug/:lang/pos/confirmation" element={<PosOrderConfirmation />} />
+            <Route path="/:brandSlug/:lang/pos" element={<div data-testid="pos-dashboard">POS Dashboard</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // useEffect fires after mount; navigate({ replace: true }) brings us to /pos
+    await waitFor(() => {
+      expect(screen.getByTestId('pos-dashboard')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/frontend/src/features/pos/__tests__/PosOrderPanel.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosOrderPanel.test.tsx
@@ -2,8 +2,12 @@
  * t-11 — OrderType toggle switches Pickup/EatIn and shows/hides the table input [AC3]
  * t-12 — EatIn with empty table blocks submit; with a table it proceeds [AC4]
  */
+// Import i18n config before components so that t() resolves to NL translations (fallback)
+import '@/i18n/config';
+
 import { describe, it, expect } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { useTranslation } from 'react-i18next';
 import { renderWithProviders } from '@/test/testUtils';
 import { PosOrderProvider, useOrderState } from '../context/PosOrderContext';
 import { PosOrderPanel } from '../components/PosOrderPanel';
@@ -78,8 +82,12 @@ describe('PosOrderPanel — table number input (t-12 precondition)', () => {
 /**
  * Minimal wrapper that exposes PosOrderPanel + a submit button to test the
  * EatIn-without-table blocking behaviour from Dashboard.
+ *
+ * Uses i18n keys for display strings so the test reflects the same keys
+ * used by the real Dashboard component and isn't brittle to translation changes.
  */
 function SubmitGuardWrapper() {
+  const { t } = useTranslation('common');
   const { state } = useOrderState();
 
   const isEatInMissingTable = state.orderType === 'EatIn' && !state.tableNumber;
@@ -90,11 +98,12 @@ function SubmitGuardWrapper() {
       <PosOrderPanel />
       {isEatInMissingTable && state.items.length > 0 && (
         <p role="alert" data-testid="table-error">
-          Tafelnummer ontbreekt
+          {/* Mirrors Dashboard.tsx: t('pos.order.tableNumber') + t('error') */}
+          {t('pos.order.tableNumber')} {t('error')}
         </p>
       )}
       <button type="button" disabled={!canSubmit} data-testid="place-order-btn">
-        Bestelling plaatsen
+        {t('pos.order.submit')}
       </button>
     </div>
   );

--- a/src/frontend/src/features/pos/__tests__/PosOrderPanel.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosOrderPanel.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * t-11 — OrderType toggle switches Pickup/EatIn and shows/hides the table input [AC3]
+ * t-12 — EatIn with empty table blocks submit; with a table it proceeds [AC4]
+ */
+import { describe, it, expect } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '@/test/testUtils';
+import { PosOrderProvider, useOrderState } from '../context/PosOrderContext';
+import { PosOrderPanel } from '../components/PosOrderPanel';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderPanel() {
+  return renderWithProviders(
+    <PosOrderProvider>
+      <PosOrderPanel />
+    </PosOrderProvider>,
+    { initialEntries: ['/frietjes/nl/pos'] },
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PosOrderPanel — OrderType toggle (t-11)', () => {
+  it('renders Pickup and EatIn toggle buttons', () => {
+    renderPanel();
+
+    expect(screen.getByTestId('order-type-pickup')).toBeInTheDocument();
+    expect(screen.getByTestId('order-type-eatin')).toBeInTheDocument();
+  });
+
+  it('defaults to Pickup and does NOT show the table number input', () => {
+    renderPanel();
+
+    // Pickup button is active by default
+    expect(screen.getByTestId('order-type-pickup')).toHaveAttribute('aria-pressed', 'true');
+
+    // Table number input should NOT be present when Pickup is selected
+    expect(screen.queryByTestId('table-number-input')).not.toBeInTheDocument();
+  });
+
+  it('shows the table number input when EatIn is selected', () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+
+    expect(screen.getByTestId('table-number-input')).toBeInTheDocument();
+  });
+
+  it('hides the table number input when switching back to Pickup', () => {
+    renderPanel();
+
+    // Switch to EatIn
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+    expect(screen.getByTestId('table-number-input')).toBeInTheDocument();
+
+    // Switch back to Pickup
+    fireEvent.click(screen.getByTestId('order-type-pickup'));
+    expect(screen.queryByTestId('table-number-input')).not.toBeInTheDocument();
+  });
+});
+
+describe('PosOrderPanel — table number input (t-12 precondition)', () => {
+  it('accepts numeric input for the table number', () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+
+    const input = screen.getByTestId('table-number-input');
+    fireEvent.change(input, { target: { value: '5' } });
+
+    expect((input as HTMLInputElement).value).toBe('5');
+  });
+});
+
+// ── Submit guard tests (t-12) ─────────────────────────────────────────────────
+
+/**
+ * Minimal wrapper that exposes PosOrderPanel + a submit button to test the
+ * EatIn-without-table blocking behaviour from Dashboard.
+ */
+function SubmitGuardWrapper() {
+  const { state } = useOrderState();
+
+  const isEatInMissingTable = state.orderType === 'EatIn' && !state.tableNumber;
+  const canSubmit = state.items.length > 0 && !isEatInMissingTable;
+
+  return (
+    <div>
+      <PosOrderPanel />
+      {isEatInMissingTable && state.items.length > 0 && (
+        <p role="alert" data-testid="table-error">
+          Tafelnummer ontbreekt
+        </p>
+      )}
+      <button type="button" disabled={!canSubmit} data-testid="place-order-btn">
+        Bestelling plaatsen
+      </button>
+    </div>
+  );
+}
+
+function renderWithItems() {
+  function PreloadedWrapper() {
+    const { addItem } = useOrderState();
+
+    return (
+      <button
+        type="button"
+        data-testid="add-item-btn"
+        onClick={() =>
+          addItem({
+            productId: 'prod-1',
+            productName: 'Friet',
+            quantity: 1,
+            unitGrossPrice: 3.5,
+            selectedModifiers: [],
+          })
+        }
+      >
+        Add item
+      </button>
+    );
+  }
+
+  return renderWithProviders(
+    <PosOrderProvider>
+      <PreloadedWrapper />
+      <SubmitGuardWrapper />
+    </PosOrderProvider>,
+    { initialEntries: ['/frietjes/nl/pos'] },
+  );
+}
+
+describe('PosOrderPanel — submit guard (t-12)', () => {
+  it('blocks submit when EatIn is selected but table number is empty', async () => {
+    renderWithItems();
+
+    // Add an item first
+    fireEvent.click(screen.getByTestId('add-item-btn'));
+
+    // Switch to EatIn
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+
+    await waitFor(() => {
+      // Submit button should be disabled
+      expect(screen.getByTestId('place-order-btn')).toBeDisabled();
+      // Error alert should show
+      expect(screen.getByTestId('table-error')).toBeInTheDocument();
+    });
+  });
+
+  it('enables submit when EatIn is selected and table number is provided', async () => {
+    renderWithItems();
+
+    // Add an item
+    fireEvent.click(screen.getByTestId('add-item-btn'));
+
+    // Switch to EatIn
+    fireEvent.click(screen.getByTestId('order-type-eatin'));
+
+    // Enter a table number
+    const input = screen.getByTestId('table-number-input');
+    fireEvent.change(input, { target: { value: '5' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('place-order-btn')).not.toBeDisabled();
+      expect(screen.queryByTestId('table-error')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/frontend/src/features/pos/__tests__/PosRouteGuard.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosRouteGuard.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * t-14 — /pos requires a staff role [AC6 precondition]
+ * - Staff renders the dashboard
+ * - Anonymous / customer is blocked
+ *
+ * We provide AuthContext directly to control the role returned.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { AuthContextValue } from '@/auth/AuthContext';
+import { AuthContext } from '@/auth/AuthContext';
+import { RequireAuth } from '@/auth/RequireAuth';
+import type { UserRole } from '@/types/auth';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function createAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    user: {
+      userId: 'user-1',
+      displayName: 'Test User',
+      email: 'test@example.com',
+      roles: ['counter-staff'],
+      brandSlug: 'frietjes',
+    },
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined) as () => Promise<void>,
+    hasRole: (role: UserRole) => overrides.user?.roles.includes(role) ?? false,
+    hasAnyRole: (roles: UserRole[]) =>
+      roles.some((r) => overrides.user?.roles.includes(r) ?? false),
+    ...overrides,
+  };
+}
+
+function renderWithAuth(
+  authCtx: AuthContextValue,
+  children: React.ReactNode,
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/frietjes/nl/pos']}>
+        <AuthContext.Provider value={authCtx}>
+          {children}
+        </AuthContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const POS_STAFF_ROLES: UserRole[] = [
+  'counter-staff',
+  'floor-staff',
+  'kitchen-staff',
+  'shop-manager',
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POS route guard (t-14)', () => {
+  it('renders children for counter-staff role', () => {
+    const authCtx = createAuthContext({
+      isAuthenticated: true,
+      user: {
+        userId: 'u1',
+        displayName: 'Counter Staff',
+        email: 'staff@test.com',
+        roles: ['counter-staff'],
+        brandSlug: 'frietjes',
+      },
+      hasAnyRole: (roles) => roles.some((r) => r === 'counter-staff'),
+    });
+
+    renderWithAuth(
+      authCtx,
+      <RequireAuth roles={POS_STAFF_ROLES}>
+        <div data-testid="pos-content">POS Dashboard</div>
+      </RequireAuth>,
+    );
+
+    expect(screen.getByTestId('pos-content')).toBeInTheDocument();
+  });
+
+  it('renders children for shop-manager role', () => {
+    const authCtx = createAuthContext({
+      isAuthenticated: true,
+      user: {
+        userId: 'u2',
+        displayName: 'Shop Manager',
+        email: 'manager@test.com',
+        roles: ['shop-manager'],
+        brandSlug: 'frietjes',
+      },
+      hasAnyRole: (roles) => roles.some((r) => r === 'shop-manager'),
+    });
+
+    renderWithAuth(
+      authCtx,
+      <RequireAuth roles={POS_STAFF_ROLES}>
+        <div data-testid="pos-content">POS Dashboard</div>
+      </RequireAuth>,
+    );
+
+    expect(screen.getByTestId('pos-content')).toBeInTheDocument();
+  });
+
+  it('blocks anonymous users (not authenticated)', () => {
+    const authCtx: AuthContextValue = {
+      isAuthenticated: false,
+      isLoading: false,
+      user: null,
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined) as () => Promise<void>,
+      hasRole: () => false,
+      hasAnyRole: () => false,
+    };
+
+    renderWithAuth(
+      authCtx,
+      <RequireAuth roles={POS_STAFF_ROLES}>
+        <div data-testid="pos-content">POS Dashboard</div>
+      </RequireAuth>,
+    );
+
+    expect(screen.queryByTestId('pos-content')).not.toBeInTheDocument();
+    // RequireAuth shows a sign-in prompt for unauthenticated users
+    expect(screen.getByText(/sign in/i)).toBeInTheDocument();
+  });
+
+  it('blocks customer role', () => {
+    const authCtx = createAuthContext({
+      isAuthenticated: true,
+      user: {
+        userId: 'u3',
+        displayName: 'Customer',
+        email: 'customer@test.com',
+        roles: ['customer'],
+        brandSlug: 'frietjes',
+      },
+      hasAnyRole: (roles) => roles.some((r) => r === 'customer'),
+    });
+
+    renderWithAuth(
+      authCtx,
+      <RequireAuth roles={POS_STAFF_ROLES}>
+        <div data-testid="pos-content">POS Dashboard</div>
+      </RequireAuth>,
+    );
+
+    expect(screen.queryByTestId('pos-content')).not.toBeInTheDocument();
+    expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+  });
+
+  it('blocks brand-admin role (not a POS staff role)', () => {
+    const authCtx = createAuthContext({
+      isAuthenticated: true,
+      user: {
+        userId: 'u4',
+        displayName: 'Brand Admin',
+        email: 'admin@test.com',
+        roles: ['brand-admin'],
+        brandSlug: 'frietjes',
+      },
+      hasAnyRole: (roles) => roles.some((r) => r === 'brand-admin'),
+    });
+
+    renderWithAuth(
+      authCtx,
+      <RequireAuth roles={POS_STAFF_ROLES}>
+        <div data-testid="pos-content">POS Dashboard</div>
+      </RequireAuth>,
+    );
+
+    expect(screen.queryByTestId('pos-content')).not.toBeInTheDocument();
+    expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/pos/__tests__/useCreateInStoreOrder.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/useCreateInStoreOrder.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * t-13 — Submitting posts the correct in-store payload to the in-store route
+ *         and clears the order on success [AC5]
+ */
+import { describe, it, expect } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+import { renderWithProviders } from '@/test/testUtils';
+import { PosOrderProvider, useOrderState } from '../context/PosOrderContext';
+import { useCreateInStoreOrder } from '../hooks/useCreateInStoreOrder';
+
+// ── Test component that exercises the full mutation ──────────────────────────
+
+interface TestOrderFormProps {
+  brandSlug: string;
+  shopId: string;
+}
+
+function TestOrderForm({ brandSlug, shopId }: TestOrderFormProps) {
+  const { state, addItem, setOrderType, setTableNumber } = useOrderState();
+  const mutation = useCreateInStoreOrder(brandSlug, shopId);
+
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="add-item"
+        onClick={() =>
+          addItem({
+            productId: 'prod-1',
+            productName: 'Kleine friet',
+            quantity: 2,
+            unitGrossPrice: 3.5,
+            selectedModifiers: [
+              { modifierId: 'mod-1', modifierName: 'Mayonaise', priceAdjustment: 0 },
+            ],
+          })
+        }
+      >
+        Add item
+      </button>
+
+      <button
+        type="button"
+        data-testid="set-eatin"
+        onClick={() => {
+          setOrderType('EatIn');
+          setTableNumber(7);
+        }}
+      >
+        Set EatIn table 7
+      </button>
+
+      <button
+        type="button"
+        data-testid="submit"
+        onClick={() => { void mutation.mutateAsync({}); }}
+      >
+        Submit
+      </button>
+
+      {mutation.isSuccess && (
+        <p data-testid="success">Order placed: {mutation.data?.orderNumber}</p>
+      )}
+      {mutation.isError && <p data-testid="error">Error</p>}
+
+      <p data-testid="item-count">{state.items.length} items</p>
+    </div>
+  );
+}
+
+function renderTestForm(brandSlug = 'frietjes', shopId = 'shop-1') {
+  return renderWithProviders(
+    <PosOrderProvider>
+      <TestOrderForm brandSlug={brandSlug} shopId={shopId} />
+    </PosOrderProvider>,
+    { initialEntries: ['/frietjes/nl/pos'] },
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useCreateInStoreOrder (t-13)', () => {
+  it('posts to the in-store route with orderType, items, and paymentMethod', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    let capturedUrl = '';
+
+    server.use(
+      http.post('/api/brands/:slug/shops/:shopId/orders/in-store', async ({ request, params }) => {
+        capturedUrl = `/api/brands/${String(params.slug)}/shops/${String(params.shopId)}/orders/in-store`;
+        capturedBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            id: 'order-new',
+            orderNumber: 'ORD-001',
+            shopId: params.shopId,
+            brandSlug: params.slug,
+            orderType: capturedBody.orderType,
+            statusName: 'New',
+            customerName: null,
+            items: [],
+            vatRatePercent: 6,
+            subtotalGross: 7,
+            totalVatAmount: 0.4,
+            totalNet: 6.6,
+            totalGross: 7,
+            createdAt: '2024-06-01T10:00:00Z',
+            paymentMethod: 'CashAtPickup',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderTestForm();
+
+    // Add an item
+    fireEvent.click(screen.getByTestId('add-item'));
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('success')).toBeInTheDocument();
+    });
+
+    // Verify payload shape
+    expect(capturedUrl).toContain('/api/brands/frietjes/shops/shop-1/orders/in-store');
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!['orderType']).toBe('Pickup');
+    expect(capturedBody!['paymentMethod']).toBe('CashAtPickup');
+    expect(Array.isArray(capturedBody!['items'])).toBe(true);
+
+    const items = capturedBody!['items'] as Array<{
+      productId: string;
+      quantity: number;
+      selectedModifierIds: string[];
+    }>;
+    expect(items).toHaveLength(1);
+    expect(items[0]?.productId).toBe('prod-1');
+    expect(items[0]?.quantity).toBe(2);
+    expect(items[0]?.selectedModifierIds).toEqual(['mod-1']);
+  });
+
+  it('includes tableNumber in the payload for EatIn orders', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post('/api/brands/:slug/shops/:shopId/orders/in-store', async ({ request, params }) => {
+        capturedBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            id: 'order-eatin',
+            orderNumber: 'ORD-002',
+            shopId: params.shopId,
+            brandSlug: params.slug,
+            orderType: 'EatIn',
+            statusName: 'New',
+            customerName: null,
+            items: [],
+            vatRatePercent: 21,
+            subtotalGross: 7,
+            totalVatAmount: 1.21,
+            totalNet: 5.79,
+            totalGross: 7,
+            createdAt: '2024-06-01T10:00:00Z',
+            paymentMethod: 'CashAtPickup',
+            tableNumber: 7,
+            createdByStaffId: 'staff-1',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderTestForm();
+
+    // Add item and set EatIn with table 7
+    fireEvent.click(screen.getByTestId('add-item'));
+    fireEvent.click(screen.getByTestId('set-eatin'));
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('success')).toBeInTheDocument();
+    });
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!['orderType']).toBe('EatIn');
+    expect(capturedBody!['tableNumber']).toBe(7);
+  });
+
+  it('clears the order items after successful submission', async () => {
+    // Default handler returns 201
+    renderTestForm();
+
+    fireEvent.click(screen.getByTestId('add-item'));
+
+    // Verify item was added
+    await waitFor(() => {
+      expect(screen.getByTestId('item-count').textContent).toBe('1 items');
+    });
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit'));
+
+    // After success, order should be cleared
+    await waitFor(() => {
+      expect(screen.getByTestId('item-count').textContent).toBe('0 items');
+    });
+  });
+
+  it('does NOT include tableNumber in payload for Pickup orders', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post('/api/brands/:slug/shops/:shopId/orders/in-store', async ({ request, params }) => {
+        capturedBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            id: 'order-pickup',
+            orderNumber: 'ORD-003',
+            shopId: params.shopId,
+            brandSlug: params.slug,
+            orderType: 'Pickup',
+            statusName: 'New',
+            customerName: null,
+            items: [],
+            vatRatePercent: 6,
+            subtotalGross: 7,
+            totalVatAmount: 0.4,
+            totalNet: 6.6,
+            totalGross: 7,
+            createdAt: '2024-06-01T10:00:00Z',
+            paymentMethod: 'CashAtPickup',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderTestForm();
+
+    fireEvent.click(screen.getByTestId('add-item'));
+    fireEvent.click(screen.getByTestId('submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('success')).toBeInTheDocument();
+    });
+
+    expect(capturedBody).not.toBeNull();
+    // tableNumber must be absent for Pickup orders
+    expect('tableNumber' in capturedBody!).toBe(false);
+    // Only the expected top-level keys should be present (no accidental extras)
+    const topLevelKeys = Object.keys(capturedBody!).sort();
+    expect(topLevelKeys).toEqual(['items', 'orderType', 'paymentMethod'].sort());
+  });
+});

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -77,7 +77,7 @@ export function KitchenOrderCard({ order }: KitchenOrderCardProps) {
         >
           {typeLabel}
         </span>
-        {order.tableNumber != null && order.tableNumber.length > 0 && (
+        {order.tableNumber != null && (
           <span
             data-testid="kitchen-order-table"
             style={{

--- a/src/frontend/src/features/pos/components/PosMenuGrid.tsx
+++ b/src/frontend/src/features/pos/components/PosMenuGrid.tsx
@@ -1,0 +1,264 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ProductListItem } from '@/types/common';
+import { useStorefrontCategories, useStorefrontCategoryProducts, useProductModifierGroups } from '@features/storefront/hooks/useStorefrontMenu';
+import type { CartItem } from '../context/PosOrderContext';
+import { useOrderState } from '../context/PosOrderContext';
+import { PosModifierModal } from './PosModifierModal';
+
+interface PosMenuGridProps {
+  brandSlug: string;
+}
+
+/**
+ * Touch-first product grid for the POS interface.
+ *
+ * Layout: CSS grid with 2-4 responsive columns (auto-fill, min 160px).
+ * All tap targets are at least 48 × 48 px.
+ * No hover-only affordances — interactions are via tap/click.
+ *
+ * Products with modifier groups open PosModifierModal before being added.
+ * Products without modifiers are added directly to the order.
+ */
+export function PosMenuGrid({ brandSlug }: PosMenuGridProps) {
+  const { t } = useTranslation('common');
+  const { data: categories, isLoading: categoriesLoading } = useStorefrontCategories(brandSlug);
+  const { addItem } = useOrderState();
+
+  const [modalProduct, setModalProduct] = useState<ProductListItem | null>(null);
+
+  function handleProductTap(product: ProductListItem, hasModifiers: boolean) {
+    if (hasModifiers) {
+      setModalProduct(product);
+    } else {
+      addItem({
+        productId: product.id,
+        productName: product.name,
+        quantity: 1,
+        unitGrossPrice: product.basePrice.amount,
+        selectedModifiers: [],
+      });
+    }
+  }
+
+  function handleModalConfirm(selectedModifiers: CartItem['selectedModifiers']) {
+    if (!modalProduct) return;
+    addItem({
+      productId: modalProduct.id,
+      productName: modalProduct.name,
+      quantity: 1,
+      unitGrossPrice: modalProduct.basePrice.amount,
+      selectedModifiers,
+    });
+    setModalProduct(null);
+  }
+
+  if (categoriesLoading) {
+    return (
+      <div style={{ padding: '2rem', color: '#6b7280', textAlign: 'center' }}>
+        {t('loading')}
+      </div>
+    );
+  }
+
+  if (!categories || categories.length === 0) {
+    return (
+      <div style={{ padding: '2rem', color: '#6b7280', textAlign: 'center' }}>
+        {t('storefront.menu.noCategories')}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        style={{ overflowY: 'auto', flex: 1, padding: '1rem' }}
+        data-testid="pos-menu-grid"
+      >
+        <h2 style={{ margin: '0 0 1rem', fontSize: '1.25rem', fontWeight: 700, color: '#111827' }}>
+          {t('pos.menu.title')}
+        </h2>
+
+        {categories.map((category) => (
+          <CategorySection
+            key={category.id}
+            brandSlug={brandSlug}
+            categoryId={category.id}
+            categoryName={category.name}
+            onProductTap={handleProductTap}
+          />
+        ))}
+      </div>
+
+      {modalProduct && (
+        <PosModifierModal
+          brandSlug={brandSlug}
+          product={modalProduct}
+          onConfirm={handleModalConfirm}
+          onClose={() => setModalProduct(null)}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Category section sub-component
+// ---------------------------------------------------------------------------
+
+interface CategorySectionProps {
+  brandSlug: string;
+  categoryId: string;
+  categoryName: string;
+  onProductTap: (product: ProductListItem, hasModifiers: boolean) => void;
+}
+
+function CategorySection({
+  brandSlug,
+  categoryId,
+  categoryName,
+  onProductTap,
+}: CategorySectionProps) {
+  const { data: products } = useStorefrontCategoryProducts(brandSlug, categoryId);
+
+  if (!products || products.length === 0) return null;
+
+  return (
+    <section style={{ marginBottom: '2rem' }}>
+      <h3
+        style={{
+          margin: '0 0 0.75rem',
+          fontSize: '1rem',
+          fontWeight: 600,
+          color: '#374151',
+          paddingBottom: '0.375rem',
+          borderBottom: '2px solid var(--brand-color-primary, #111827)',
+          display: 'inline-block',
+        }}
+      >
+        {categoryName}
+      </h3>
+
+      {/* Responsive grid: 2-4 cols based on viewport, min tap target 48px */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+          gap: '0.75rem',
+        }}
+      >
+        {products.map((product) => (
+          <ProductTile
+            key={product.id}
+            brandSlug={brandSlug}
+            product={product}
+            onTap={onProductTap}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Product tile sub-component
+// ---------------------------------------------------------------------------
+
+interface ProductTileProps {
+  brandSlug: string;
+  product: ProductListItem;
+  onTap: (product: ProductListItem, hasModifiers: boolean) => void;
+}
+
+function ProductTile({ brandSlug, product, onTap }: ProductTileProps) {
+  const { t } = useTranslation('common');
+  const { data: modifierGroups } = useProductModifierGroups(brandSlug, product.id);
+  const hasModifiers = modifierGroups !== undefined && modifierGroups.length > 0;
+
+  const formattedPrice = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: product.basePrice.currency || 'EUR',
+  }).format(product.basePrice.amount);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onTap(product, hasModifiers)}
+      aria-label={`${product.name} — ${formattedPrice}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: '0.5rem',
+        padding: '0.875rem',
+        borderRadius: '0.75rem',
+        border: '2px solid #e5e7eb',
+        background: '#fff',
+        cursor: 'pointer',
+        textAlign: 'left',
+        width: '100%',
+        /* Touch target: always at least 48px tall */
+        minHeight: '4rem',
+        transition: 'border-color 0.15s',
+      }}
+      onFocus={(e) => {
+        e.currentTarget.style.borderColor = 'var(--brand-color-primary, #111827)';
+      }}
+      onBlur={(e) => {
+        e.currentTarget.style.borderColor = '#e5e7eb';
+      }}
+      onPointerDown={(e) => {
+        e.currentTarget.style.borderColor = 'var(--brand-color-primary, #111827)';
+        e.currentTarget.style.background = '#f9fafb';
+      }}
+      onPointerUp={(e) => {
+        e.currentTarget.style.borderColor = '#e5e7eb';
+        e.currentTarget.style.background = '#fff';
+      }}
+    >
+      {product.imageUrl && (
+        <img
+          src={product.imageUrl}
+          alt=""
+          aria-hidden="true"
+          style={{
+            width: '100%',
+            height: '6rem',
+            objectFit: 'cover',
+            borderRadius: '0.375rem',
+          }}
+        />
+      )}
+      <span
+        style={{
+          fontWeight: 600,
+          fontSize: '0.9375rem',
+          color: '#111827',
+          lineHeight: 1.3,
+        }}
+      >
+        {product.name}
+      </span>
+      <span
+        style={{
+          fontSize: '0.875rem',
+          color: 'var(--brand-color-primary, #374151)',
+          fontWeight: 700,
+        }}
+      >
+        {formattedPrice}
+      </span>
+      {hasModifiers && (
+        <span
+          style={{
+            fontSize: '0.75rem',
+            color: '#6b7280',
+            fontStyle: 'italic',
+          }}
+        >
+          {t('pos.menu.modifierIndicator')}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/frontend/src/features/pos/components/PosModifierModal.tsx
+++ b/src/frontend/src/features/pos/components/PosModifierModal.tsx
@@ -1,0 +1,281 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ProductListItem, ModifierResponse } from '@/types/common';
+import type { CartModifier } from '../context/PosOrderContext';
+import { useProductModifierGroups } from '@features/storefront/hooks/useStorefrontMenu';
+
+interface PosModifierModalProps {
+  brandSlug: string;
+  product: ProductListItem;
+  onConfirm: (selectedModifiers: CartModifier[]) => void;
+  onClose: () => void;
+}
+
+/**
+ * Touch-optimised modifier selection modal for the POS interface.
+ *
+ * Design choices vs storefront ModifierModal:
+ * - Large (min 48px) checkbox targets for finger-first use
+ * - Close button is explicit and large; backdrop tap does NOT close the modal
+ *   (prevents accidental dismissal on a touch screen)
+ * - Confirm and cancel buttons are full-width and tall
+ */
+export function PosModifierModal({
+  brandSlug,
+  product,
+  onConfirm,
+  onClose,
+}: PosModifierModalProps) {
+  const { t } = useTranslation('common');
+  const { data: modifierGroups, isLoading } = useProductModifierGroups(brandSlug, product.id);
+  const [selectedModifierIds, setSelectedModifierIds] = useState<Set<string>>(new Set());
+
+  function toggleModifier(modifier: ModifierResponse) {
+    setSelectedModifierIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(modifier.id)) {
+        next.delete(modifier.id);
+      } else {
+        next.add(modifier.id);
+      }
+      return next;
+    });
+  }
+
+  function handleConfirm() {
+    if (!modifierGroups) {
+      onConfirm([]);
+      return;
+    }
+
+    const selected: CartModifier[] = [];
+    for (const group of modifierGroups) {
+      for (const modifier of group.modifiers) {
+        if (selectedModifierIds.has(modifier.id)) {
+          const modifierName = modifier.translations[0]?.name ?? '';
+          selected.push({
+            modifierId: modifier.id,
+            modifierName,
+            priceAdjustment: modifier.priceAdjustment,
+          });
+        }
+      }
+    }
+    onConfirm(selected);
+  }
+
+  const formattedBasePrice = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: product.basePrice.currency || 'EUR',
+  }).format(product.basePrice.amount);
+
+  return (
+    <>
+      {/*
+        Backdrop: intentionally does NOT close on click (touch-safe).
+        Staff must use the explicit close button.
+      */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.5)',
+          zIndex: 200,
+        }}
+      />
+
+      {/* Modal panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('storefront.menu.customise')}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          margin: 'auto',
+          width: 'min(36rem, calc(100vw - 2rem))',
+          maxHeight: 'calc(100vh - 4rem)',
+          background: '#fff',
+          borderRadius: '1rem',
+          boxShadow: '0 24px 64px rgba(0,0,0,0.3)',
+          zIndex: 201,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: '1.5rem',
+            borderBottom: '1px solid #e5e7eb',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+          }}
+        >
+          <div>
+            <h2 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 700, color: '#111827' }}>
+              {product.name}
+            </h2>
+            <p style={{ margin: '0.25rem 0 0', fontSize: '1rem', color: '#6b7280' }}>
+              {formattedBasePrice}
+            </p>
+          </div>
+          {/* Large explicit close button — no accidental backdrop dismiss */}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('storefront.menu.closeModal')}
+            style={{
+              minWidth: '3rem',
+              minHeight: '3rem',
+              background: '#f3f4f6',
+              border: 'none',
+              borderRadius: '0.5rem',
+              cursor: 'pointer',
+              color: '#374151',
+              fontSize: '1.5rem',
+              lineHeight: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '1rem 1.5rem' }}>
+          {isLoading && (
+            <p style={{ color: '#6b7280', fontSize: '1rem' }}>
+              {t('storefront.menu.loadingModifiers')}
+            </p>
+          )}
+
+          {!isLoading && modifierGroups && modifierGroups.length === 0 && (
+            <p style={{ color: '#6b7280', fontSize: '1rem' }}>
+              {t('storefront.menu.noModifiers')}
+            </p>
+          )}
+
+          {!isLoading &&
+            modifierGroups?.map((group) => (
+              <div key={group.modifierGroupId} style={{ marginBottom: '1.5rem' }}>
+                <h3
+                  style={{
+                    margin: '0 0 0.75rem',
+                    fontSize: '1.0625rem',
+                    fontWeight: 600,
+                    color: '#374151',
+                  }}
+                >
+                  {group.name}
+                </h3>
+                {group.modifiers.map((modifier) => {
+                  const modifierName = modifier.translations[0]?.name ?? '';
+                  const isChecked = selectedModifierIds.has(modifier.id);
+                  const adjustmentLabel =
+                    modifier.priceAdjustment !== 0
+                      ? ` (+${new Intl.NumberFormat('nl-BE', {
+                          style: 'currency',
+                          currency: 'EUR',
+                        }).format(modifier.priceAdjustment)})`
+                      : '';
+
+                  return (
+                    <label
+                      key={modifier.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '1rem',
+                        padding: '0.875rem 0.5rem',
+                        cursor: 'pointer',
+                        fontSize: '1rem',
+                        color: '#111827',
+                        borderBottom: '1px solid #f3f4f6',
+                        minHeight: '3rem',
+                      }}
+                    >
+                      {/* Large touch target checkbox */}
+                      <input
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={() => toggleModifier(modifier)}
+                        style={{
+                          width: '1.5rem',
+                          height: '1.5rem',
+                          cursor: 'pointer',
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span style={{ flex: 1 }}>{modifierName}</span>
+                      {adjustmentLabel && (
+                        <span style={{ color: '#6b7280', fontSize: '0.9375rem' }}>
+                          {adjustmentLabel}
+                        </span>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            ))}
+        </div>
+
+        {/* Footer — full-width buttons for touch use */}
+        <div
+          style={{
+            padding: '1rem 1.5rem',
+            borderTop: '1px solid #e5e7eb',
+            display: 'flex',
+            gap: '0.75rem',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              flex: 1,
+              padding: '0.875rem',
+              borderRadius: '0.5rem',
+              border: '1px solid #d1d5db',
+              background: '#fff',
+              color: '#374151',
+              fontWeight: 600,
+              fontSize: '1rem',
+              cursor: 'pointer',
+              minHeight: '3rem',
+            }}
+          >
+            {t('storefront.menu.cancel')}
+          </button>
+          <button
+            type="button"
+            data-testid="pos-modifier-confirm"
+            onClick={handleConfirm}
+            disabled={isLoading}
+            style={{
+              flex: 2,
+              padding: '0.875rem',
+              borderRadius: '0.5rem',
+              border: 'none',
+              background: 'var(--brand-color-primary, #111827)',
+              color: '#fff',
+              fontWeight: 600,
+              fontSize: '1rem',
+              cursor: isLoading ? 'not-allowed' : 'pointer',
+              opacity: isLoading ? 0.6 : 1,
+              minHeight: '3rem',
+            }}
+          >
+            {t('storefront.menu.addToCart')}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/frontend/src/features/pos/components/PosModifierModal.tsx
+++ b/src/frontend/src/features/pos/components/PosModifierModal.tsx
@@ -50,7 +50,7 @@ export function PosModifierModal({
 
     const selected: CartModifier[] = [];
     for (const group of modifierGroups) {
-      for (const modifier of group.modifiers) {
+      for (const modifier of group.modifiers ?? []) {
         if (selectedModifierIds.has(modifier.id)) {
           const modifierName = modifier.translations[0]?.name ?? '';
           selected.push({
@@ -175,7 +175,7 @@ export function PosModifierModal({
                 >
                   {group.name}
                 </h3>
-                {group.modifiers.map((modifier) => {
+                {(group.modifiers ?? []).map((modifier) => {
                   const modifierName = modifier.translations[0]?.name ?? '';
                   const isChecked = selectedModifierIds.has(modifier.id);
                   const adjustmentLabel =

--- a/src/frontend/src/features/pos/components/PosOrderPanel.tsx
+++ b/src/frontend/src/features/pos/components/PosOrderPanel.tsx
@@ -1,0 +1,309 @@
+import { useTranslation } from 'react-i18next';
+import { useOrderState } from '../context/PosOrderContext';
+import type { CartItem, CartModifier } from '../context/PosOrderContext';
+
+/**
+ * Sidebar / bottom panel showing the running POS order.
+ *
+ * - Lists all items with per-line qty +/- controls and line totals
+ * - OrderType toggle (Pickup / EatIn) — large buttons for touch
+ * - Conditional table-number input (numeric, only when EatIn)
+ * - Subtotal + VAT (colour-coded by order type) + total
+ * - All amounts formatted via Intl.NumberFormat nl-BE
+ */
+export function PosOrderPanel() {
+  const { t } = useTranslation('common');
+  const {
+    state,
+    totals,
+    updateQuantity,
+    removeItem,
+    setOrderType,
+    setTableNumber,
+    getModifierKey,
+  } = useOrderState();
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('nl-BE', { style: 'currency', currency: 'EUR' }).format(amount);
+
+  const vatColor = state.orderType === 'EatIn' ? '#7c3aed' : '#059669';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: '#f9fafb',
+        borderLeft: '1px solid #e5e7eb',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '1rem 1.25rem',
+          borderBottom: '1px solid #e5e7eb',
+          background: '#fff',
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 700, color: '#111827' }}>
+          {t('pos.order.title')}
+        </h2>
+      </div>
+
+      {/* Order type toggle */}
+      <div style={{ padding: '0.875rem 1.25rem', borderBottom: '1px solid #e5e7eb', background: '#fff' }}>
+        <p style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600, color: '#374151' }}>
+          {t('pos.order.orderType')}
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          {(['Pickup', 'EatIn'] as const).map((type) => {
+            const isActive = state.orderType === type;
+            return (
+              <button
+                key={type}
+                type="button"
+                data-testid={`order-type-${type.toLowerCase()}`}
+                onClick={() => setOrderType(type)}
+                aria-pressed={isActive}
+                style={{
+                  flex: 1,
+                  padding: '0.75rem',
+                  borderRadius: '0.5rem',
+                  border: `2px solid ${isActive ? 'var(--brand-color-primary, #111827)' : '#e5e7eb'}`,
+                  background: isActive ? 'var(--brand-color-primary, #111827)' : '#fff',
+                  color: isActive ? '#fff' : '#374151',
+                  fontWeight: 600,
+                  fontSize: '0.9375rem',
+                  cursor: 'pointer',
+                  minHeight: '3rem',
+                }}
+              >
+                {type === 'Pickup' ? t('pos.order.pickup') : t('pos.order.eatIn')}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Table number — only shown when EatIn */}
+        {state.orderType === 'EatIn' && (
+          <div style={{ marginTop: '0.75rem' }}>
+            <label
+              htmlFor="pos-table-number"
+              style={{
+                display: 'block',
+                fontSize: '0.875rem',
+                fontWeight: 600,
+                color: '#374151',
+                marginBottom: '0.375rem',
+              }}
+            >
+              {t('pos.order.tableNumber')}
+            </label>
+            <input
+              id="pos-table-number"
+              data-testid="table-number-input"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              value={state.tableNumber ?? ''}
+              onChange={(e) => {
+                const val = e.target.value;
+                setTableNumber(val === '' ? undefined : parseInt(val, 10));
+              }}
+              placeholder={t('pos.order.tableNumberPlaceholder')}
+              style={{
+                width: '100%',
+                padding: '0.625rem 0.875rem',
+                borderRadius: '0.375rem',
+                border: '1px solid #d1d5db',
+                fontSize: '1rem',
+                color: '#111827',
+                boxSizing: 'border-box',
+                minHeight: '3rem',
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Order items list */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 1.25rem' }}>
+        {state.items.length === 0 && (
+          <p style={{ color: '#9ca3af', fontSize: '0.9375rem', textAlign: 'center', marginTop: '2rem' }}>
+            {t('storefront.cart.empty')}
+          </p>
+        )}
+
+        {state.items.map((item) => (
+          <OrderLine
+            key={`${item.productId}-${getModifierKey(item.selectedModifiers)}`}
+            item={item}
+            onIncrease={() =>
+              updateQuantity(item.productId, item.selectedModifiers, item.quantity + 1)
+            }
+            onDecrease={() =>
+              item.quantity <= 1
+                ? removeItem(item.productId, item.selectedModifiers)
+                : updateQuantity(item.productId, item.selectedModifiers, item.quantity - 1)
+            }
+            formatCurrency={formatCurrency}
+          />
+        ))}
+      </div>
+
+      {/* Totals */}
+      <div
+        style={{
+          padding: '1rem 1.25rem',
+          borderTop: '2px solid #e5e7eb',
+          background: '#fff',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.375rem' }}>
+          <span style={{ fontSize: '0.9375rem', color: '#374151' }}>{t('pos.order.subtotal')}</span>
+          <span style={{ fontSize: '0.9375rem', fontWeight: 600, color: '#111827' }}>
+            {formatCurrency(totals.subtotalGross)}
+          </span>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+          <span style={{ fontSize: '0.9375rem', color: vatColor }}>
+            {t('pos.order.vat', { rate: totals.vatPercent })}
+          </span>
+          <span style={{ fontSize: '0.9375rem', fontWeight: 600, color: vatColor }}>
+            {formatCurrency(totals.vatAmount)}
+          </span>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            paddingTop: '0.75rem',
+            borderTop: '1px solid #e5e7eb',
+          }}
+        >
+          <span style={{ fontSize: '1.125rem', fontWeight: 700, color: '#111827' }}>
+            {t('pos.order.total')}
+          </span>
+          <span style={{ fontSize: '1.25rem', fontWeight: 800, color: '#111827' }}>
+            {formatCurrency(totals.totalGross)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single order line sub-component
+// ---------------------------------------------------------------------------
+
+interface OrderLineProps {
+  item: CartItem;
+  onIncrease: () => void;
+  onDecrease: () => void;
+  formatCurrency: (amount: number) => string;
+}
+
+function OrderLine({ item, onIncrease, onDecrease, formatCurrency }: OrderLineProps) {
+  const modifierTotal = item.selectedModifiers.reduce(
+    (s: number, m: CartModifier) => s + m.priceAdjustment,
+    0,
+  );
+  const lineTotal = item.quantity * (item.unitGrossPrice + modifierTotal);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.75rem',
+        alignItems: 'flex-start',
+        paddingBottom: '0.75rem',
+        marginBottom: '0.75rem',
+        borderBottom: '1px solid #f3f4f6',
+      }}
+    >
+      {/* Qty controls */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', flexShrink: 0 }}>
+        <button
+          type="button"
+          onClick={onDecrease}
+          aria-label={`Decrease ${item.productName}`}
+          style={{
+            width: '2.25rem',
+            height: '2.25rem',
+            borderRadius: '0.375rem',
+            border: '1px solid #d1d5db',
+            background: '#fff',
+            cursor: 'pointer',
+            fontSize: '1.125rem',
+            fontWeight: 700,
+            color: '#374151',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          −
+        </button>
+        <span
+          style={{
+            minWidth: '1.75rem',
+            textAlign: 'center',
+            fontWeight: 700,
+            fontSize: '1rem',
+            color: '#111827',
+          }}
+        >
+          {item.quantity}
+        </span>
+        <button
+          type="button"
+          onClick={onIncrease}
+          aria-label={`Increase ${item.productName}`}
+          style={{
+            width: '2.25rem',
+            height: '2.25rem',
+            borderRadius: '0.375rem',
+            border: '1px solid #d1d5db',
+            background: '#fff',
+            cursor: 'pointer',
+            fontSize: '1.125rem',
+            fontWeight: 700,
+            color: '#374151',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          +
+        </button>
+      </div>
+
+      {/* Name + modifiers */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{ margin: 0, fontWeight: 600, fontSize: '0.9375rem', color: '#111827' }}>
+          {item.productName}
+        </p>
+        {item.selectedModifiers.length > 0 && (
+          <p style={{ margin: '0.125rem 0 0', fontSize: '0.8125rem', color: '#6b7280' }}>
+            {item.selectedModifiers.map((m) => m.modifierName).join(', ')}
+          </p>
+        )}
+      </div>
+
+      {/* Line total */}
+      <span
+        style={{
+          fontWeight: 700,
+          fontSize: '0.9375rem',
+          color: '#111827',
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+        }}
+      >
+        {formatCurrency(lineTotal)}
+      </span>
+    </div>
+  );
+}

--- a/src/frontend/src/features/pos/context/PosOrderContext.tsx
+++ b/src/frontend/src/features/pos/context/PosOrderContext.tsx
@@ -1,0 +1,282 @@
+import {
+  createContext,
+  useContext,
+  useReducer,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import type { CartItem, CartModifier } from '@features/storefront/context/CartContext';
+import type { OrderType, PaymentMethod } from '@api/orders';
+
+// Re-export CartItem and CartModifier so POS components can import from one place
+export type { CartItem, CartModifier };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PosOrderState {
+  items: CartItem[];
+  orderType: OrderType;
+  tableNumber: number | undefined;
+  paymentMethod: PaymentMethod;
+}
+
+export interface PosOrderTotals {
+  subtotalGross: number;
+  vatPercent: number;
+  vatAmount: number;
+  totalGross: number;
+}
+
+interface PosOrderContextValue {
+  state: PosOrderState;
+  totals: PosOrderTotals;
+  addItem: (item: CartItem) => void;
+  removeItem: (productId: string, modifiers: CartModifier[]) => void;
+  updateQuantity: (productId: string, modifiers: CartModifier[], quantity: number) => void;
+  clearOrder: () => void;
+  setOrderType: (orderType: OrderType) => void;
+  setTableNumber: (tableNumber: number | undefined) => void;
+  setPaymentMethod: (paymentMethod: PaymentMethod) => void;
+  getModifierKey: (modifiers: CartModifier[]) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a stable deduplication key from selected modifiers.
+ * Same product + same modifiers = same line item.
+ */
+export function modifierKey(selectedModifiers: CartModifier[]): string {
+  return selectedModifiers
+    .map((m) => m.modifierId)
+    .sort()
+    .join(',');
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+type PosOrderAction =
+  | { type: 'ADD_ITEM'; payload: CartItem }
+  | { type: 'REMOVE_ITEM'; payload: { productId: string; modifierKey: string } }
+  | { type: 'UPDATE_QUANTITY'; payload: { productId: string; modifierKey: string; quantity: number } }
+  | { type: 'CLEAR_ORDER' }
+  | { type: 'SET_ORDER_TYPE'; payload: OrderType }
+  | { type: 'SET_TABLE_NUMBER'; payload: number | undefined }
+  | { type: 'SET_PAYMENT_METHOD'; payload: PaymentMethod };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function posOrderReducer(state: PosOrderState, action: PosOrderAction): PosOrderState {
+  switch (action.type) {
+    case 'ADD_ITEM': {
+      const newItemKey = modifierKey(action.payload.selectedModifiers);
+      const existingIndex = state.items.findIndex(
+        (item) =>
+          item.productId === action.payload.productId &&
+          modifierKey(item.selectedModifiers) === newItemKey,
+      );
+
+      if (existingIndex >= 0) {
+        const updatedItems = state.items.map((item, idx) =>
+          idx === existingIndex
+            ? { ...item, quantity: item.quantity + action.payload.quantity }
+            : item,
+        );
+        return { ...state, items: updatedItems };
+      }
+
+      return { ...state, items: [...state.items, action.payload] };
+    }
+
+    case 'REMOVE_ITEM':
+      return {
+        ...state,
+        items: state.items.filter(
+          (item) =>
+            !(
+              item.productId === action.payload.productId &&
+              modifierKey(item.selectedModifiers) === action.payload.modifierKey
+            ),
+        ),
+      };
+
+    case 'UPDATE_QUANTITY':
+      if (action.payload.quantity <= 0) {
+        return {
+          ...state,
+          items: state.items.filter(
+            (item) =>
+              !(
+                item.productId === action.payload.productId &&
+                modifierKey(item.selectedModifiers) === action.payload.modifierKey
+              ),
+          ),
+        };
+      }
+      return {
+        ...state,
+        items: state.items.map((item) =>
+          item.productId === action.payload.productId &&
+          modifierKey(item.selectedModifiers) === action.payload.modifierKey
+            ? { ...item, quantity: action.payload.quantity }
+            : item,
+        ),
+      };
+
+    case 'CLEAR_ORDER':
+      return {
+        items: [],
+        orderType: state.orderType,
+        tableNumber: undefined,
+        paymentMethod: state.paymentMethod,
+      } satisfies PosOrderState;
+
+    case 'SET_ORDER_TYPE': {
+      // Clear table number when switching away from EatIn
+      const nextTableNumber =
+        action.payload === 'EatIn' ? state.tableNumber : undefined;
+      return {
+        ...state,
+        orderType: action.payload,
+        tableNumber: nextTableNumber,
+      } satisfies PosOrderState;
+    }
+
+    case 'SET_TABLE_NUMBER':
+      return { ...state, tableNumber: action.payload };
+
+    case 'SET_PAYMENT_METHOD':
+      return { ...state, paymentMethod: action.payload };
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const PosOrderContext = createContext<PosOrderContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface PosOrderProviderProps {
+  children: ReactNode;
+  /** Initial payment method. Defaults to CashAtPickup (POS default). */
+  initialPaymentMethod?: PaymentMethod;
+  /** Initial order type. Defaults to Pickup. */
+  initialOrderType?: OrderType;
+}
+
+export function PosOrderProvider({
+  children,
+  initialPaymentMethod = 'CashAtPickup',
+  initialOrderType = 'Pickup',
+}: PosOrderProviderProps) {
+  const initialState: PosOrderState = {
+    items: [],
+    orderType: initialOrderType,
+    tableNumber: undefined,
+    paymentMethod: initialPaymentMethod,
+  };
+
+  const [state, dispatch] = useReducer(posOrderReducer, initialState);
+
+  const addItem = useCallback((item: CartItem) => {
+    dispatch({ type: 'ADD_ITEM', payload: item });
+  }, []);
+
+  const removeItem = useCallback((productId: string, modifiers: CartModifier[]) => {
+    dispatch({
+      type: 'REMOVE_ITEM',
+      payload: { productId, modifierKey: modifierKey(modifiers) },
+    });
+  }, []);
+
+  const updateQuantity = useCallback(
+    (productId: string, modifiers: CartModifier[], quantity: number) => {
+      dispatch({
+        type: 'UPDATE_QUANTITY',
+        payload: { productId, modifierKey: modifierKey(modifiers), quantity },
+      });
+    },
+    [],
+  );
+
+  const clearOrder = useCallback(() => {
+    dispatch({ type: 'CLEAR_ORDER' });
+  }, []);
+
+  const setOrderType = useCallback((orderType: OrderType) => {
+    dispatch({ type: 'SET_ORDER_TYPE', payload: orderType });
+  }, []);
+
+  const setTableNumber = useCallback((tableNumber: number | undefined) => {
+    dispatch({ type: 'SET_TABLE_NUMBER', payload: tableNumber });
+  }, []);
+
+  const setPaymentMethod = useCallback((paymentMethod: PaymentMethod) => {
+    dispatch({ type: 'SET_PAYMENT_METHOD', payload: paymentMethod });
+  }, []);
+
+  const totals = useMemo<PosOrderTotals>(() => {
+    const subtotalGross = state.items.reduce(
+      (sum, item) =>
+        sum +
+        item.quantity *
+          (item.unitGrossPrice +
+            item.selectedModifiers.reduce((ms, m) => ms + m.priceAdjustment, 0)),
+      0,
+    );
+
+    const vatPercent = state.orderType === 'EatIn' ? 21 : 6;
+    // VAT is already included in gross price — extract it: vatAmount = gross * rate / (100 + rate)
+    const vatAmount = (subtotalGross * vatPercent) / (100 + vatPercent);
+    const totalGross = subtotalGross;
+
+    return { subtotalGross, vatPercent, vatAmount, totalGross };
+  }, [state.items, state.orderType]);
+
+  const value: PosOrderContextValue = {
+    state,
+    totals,
+    addItem,
+    removeItem,
+    updateQuantity,
+    clearOrder,
+    setOrderType,
+    setTableNumber,
+    setPaymentMethod,
+    getModifierKey: modifierKey,
+  };
+
+  return <PosOrderContext.Provider value={value}>{children}</PosOrderContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the current POS order context.
+ * Throws if called outside a PosOrderProvider.
+ */
+export function useOrderState(): PosOrderContextValue {
+  const ctx = useContext(PosOrderContext);
+  if (ctx === null) {
+    throw new Error('useOrderState must be used within a PosOrderProvider.');
+  }
+  return ctx;
+}

--- a/src/frontend/src/features/pos/hooks/useCreateInStoreOrder.ts
+++ b/src/frontend/src/features/pos/hooks/useCreateInStoreOrder.ts
@@ -1,0 +1,38 @@
+import { useMutation } from '@tanstack/react-query';
+import { ordersApi } from '@api/orders';
+import type { CreateInStoreOrderRequest, OrderResponse } from '@api/orders';
+import { useOrderState } from '../context/PosOrderContext';
+
+/**
+ * TanStack Query mutation hook for creating an in-store (POS) order.
+ *
+ * - Accepts brandSlug + shopId as route params (not in the body)
+ * - Builds the request payload from current POS order state
+ * - Clears the order on success so the terminal is ready for the next customer
+ * - Error handling mirrors useCreateOrder in the storefront feature
+ */
+export function useCreateInStoreOrder(brandSlug: string, shopId: string) {
+  const { state, clearOrder } = useOrderState();
+
+  return useMutation<OrderResponse, Error, { customerName?: string }>({
+    mutationFn: ({ customerName }) => {
+      const payload: CreateInStoreOrderRequest = {
+        orderType: state.orderType,
+        paymentMethod: state.paymentMethod,
+        items: state.items.map((item) => ({
+          productId: item.productId,
+          quantity: item.quantity,
+          selectedModifierIds: item.selectedModifiers.map((m) => m.modifierId),
+        })),
+        ...(customerName ? { customerName } : {}),
+        ...(state.orderType === 'EatIn' && state.tableNumber !== undefined
+          ? { tableNumber: state.tableNumber }
+          : {}),
+      };
+      return ordersApi.createInStore(brandSlug, shopId, payload);
+    },
+    onSuccess: () => {
+      clearOrder();
+    },
+  });
+}

--- a/src/frontend/src/features/pos/pages/Dashboard.tsx
+++ b/src/frontend/src/features/pos/pages/Dashboard.tsx
@@ -1,8 +1,189 @@
-export function PosDashboard() {
+import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/auth/useAuth';
+import { LanguageSelector } from '@features/storefront/components/LanguageSelector';
+import { PosOrderProvider, useOrderState } from '../context/PosOrderContext';
+import { PosMenuGrid } from '../components/PosMenuGrid';
+import { PosOrderPanel } from '../components/PosOrderPanel';
+import { useCreateInStoreOrder } from '../hooks/useCreateInStoreOrder';
+
+// ---------------------------------------------------------------------------
+// Inner dashboard — must be inside PosOrderProvider
+// ---------------------------------------------------------------------------
+
+interface PosDashboardInnerProps {
+  brandSlug: string;
+  shopId: string;
+}
+
+function PosDashboardInner({ brandSlug, shopId }: PosDashboardInnerProps) {
+  const { t } = useTranslation('common');
+  const { user } = useAuth();
+  const { state } = useOrderState();
+  const { lang, brandSlug: paramBrandSlug } = useParams<{ lang: string; brandSlug: string }>();
+  const navigate = useNavigate();
+
+  const mutation = useCreateInStoreOrder(brandSlug, shopId);
+
+  // Client-side guard: block submit when order is empty or EatIn without table number
+  const isEatInMissingTable =
+    state.orderType === 'EatIn' && !state.tableNumber;
+  const canSubmit =
+    state.items.length > 0 && !isEatInMissingTable && !mutation.isPending;
+
+  async function handlePlaceOrder() {
+    if (!canSubmit) return;
+    try {
+      const order = await mutation.mutateAsync({});
+      void navigate(`/${paramBrandSlug}/${lang}/pos/confirmation/${order.orderNumber}`);
+    } catch {
+      // error is exposed via mutation.isError
+    }
+  }
+
+  // Derive a friendly brand display name from the slug (capitalise first letter)
+  const brandDisplayName =
+    brandSlug.charAt(0).toUpperCase() + brandSlug.slice(1);
+
   return (
-    <main>
-      <h1>POS Dashboard</h1>
-      <p>Point of sale interface — touch-friendly, offline-capable.</p>
-    </main>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateRows: 'auto 1fr',
+        gridTemplateColumns: '1fr 22rem',
+        height: '100dvh',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header — spans full width */}
+      <header
+        style={{
+          gridColumn: '1 / -1',
+          padding: '0.875rem 1.25rem',
+          borderBottom: '1px solid #e5e7eb',
+          background: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '1rem',
+        }}
+      >
+        <span style={{ fontWeight: 700, fontSize: '1.0625rem', color: '#111827' }}>
+          {brandDisplayName} — POS
+        </span>
+        {user && (
+          <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+            {user.displayName}{' '}
+            <span style={{ color: '#9ca3af' }}>
+              ({user.roles.join(', ')})
+            </span>
+          </span>
+        )}
+        <div style={{ marginLeft: 'auto' }}>
+          <LanguageSelector />
+        </div>
+      </header>
+
+      {/* Menu grid — left column */}
+      <div style={{ overflowY: 'auto', background: '#fff' }}>
+        <PosMenuGrid brandSlug={brandSlug} />
+      </div>
+
+      {/* Order panel + submit — right column */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          borderLeft: '1px solid #e5e7eb',
+        }}
+      >
+        <div style={{ flex: 1, overflow: 'hidden' }}>
+          <PosOrderPanel />
+        </div>
+
+        {/* Validation feedback */}
+        {state.items.length > 0 && isEatInMissingTable && (
+          <div
+            role="alert"
+            style={{
+              margin: '0 1.25rem',
+              padding: '0.625rem 0.875rem',
+              borderRadius: '0.375rem',
+              background: '#fef2f2',
+              border: '1px solid #fecaca',
+              color: '#991b1b',
+              fontSize: '0.875rem',
+            }}
+          >
+            {t('pos.order.tableNumber')} {t('error')}
+          </div>
+        )}
+
+        {mutation.isError && (
+          <div
+            role="alert"
+            style={{
+              margin: '0 1.25rem',
+              padding: '0.625rem 0.875rem',
+              borderRadius: '0.375rem',
+              background: '#fef2f2',
+              border: '1px solid #fecaca',
+              color: '#991b1b',
+              fontSize: '0.875rem',
+            }}
+          >
+            {t('pos.error.submit')}
+          </div>
+        )}
+
+        {/* Place Order button */}
+        <div style={{ padding: '1rem 1.25rem', background: '#fff', borderTop: '1px solid #e5e7eb' }}>
+          <button
+            type="button"
+            onClick={() => { void handlePlaceOrder(); }}
+            disabled={!canSubmit}
+            aria-disabled={!canSubmit}
+            style={{
+              width: '100%',
+              padding: '1rem',
+              borderRadius: '0.5rem',
+              border: 'none',
+              background: canSubmit ? 'var(--brand-color-primary, #111827)' : '#9ca3af',
+              color: '#fff',
+              fontWeight: 700,
+              fontSize: '1.0625rem',
+              cursor: canSubmit ? 'pointer' : 'not-allowed',
+              minHeight: '3.5rem',
+            }}
+          >
+            {mutation.isPending ? '…' : t('pos.order.submit')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// POS Dashboard — wraps inner component in the PosOrderProvider
+// ---------------------------------------------------------------------------
+
+/**
+ * Main POS page for placing in-store orders.
+ *
+ * Reads brandSlug and shopId from route params.
+ * shopId is assumed to be provided in the URL; in production it will come from
+ * a shop-selection step or the staff's assigned shop.
+ */
+export function PosDashboard() {
+  const { brandSlug, shopId } = useParams<{ brandSlug: string; shopId: string }>();
+  const resolvedBrandSlug = brandSlug ?? 'frietjes';
+  // shopId is optional in the route for now; fall back to 'shop-1' for dev
+  const resolvedShopId = shopId ?? 'shop-1';
+
+  return (
+    <PosOrderProvider>
+      <PosDashboardInner brandSlug={resolvedBrandSlug} shopId={resolvedShopId} />
+    </PosOrderProvider>
   );
 }

--- a/src/frontend/src/features/pos/pages/PosOrderConfirmation.tsx
+++ b/src/frontend/src/features/pos/pages/PosOrderConfirmation.tsx
@@ -1,0 +1,113 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface PosOrderConfirmationProps {
+  orderNumber: string;
+  onBackToMenu: () => void;
+}
+
+/**
+ * Minimal POS-specific order confirmation page.
+ * Shows the order number, a success indicator, and a "Back to Menu" button.
+ *
+ * This is intentionally simple — no storefront OrderConfirmationPage complexity
+ * (no SignalR tracking, no payment status) since the staff already knows the order
+ * was placed successfully.
+ */
+export function PosOrderConfirmationInner({ orderNumber, onBackToMenu }: PosOrderConfirmationProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <main
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '60vh',
+        padding: '2rem',
+        textAlign: 'center',
+      }}
+    >
+      {/* Success indicator */}
+      <div
+        style={{
+          width: '5rem',
+          height: '5rem',
+          borderRadius: '50%',
+          background: '#d1fae5',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <span style={{ fontSize: '2.5rem', lineHeight: 1 }}>✓</span>
+      </div>
+
+      <h1 style={{ fontSize: '1.75rem', fontWeight: 800, color: '#111827', margin: '0 0 0.75rem' }}>
+        {t('pos.confirmation.title')}
+      </h1>
+
+      <p
+        style={{ fontSize: '1.25rem', fontWeight: 600, color: '#374151', margin: '0 0 2rem' }}
+        data-testid="pos-order-number"
+      >
+        {t('pos.confirmation.orderNumber', { number: orderNumber })}
+      </p>
+
+      <button
+        type="button"
+        onClick={onBackToMenu}
+        style={{
+          padding: '0.875rem 2.5rem',
+          borderRadius: '0.5rem',
+          border: 'none',
+          background: 'var(--brand-color-primary, #111827)',
+          color: '#fff',
+          fontWeight: 700,
+          fontSize: '1.0625rem',
+          cursor: 'pointer',
+          minHeight: '3rem',
+        }}
+      >
+        {t('pos.confirmation.back')}
+      </button>
+    </main>
+  );
+}
+
+/**
+ * Route component for /pos/confirmation/:orderNumber
+ */
+export function PosOrderConfirmation() {
+  const { brandSlug, lang, orderNumber } = useParams<{
+    brandSlug: string;
+    lang: string;
+    orderNumber: string;
+  }>();
+  const navigate = useNavigate();
+
+  // Redirect to /pos dashboard if the orderNumber param is missing (e.g. direct navigation)
+  useEffect(() => {
+    if (!orderNumber) {
+      void navigate(`/${brandSlug}/${lang}/pos`, { replace: true });
+    }
+  }, [orderNumber, navigate, brandSlug, lang]);
+
+  function handleBackToMenu() {
+    void navigate(`/${brandSlug}/${lang}/pos`);
+  }
+
+  if (!orderNumber) {
+    return null;
+  }
+
+  return (
+    <PosOrderConfirmationInner
+      orderNumber={orderNumber}
+      onBackToMenu={handleBackToMenu}
+    />
+  );
+}

--- a/src/frontend/src/features/pos/routes.tsx
+++ b/src/frontend/src/features/pos/routes.tsx
@@ -1,17 +1,22 @@
-// fallow-ignore-file unused-file
-//
 // POS route module. Wired up by US-FP-018 (POS ordering).
 
 import type { RouteObject } from 'react-router-dom';
 import { PosDashboard } from './pages/Dashboard';
+import { PosOrderConfirmation } from './pages/PosOrderConfirmation';
 
 /**
  * Route configuration for the in-store POS interface.
  * These routes are nested under /:brandSlug/:lang/pos/ in the main router.
+ *
+ * Auth guard (RequireAuth with staff roles) is applied in router.tsx — not duplicated here.
  */
 export const posRoutes: RouteObject[] = [
   {
     index: true,
     element: <PosDashboard />,
+  },
+  {
+    path: 'confirmation/:orderNumber',
+    element: <PosOrderConfirmation />,
   },
 ];

--- a/src/frontend/src/features/storefront/components/ModifierModal.tsx
+++ b/src/frontend/src/features/storefront/components/ModifierModal.tsx
@@ -42,7 +42,7 @@ export function ModifierModal({ brandSlug, product, onConfirm, onClose }: Modifi
 
     const selected: CartModifier[] = [];
     for (const group of modifierGroups) {
-      for (const modifier of group.modifiers) {
+      for (const modifier of group.modifiers ?? []) {
         if (selectedModifierIds.has(modifier.id)) {
           const modifierName = modifier.translations[0]?.name ?? '';
           selected.push({
@@ -158,7 +158,7 @@ export function ModifierModal({ brandSlug, product, onConfirm, onClose }: Modifi
                   >
                     {group.name}
                   </h3>
-                  {group.modifiers.map((modifier) => {
+                  {(group.modifiers ?? []).map((modifier) => {
                     const modifierName = modifier.translations[0]?.name ?? '';
                     const isChecked = selectedModifierIds.has(modifier.id);
                     const adjustmentLabel =

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -112,6 +112,30 @@
         "reconnecting": "Wiederverbinden…",
         "disconnected": "Offline"
       }
+    },
+    "menu": {
+      "title": "Menü",
+      "modifierIndicator": "+ Optionen"
+    },
+    "order": {
+      "title": "Bestellung",
+      "orderType": "Bestellart",
+      "pickup": "Abholung",
+      "eatIn": "Vor Ort",
+      "tableNumber": "Tischnummer",
+      "tableNumberPlaceholder": "z.B. 5",
+      "submit": "Bestellung aufgeben",
+      "subtotal": "Zwischensumme",
+      "vat": "MwSt. ({{rate}}%)",
+      "total": "Gesamt"
+    },
+    "error": {
+      "submit": "Bestellung fehlgeschlagen. Bitte erneut versuchen."
+    },
+    "confirmation": {
+      "title": "Bestellung aufgegeben!",
+      "orderNumber": "Bestellnummer: {{number}}",
+      "back": "Zurück zum Menü"
     }
   },
   "allergens": {

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -112,6 +112,30 @@
         "reconnecting": "Reconnexion…",
         "disconnected": "Hors ligne"
       }
+    },
+    "menu": {
+      "title": "Menu",
+      "modifierIndicator": "+ options"
+    },
+    "order": {
+      "title": "Commande",
+      "orderType": "Type de commande",
+      "pickup": "À emporter",
+      "eatIn": "Sur place",
+      "tableNumber": "Numéro de table",
+      "tableNumberPlaceholder": "ex. 5",
+      "submit": "Passer la commande",
+      "subtotal": "Sous-total",
+      "vat": "TVA ({{rate}}%)",
+      "total": "Total"
+    },
+    "error": {
+      "submit": "Échec de la commande. Veuillez réessayer."
+    },
+    "confirmation": {
+      "title": "Commande passée !",
+      "orderNumber": "Numéro de commande : {{number}}",
+      "back": "Retour au menu"
     }
   },
   "allergens": {

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -112,6 +112,30 @@
         "reconnecting": "Opnieuw verbinden…",
         "disconnected": "Verbinding verbroken"
       }
+    },
+    "menu": {
+      "title": "Menu",
+      "modifierIndicator": "+ opties"
+    },
+    "order": {
+      "title": "Bestelling",
+      "orderType": "Besteltype",
+      "pickup": "Afhalen",
+      "eatIn": "Ter plaatse",
+      "tableNumber": "Tafelnummer",
+      "tableNumberPlaceholder": "bijv. 5",
+      "submit": "Bestelling plaatsen",
+      "subtotal": "Subtotaal",
+      "vat": "BTW ({{rate}}%)",
+      "total": "Totaal"
+    },
+    "error": {
+      "submit": "Bestelling plaatsen mislukt. Probeer opnieuw."
+    },
+    "confirmation": {
+      "title": "Bestelling geplaatst!",
+      "orderNumber": "Bestelnummer: {{number}}",
+      "back": "Terug naar menu"
     }
   },
   "allergens": {

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -8,15 +8,12 @@ import { SuspenseWrapper } from '@components/SuspenseWrapper';
 import { RequireAuth } from '@/auth/RequireAuth';
 import { adminRoutes } from '@features/admin/routes';
 import { storefrontRoutes } from '@features/storefront/routes';
+import { posRoutes } from '@features/pos/routes';
 import { ThemeProvider } from '@features/storefront/components/ThemeProvider';
 
 // ---------------------------------------------------------------------------
 // Lazy-loaded feature pages — split into separate chunks by Vite/Rollup
 // ---------------------------------------------------------------------------
-
-const LazyPosDashboard = lazy(() =>
-  import('@features/pos/pages/Dashboard').then((m) => ({ default: m.PosDashboard })),
-);
 
 const LazyKitchenDisplay = lazy(() =>
   import('@features/pos/pages/KitchenDisplay').then((m) => ({ default: m.KitchenDisplay })),
@@ -75,14 +72,8 @@ export const router = createBrowserRouter([
           </RequireAuth>
         ),
         children: [
-          {
-            index: true,
-            element: (
-              <SuspenseWrapper>
-                <LazyPosDashboard />
-              </SuspenseWrapper>
-            ),
-          },
+          // POS routes (index -> Dashboard, confirmation) live in features/pos/routes.
+          ...posRoutes,
           {
             // Kitchen display screen (US-FP-027) — shop-scoped because each store
             // has its own pass and the staff member is at a single station.

--- a/src/frontend/src/test/msw/handlers.ts
+++ b/src/frontend/src/test/msw/handlers.ts
@@ -661,6 +661,72 @@ export const handlers = [
     new HttpResponse(null, { status: 200 }),
   ),
 
+  // ── In-store Orders (/api/brands/:slug/shops/:shopId/orders/in-store) ────
+
+  http.post('/api/brands/:slug/shops/:shopId/orders/in-store', async ({ params, request }) => {
+    const body = await request.json() as {
+      orderType: string;
+      paymentMethod: string;
+      tableNumber?: number;
+      customerName?: string;
+      items: Array<{ productId: string; quantity: number; selectedModifierIds: string[] }>;
+    };
+
+    // Minimal server-side validation: reject obviously malformed payloads in tests
+    const validOrderTypes = ['Pickup', 'EatIn', 'Delivery'];
+    if (!validOrderTypes.includes(body.orderType)) {
+      return HttpResponse.json({ error: `Invalid orderType: ${body.orderType}` }, { status: 400 });
+    }
+    if (!Array.isArray(body.items) || body.items.length === 0) {
+      return HttpResponse.json({ error: 'items must be a non-empty array' }, { status: 400 });
+    }
+    if (!body.paymentMethod) {
+      return HttpResponse.json({ error: 'paymentMethod is required' }, { status: 400 });
+    }
+
+    return HttpResponse.json(
+      {
+        id: 'instore-order-1',
+        orderNumber: 'ORD-999',
+        shopId: params.shopId,
+        brandSlug: params.slug,
+        orderType: body.orderType,
+        statusName: 'New',
+        customerName: body.customerName ?? null,
+        items: (body.items ?? []).map((item) => ({
+          productId: item.productId,
+          productName: 'Kleine friet',
+          quantity: item.quantity,
+          unitGrossPrice: 3.5,
+          unitNetPrice: 3.3,
+          unitVatAmount: 0.2,
+          lineTotal: item.quantity * 3.5,
+          selectedModifiers: item.selectedModifierIds.map((id) => ({
+            modifierId: id,
+            modifierName: 'Mayonaise',
+            priceAdjustment: 0,
+          })),
+        })),
+        vatRatePercent: body.orderType === 'EatIn' ? 21 : 6,
+        subtotalGross: (body.items ?? []).reduce(
+          (sum: number, item) => sum + item.quantity * 3.5,
+          0,
+        ),
+        totalVatAmount: 0.2,
+        totalNet: 3.3,
+        totalGross: (body.items ?? []).reduce(
+          (sum: number, item) => sum + item.quantity * 3.5,
+          0,
+        ),
+        createdAt: '2024-06-01T10:00:00Z',
+        paymentMethod: body.paymentMethod,
+        tableNumber: body.tableNumber,
+        createdByStaffId: 'staff-1',
+      },
+      { status: 201 },
+    );
+  }),
+
   // ── Tax Configuration (/api/brands/:slug/tax-configuration) ─────────────
 
   http.get('/api/brands/:slug/tax-configuration', () =>

--- a/src/frontend/src/types/common.ts
+++ b/src/frontend/src/types/common.ts
@@ -337,7 +337,13 @@ export interface ModifierGroupListItem {
 }
 
 /**
- * Modifier group assigned to a product, including its modifiers and sort order on the product.
+ * Modifier group assigned to a product, including its modifiers and sort order.
+ *
+ * NOTE: the admin assignment endpoint (`GET .../products/:id/modifier-groups`)
+ * returns ONLY `{ modifierGroupId, sortOrder }` — `name`/`modifiers` are absent
+ * there, and `ProductEdit` resolves them from the modifier-group list
+ * (useModifierGroups). The storefront/POS menu endpoints DO populate `name` +
+ * `modifiers`, so the fields stay required here for those (typed) consumers.
  */
 export interface ProductModifierGroupResponse {
   modifierGroupId: string;


### PR DESCRIPTION
## US-FP-018 — Place an in-store order (counter staff)

A touch-friendly POS interface for counter staff to take walk-in orders, reusing the existing Order pipeline end to end.

### Backend
- New **staff-authenticated** endpoint `POST /api/brands/{brandSlug}/shops/{shopId}/orders/in-store` (`Roles("CounterStaff")`), reusing `OrderService` via a shared `CreateOrderCoreAsync`. The public `POST .../orders` is unchanged and stays anonymous.
- Persists **`TableNumber`** (required for eat-in) and **`CreatedByStaffId`** (captured server-side from the auth token, never the request body) on the `Order` aggregate — EF mapping + BrandDb migration.
- Forces `CashAtPickup`; reuses the existing `OrderCreatedEvent → SignalR` fulfillment fan-out.

### Frontend (POS)
- Touch-first ordering under the staff-guarded `/pos`: menu grid, touch modifier modal, running-order panel with a **Pickup/EatIn** toggle + conditional **table number**, submit, and a minimal confirmation page.
- `CreateInStoreOrderRequest` + `ordersApi.createInStore`; `pos.*` i18n for NL/FR/DE.

### Fixes found while testing
- **`fix(modifier-groups)`** — `GET .../products/:id/modifier-groups` now returns each group's resolved **name + modifiers** (the frontend type already expected them); fixes the POS *and* storefront modifier modals + ProductEdit. Modals also guard against a missing array.
- **`fix(admin)`** — ProductEdit resolves modifier-group name/count from the group list (no longer crashes on the lean assignment shape).
- **`fix(seed)`** — seeded products are assigned to menu categories so the menu shows them grouped.
- **`feat(dev)`** — one-click "BFF login" button in the mock-auth dev toolbar (disabled for roles with no server persona).

### Integration with `main`
Rebased onto latest `main` and reconciled with **US-FP-027 (kitchen display)** and **US-FP-064 (allergen/dietary filters)**. The KDS we deferred from US-FP-018 is already on main; `OrderResponse.tableNumber` is now a real `number` and the kitchen card consumes it.

### Verification
- Backend — `dotnet build -c Release`: **0 errors**; **268** TUnit unit tests pass (re-run post-rebase); in-store flow also covered by Testcontainers integration tests.
- Frontend — `tsc`: clean; **291** Vitest tests across **57** files pass (re-run post-rebase).

### Follow-ups (out of scope)
- Role-gated **HTTP** backend test (Testing env uses JWT Bearer with no mock tokens; currently proven via anonymous→401 + the `Configure()` role declaration).
- Verify the staff-id **claim name** against the BFF in a running environment.
- Combos are submitted as a single order line (no per-component customisation).

> The `/workflows`-arm process writeup (how this was planned/built/reviewed) is in `OUTPUT_SUMMARY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)