### PR TITLE
feat: storefront shop selection (US-FP-071) + guest checkout contact fields (US-FP-017)

### DIFF
--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -1,7 +1,7 @@
 # User Story Dependency Tree & Progress Tracker
 
 > Generated from [frietjes-platform.md](./extract-prd/user-stories/frietjes-platform.md)
-> Last updated: 2026-04-09
+> Last updated: 2026-06-03 (statuses reconciled against GitHub issue acceptance criteria — see "Status Accuracy" below)
 
 ## Progress Legend
 
@@ -13,13 +13,39 @@
 
 ---
 
+## Status Accuracy & AC Verification (2026-06-03)
+
+> **Tracking caveat:** GitHub issues are *not* closed when work merges, and this tree had drifted. Statuses below were re-verified on 2026-06-03 by checking each open issue's **acceptance-criteria checklist** against the actual code (backend + frontend). Treat the issue tracker's open/closed state as unreliable on its own — verify against ACs.
+
+**⚠ Online-ordering journey has NO entry point (found 2026-06-03).** The storefront landing page (`Home.tsx`) is a stub — no shop list, no menu link. The menu only renders at `…/shops/{shopId}/menu` where `shopId` is a **database GUID**, and nothing in the storefront ever links there (only `CartDrawer`→`/checkout` and a checkout-empty redirect back). `shopId` is then carried through checkout/confirmation via `localStorage`/`sessionStorage` hacks (see the "For now" TODO in `OrderConfirmationPage.tsx`). **A real customer cannot reach the order flow.** Therefore **US-FP-016 / 038 / 058 / 063 are component-complete but NOT user-reachable** — downgraded from ✅ to 🚧; do NOT close their issues. Missing work: a storefront entry / shop-discovery page (list the brand's shops → link to menu), human-readable shop slugs instead of GUIDs, and `shopId` carried in the route rather than storage. **Now tracked as US-FP-071 (#127)** — a shop-selection page at `/{brand}/{lang}/shops` plus shop-slug-scoped storefront routes (`{shopSlug}/menu` → checkout/order), removing the localStorage shopId hack. This is the top-priority gap for the entire online channel.
+
+**Changed this session (2026-06-03):**
+- **US-FP-018** → ✅ done. Functionally complete; ticket-printer scope reclassified to US-FP-028. GitHub #18 closed.
+- **US-FP-017** → email + phone at checkout implemented and **build-verified** (working tree, uncommitted; migration `AddCustomerContactToOrder`). Its own ACs are now met, but it shares the entry-point blocker — stays 🚧 until US-FP-071 (#127) lands.
+
+**Partial (🚧) — specific remaining gaps:**
+- **US-FP-069** — per-endpoint RBAC not enforced (62 endpoints `AllowAnonymous`; roles only checked at the BFF proxy). ⚠ security hardening needed before production.
+- **US-FP-023** — keystone. SignalR/tracking plumbing all exists; missing only the status-advance endpoint + kitchen-card button (today just a dev-only Simulate endpoint).
+- **US-FP-024** — table-number capture + 21% VAT done; missing `Shop.IsEatInEnabled` gating + group-kitchen-cards-by-table.
+- **US-FP-037** — mock auth + BFF login work; customer self-registration not implemented.
+- **US-FP-039** — session timeout configurable; missing dynamic per-brand login UI, role-based redirect, failed-login errors.
+- **US-FP-055** — static manifest only; needs per-brand manifest (logo/colors/icons).
+- **US-FP-056** — app shell cached; needs menu-data caching + stale-data banner.
+- **US-FP-059** — order type + 6% VAT done; missing delivery address capture/storage + per-shop delivery fee.
+- **US-FP-060** — brand CRUD done; missing shop-count metrics + true platform-level dashboard.
+- **US-FP-067** — custom-domain field stored; missing DNS instructions, SSL provisioning, host→brand routing.
+
+**Everything else not marked ✅/🚧 below is not started** (33 stories).
+
+---
+
 ## Layer 0 — Foundation (sequential)
 
 These are prerequisites for everything else. Must be done in order.
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| ✅ | **US-FP-069** | REST API backbone (FastEndpoints, BFF, YARP) | — |
+| 🚧 | **US-FP-069** | REST API backbone (FastEndpoints, BFF, YARP) — ⚠ per-endpoint RBAC not enforced | — |
 | ✅ | **US-FP-061** | Platform admin accounts | — |
 | ✅ | **US-FP-001** | Create and manage brands | 069 |
 | ✅ | **US-FP-070** | Database-per-brand provisioning | 001 |
@@ -58,7 +84,7 @@ Once brands + shops exist, these streams are **independent of each other**.
 | ✅ | **US-FP-003** | Assign brand-level staff auth method | 001 |
 | 🚧 | **US-FP-037** | Customer registration and login | 001 |
 | ✅ | **US-FP-032** | Manage staff accounts | 001, 003 |
-| ⬜ | **US-FP-039** | Staff login with configured auth method | 003, 032 |
+| 🚧 | **US-FP-039** | Staff login with configured auth method | 003, 032 |
 
 **Notes:**
 - 003: Full-stack complete — domain, endpoint, frontend config UI with confirmation dialog and i18n
@@ -84,7 +110,7 @@ Once brands + shops exist, these streams are **independent of each other**.
 | ✅ | **US-FP-029** | Configure brand theming | 001 |
 | ✅ | **US-FP-030** | Provide translations for product catalog | 005 |
 | ✅ | **US-FP-031** | Select language on the storefront | 030 |
-| ⬜ | **US-FP-067** | Configure custom domain for brand | 029 |
+| 🚧 | **US-FP-067** | Configure custom domain for brand | 029 |
 
 > **Note:** 030 and 031 depend on products (Stream A), so they can start once 005 is done.
 
@@ -96,10 +122,11 @@ Once brands + shops exist, these streams are **independent of each other**.
 |--------|-------|-------------|------------|
 | ✅ | **US-FP-046** | Apply Belgian VAT rates | 022 |
 | ✅ | **US-FP-068** | Real-time updates (SignalR/SSE) | — (infra, can start in L1) |
-| ✅ | **US-FP-016** | Place an online order | 005, 006, 007, 014, 022, 046 |
-| ✅ | **US-FP-058** | Complete payment flow (mocked) | 016 |
-| ⬜ | **US-FP-017** | Place an order as a guest | 016 |
-| ⬜ | **US-FP-018** | Place an in-store order (POS) | 016 |
+| 🚧 | **US-FP-016** | Place an online order — ⚠ no storefront entry point (shop discovery missing) | 005, 006, 007, 014, 022, 046 |
+| 🚧 | **US-FP-071** | Shop selection + shop-scoped routes (`/shops` chooser → `{shopSlug}/menu` → checkout/order) — #127 — implemented on branch `feat/us-fp-071-shop-selection`; FE build verified, BE compiles (per review); runtime NOT yet verified | 002, 005 |
+| 🚧 | **US-FP-058** | Complete payment flow (mocked) — built but unreachable (blocked by 016 entry point) | 016 |
+| 🚧 | **US-FP-017** | Place an order as a guest | 016 |
+| ✅ | **US-FP-018** | Place an in-store order (POS) | 016 |
 
 ---
 
@@ -112,21 +139,21 @@ Once ordering works, these streams are **all independent**.
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
 | ✅ | **US-FP-027** | View order on kitchen display | 022, 068 |
-| ⬜ | **US-FP-023** | Update order status (kitchen) | 022, 027 |
-| ⬜ | **US-FP-028** | Print order ticket | 022 |
+| 🚧 | **US-FP-023** | Update order status (kitchen) | 022, 027 |
+| ⬜ | **US-FP-028** | Print order ticket (incl. in-store POS ticket, reclassified from US-FP-018) | 022 |
 | ⬜ | **US-FP-026** | Configure order notifications | 022 |
 
 ### Stream F: Customer Experience
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| ✅ | **US-FP-063** | Track current order status | 022, 068 |
+| 🚧 | **US-FP-063** | Track current order status — built but unreachable (blocked by 016 entry point) | 022, 068 |
 | ⬜ | **US-FP-062** | View order history | 016, 037 |
-| ⬜ | **US-FP-024** | Eat-in ordering with table number | 016, 066 |
+| 🚧 | **US-FP-024** | Eat-in ordering with table number | 016, 066 |
 | ⬜ | **US-FP-025** | QR code table ordering | 024, 065 |
 | ⬜ | **US-FP-019** | Select time slot at checkout | 016, 020 |
 | ✅ | **US-FP-064** | Browse menu with allergen/dietary filters | 008 |
-| ⬜ | **US-FP-059** | Place a delivery order (POC) | 016 |
+| 🚧 | **US-FP-059** | Place a delivery order (POC) | 016 |
 
 ### Stream G: Shop Product Management
 
@@ -177,8 +204,8 @@ Once ordering works, these streams are **all independent**.
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| ⬜ | **US-FP-055** | Install storefront as PWA | 029 |
-| ⬜ | **US-FP-056** | Offline caching of menu data | 055 |
+| 🚧 | **US-FP-055** | Install storefront as PWA | 029 |
+| 🚧 | **US-FP-056** | Offline caching of menu data | 055 |
 | ⬜ | **US-FP-057** | Push notifications for order status | 055, 063 |
 
 ### Stream M: Staff Scheduling
@@ -196,20 +223,20 @@ Once ordering works, these streams are **all independent**.
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| ⬜ | **US-FP-060** | Platform admin dashboard | 001, reporting |
+| 🚧 | **US-FP-060** | Platform admin dashboard | 001, reporting |
 | ⬜ | **US-FP-045** | View inventory signals | 012, 013 |
-| ⬜ | **US-FP-038** | Guest checkout (refinement) | 017 |
+| 🚧 | **US-FP-038** | Guest checkout (refinement) — built but unreachable (blocked by 016 entry point) | 017 |
 
 ---
 
 ## Visual Summary
 
 ```
-L0: [069✅] → [061✅] → [001✅] → [070✅] → [004✅] → [002✅]
+L0: [069🚧] → [061✅] → [001✅] → [070✅] → [004✅] → [002✅]
 
 L1: [A: Products✅]  [B: Auth/Staff🚧]  [C: Shop Config🚧]  [D: Branding✅]  ← 4 parallel
          │                │                  │
-L2: [046✅ VAT] [068✅ Realtime] → [016✅ Ordering] → [058/017/018]            ← ordering core
+L2: [046✅ VAT] [068✅ Realtime] → [016🚧 ⚠no entry point] → [058🚧 018✅ 017🚧]   ← ordering core
                                         │
 L3: [E: Kitchen] [F: Customer] [G: Shop Mgmt] [H: Loyalty] [I: Reports]      ← 5 parallel
          │            │

--- a/docs/extract-prd/user-stories/frietjes-platform.md
+++ b/docs/extract-prd/user-stories/frietjes-platform.md
@@ -1003,3 +1003,21 @@ This document contains the complete set of user stories for the Frietjes Platfor
 - [ ] Database schema migrations are applied to all brand databases consistently
 
 ---
+
+### US-FP-071: Storefront landing & shop selection
+**As a** Customer (guest or registered), **I want** to arrive on a brand's storefront and find or select a shop, **so that** I can reach a shop's menu and order without already knowing a shop's URL.
+
+**Priority:** Must Have
+
+**Acceptance Criteria:**
+- [ ] `/{brandSlug}/{lang}/shops` lists the brand's active shops (name, address, open/closed status) to choose from; the landing (`/{brandSlug}/{lang}`) routes here
+- [ ] Shops have a unique, brand-scoped slug (backend), plus a public endpoint to list a brand's active shops and resolve a shop by slug
+- [ ] Selecting a shop navigates to `/{brandSlug}/{lang}/{shopSlug}/menu`; the order flow is nested under the shop slug (`…/{shopSlug}/checkout`, `…/{shopSlug}/order/{orderId}`, `…/{shopSlug}/order/{orderId}/track`)
+- [ ] Shop context is read from the route slug — the localStorage/sessionStorage shopId-recovery hacks are removed
+- [ ] If the brand has exactly one active shop, the customer can be taken straight to its menu
+- [ ] Closed / inactive shops are clearly indicated and cannot start an order
+- [ ] Deep links to `…/{shopSlug}/menu` work directly
+
+> Added 2026-06-03 (GitHub issue #127). Shop selection + shop-scoped routing; closes the storefront entry-point gap blocking US-FP-016 / 017 / 038 / 058 / 063 from being user-reachable.
+
+---

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
@@ -15,7 +15,9 @@ public sealed record CreateOrderApiRequest(
     string OrderType,
     string PaymentMethod,
     string? CustomerName,
-    List<OrderItemApiInput> Items);
+    List<OrderItemApiInput> Items,
+    string? CustomerEmail = null,
+    string? CustomerPhone = null);
 
 public sealed class CreateOrderRequestValidator : Validator<CreateOrderApiRequest>
 {
@@ -47,6 +49,15 @@ public sealed class CreateOrderRequestValidator : Validator<CreateOrderApiReques
         RuleFor(x => x.CustomerName)
             .MaximumLength(200)
             .When(x => x.CustomerName is not null);
+
+        RuleFor(x => x.CustomerEmail)
+            .EmailAddress().WithMessage("CustomerEmail must be a valid email address.")
+            .MaximumLength(320).WithMessage("CustomerEmail must not exceed 320 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CustomerEmail));
+
+        RuleFor(x => x.CustomerPhone)
+            .MaximumLength(32).WithMessage("CustomerPhone must not exceed 32 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CustomerPhone));
     }
 }
 
@@ -89,7 +100,9 @@ public sealed class CreateOrderEndpoint(IOrderService orderService)
                         i.Quantity,
                         (i.SelectedModifierIds ?? []).AsReadOnly()))
                     .ToList()
-                    .AsReadOnly());
+                    .AsReadOnly(),
+                req.CustomerEmail,
+                req.CustomerPhone);
 
             var response = await orderService.CreateOrderAsync(appRequest, ct);
 

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
@@ -43,5 +43,7 @@ internal static class OrderTrackingMapper
             order.TotalGross,
             order.CreatedAt,
             order.TableNumber,
-            order.CreatedByStaffId);
+            order.CreatedByStaffId,
+            order.CustomerEmail,
+            order.CustomerPhone);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/ListActiveShopsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/ListActiveShopsEndpoint.cs
@@ -1,0 +1,40 @@
+using FastEndpoints;
+using TheMillionthFoodOrderApp.Application.Shops;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Shops;
+
+public sealed record ListActiveShopsRequest([property: RouteParam] string BrandSlug);
+
+/// <summary>
+/// Public storefront endpoint — lists only active shops for a brand,
+/// enriched with real-time open/closed status.
+/// The frontend uses the returned <c>slug</c> field to resolve a shop URL
+/// and the <c>id</c> field when placing orders.
+/// </summary>
+public sealed class ListActiveShopsEndpoint(IShopService shopService)
+    : Endpoint<ListActiveShopsRequest, IReadOnlyList<StorefrontShopResponse>>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/active";
+
+    public override void Configure()
+    {
+        Get(Route);
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<ListActiveShopsRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "List active shops for the storefront";
+            s.Description =
+                "Returns all active shops belonging to the brand, ordered by name, " +
+                "with real-time open/closed status. " +
+                "Use the shop slug for customer-facing URLs; use the shop id when placing orders.";
+            s.Response<IReadOnlyList<StorefrontShopResponse>>(200, "List of active shops with open/closed status.");
+        });
+    }
+
+    public override async Task HandleAsync(ListActiveShopsRequest req, CancellationToken ct)
+    {
+        var response = await shopService.GetActiveShopsAsync(ct);
+        await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/CreateOrderRequest.cs
@@ -9,4 +9,6 @@ public sealed record CreateOrderRequest(
     string OrderType,
     string PaymentMethod,
     string? CustomerName,
-    IReadOnlyList<OrderItemInput> Items);
+    IReadOnlyList<OrderItemInput> Items,
+    string? CustomerEmail = null,
+    string? CustomerPhone = null);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
@@ -45,4 +45,8 @@ public sealed record OrderResponse(
     /// <summary>Table number for eat-in in-store orders; null for online/pickup/delivery orders.</summary>
     int? TableNumber = null,
     /// <summary>Counter staff ID extracted server-side from JWT claims; null for customer-facing orders.</summary>
-    Guid? CreatedByStaffId = null);
+    Guid? CreatedByStaffId = null,
+    /// <summary>Optional customer email address for digital receipts (US-FP-017).</summary>
+    string? CustomerEmail = null,
+    /// <summary>Optional customer phone number (US-FP-017).</summary>
+    string? CustomerPhone = null);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -49,7 +49,9 @@ public sealed class OrderService(
             tableNumber: null,
             createdByStaffId: null,
             request.Items,
-            cancellationToken);
+            cancellationToken,
+            request.CustomerEmail,
+            request.CustomerPhone);
     }
 
     public async Task<OrderResponse> CreateInStoreOrderAsync(
@@ -113,7 +115,9 @@ public sealed class OrderService(
         int? tableNumber,
         Guid? createdByStaffId,
         IReadOnlyList<OrderItemInput> items,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? customerEmail = null,
+        string? customerPhone = null)
     {
         // 1. Determine consumption mode for VAT calculation
         var consumptionMode = orderType == OrderType.EatIn
@@ -245,7 +249,9 @@ public sealed class OrderService(
                 vatRate,
                 orderItems,
                 tableNumber,
-                createdByStaffId);
+                createdByStaffId,
+                customerEmail,
+                customerPhone);
 
             try
             {
@@ -324,5 +330,7 @@ public sealed class OrderService(
             order.TotalGross,
             order.CreatedAt,
             order.TableNumber,
-            order.CreatedByStaffId);
+            order.CreatedByStaffId,
+            order.CustomerEmail,
+            order.CustomerPhone);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -51,7 +51,8 @@ public sealed class OrderService(
             request.Items,
             cancellationToken,
             request.CustomerEmail,
-            request.CustomerPhone);
+            request.CustomerPhone,
+            enforceOpeningHours: true);
     }
 
     public async Task<OrderResponse> CreateInStoreOrderAsync(
@@ -117,7 +118,8 @@ public sealed class OrderService(
         IReadOnlyList<OrderItemInput> items,
         CancellationToken cancellationToken,
         string? customerEmail = null,
-        string? customerPhone = null)
+        string? customerPhone = null,
+        bool enforceOpeningHours = false)
     {
         // 1. Determine consumption mode for VAT calculation
         var consumptionMode = orderType == OrderType.EatIn
@@ -134,6 +136,12 @@ public sealed class OrderService(
         var shop = await shopRepository.GetByIdAsync(shopId, cancellationToken);
         if (shop is null)
             throw new KeyNotFoundException($"Shop with id '{shopId}' was not found.");
+
+        // 3b. Online customer orders are rejected when the shop is currently closed (US-FP-071 / #127).
+        //     In-store staff orders are exempt — staff are physically present at the counter.
+        if (enforceOpeningHours && !shop.IsOpenAt(DateTimeOffset.UtcNow))
+            throw new InvalidOperationException(
+                "This shop is currently closed and is not accepting online orders.");
 
         // 4. Load order lifecycle config to determine opening status (lazy-init default if missing)
         var lifecycleConfig = await orderLifecycleConfigRepository.GetByShopIdAsync(shopId, cancellationToken);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/IShopService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/IShopService.cs
@@ -8,4 +8,10 @@ public interface IShopService
     Task ActivateShopAsync(Guid id, CancellationToken cancellationToken = default);
     Task<ShopResponse> GetShopAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<ShopResponse>> GetShopsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns only active shops, enriched with real-time open/closed status.
+    /// Intended for the public storefront — does not expose admin-only fields.
+    /// </summary>
+    Task<IReadOnlyList<StorefrontShopResponse>> GetActiveShopsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
@@ -37,3 +37,14 @@ public sealed record ShopResponse(
     bool IsActive,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);
+
+/// <summary>
+/// Lightweight shop summary returned by the public storefront endpoint.
+/// Only active shops are included; <see cref="IsOpen"/> reflects real-time status.
+/// </summary>
+public sealed record StorefrontShopResponse(
+    Guid Id,
+    string Name,
+    string Slug,
+    AddressResponse Address,
+    bool IsOpen);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
@@ -70,6 +70,13 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
         return shops.Select(MapToResponse).ToList().AsReadOnly();
     }
 
+    public async Task<IReadOnlyList<StorefrontShopResponse>> GetActiveShopsAsync(CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shops = await shopRepository.GetActiveAsync(cancellationToken);
+        return shops.Select(s => MapToStorefrontResponse(s, now)).ToList().AsReadOnly();
+    }
+
     // ── Private helpers ──────────────────────────────────────────────────────
 
     private static Address MapToAddress(AddressRequest req) =>
@@ -91,4 +98,17 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
             shop.IsActive,
             shop.CreatedAt,
             shop.UpdatedAt);
+
+    private static StorefrontShopResponse MapToStorefrontResponse(Shop shop, DateTimeOffset now) =>
+        new(
+            shop.Id,
+            shop.Name,
+            shop.Slug,
+            new AddressResponse(
+                shop.Address.Street,
+                shop.Address.Number,
+                shop.Address.City,
+                shop.Address.PostalCode,
+                shop.Address.Country),
+            shop.IsOpenAt(now));
 }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
@@ -24,6 +24,12 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
     /// <summary>Optional customer name for display on kitchen displays and receipts.</summary>
     public string? CustomerName { get; private set; }
 
+    /// <summary>Optional customer email address for digital receipts (US-FP-017).</summary>
+    public string? CustomerEmail { get; private set; }
+
+    /// <summary>Optional customer phone number (US-FP-017).</summary>
+    public string? CustomerPhone { get; private set; }
+
     /// <summary>
     /// Table number for eat-in orders placed by counter staff.
     /// Null for online/pickup/delivery orders.
@@ -87,7 +93,9 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
         decimal vatRatePercent,
         IEnumerable<OrderItem> items,
         int? tableNumber = null,
-        Guid? createdByStaffId = null)
+        Guid? createdByStaffId = null,
+        string? customerEmail = null,
+        string? customerPhone = null)
     {
         if (tableNumber.HasValue && tableNumber.Value <= 0)
             throw new ArgumentException("TableNumber must be greater than zero when provided.", nameof(tableNumber));
@@ -112,6 +120,8 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
             PaymentMethod = paymentMethod,
             StatusName = statusName,
             CustomerName = customerName,
+            CustomerEmail = string.IsNullOrWhiteSpace(customerEmail) ? null : customerEmail.Trim(),
+            CustomerPhone = string.IsNullOrWhiteSpace(customerPhone) ? null : customerPhone.Trim(),
             TableNumber = tableNumber,
             CreatedByStaffId = createdByStaffId,
             VatRatePercent = vatRatePercent,

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Shops/IShopRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Shops/IShopRepository.cs
@@ -5,6 +5,10 @@ public interface IShopRepository
     Task<Shop?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<Shop?> GetBySlugAsync(string slug, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Shop>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Returns only active shops, ordered by name, with opening hours included.</summary>
+    Task<IReadOnlyList<Shop>> GetActiveAsync(CancellationToken cancellationToken = default);
+
     Task AddAsync(Shop shop, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
@@ -38,6 +38,12 @@ public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.Property(o => o.CustomerName)
             .HasMaxLength(200);
 
+        builder.Property(o => o.CustomerEmail)
+            .HasMaxLength(320);
+
+        builder.Property(o => o.CustomerPhone)
+            .HasMaxLength(32);
+
         builder.Property(o => o.VatRatePercent)
             .HasColumnType("decimal(5,2)")
             .IsRequired();

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260603080827_AddCustomerContactToOrder.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260603080827_AddCustomerContactToOrder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603080827_AddCustomerContactToOrder")]
+    partial class AddCustomerContactToOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260603080827_AddCustomerContactToOrder.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260603080827_AddCustomerContactToOrder.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddCustomerContactToOrder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerEmail",
+                table: "Orders",
+                type: "nvarchar(320)",
+                maxLength: 320,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerPhone",
+                table: "Orders",
+                type: "nvarchar(32)",
+                maxLength: 32,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CustomerEmail",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "CustomerPhone",
+                table: "Orders");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
@@ -30,6 +30,7 @@ public sealed class BrandDbSeeder(
         var categories = await SeedMenuCategoriesAsync(context, cancellationToken);
         await SeedProductsAsync(context, categories, cancellationToken);
         await context.SaveChangesAsync(cancellationToken);
+        await SeedOpeningHoursAsync(context, cancellationToken);
         await SeedModifierGroupsAsync(context, cancellationToken);
         await SeedOrderLifecycleConfigsAsync(context, cancellationToken);
         await SeedTaxConfigurationAsync(context, cancellationToken);
@@ -117,6 +118,42 @@ public sealed class BrandDbSeeder(
             await context.Shops.AddAsync(shop, cancellationToken);
             logger.LogInformation("Seed: Created shop '{Name}' (slug: {Slug}).", shop.Name, shop.Slug);
         }
+    }
+
+    private async Task SeedOpeningHoursAsync(
+        BrandDbContext context,
+        CancellationToken cancellationToken)
+    {
+        // Default dev/demo schedule: open every day 11:00-23:00 (shop-local time, Europe/Brussels).
+        // Idempotent — only applied to shops with no opening hours yet, so it also backfills shops
+        // seeded before opening hours existed, without clobbering any configured schedule.
+        var shops = await context.Shops
+            .Include(s => s.OpeningHours)
+            .ToListAsync(cancellationToken);
+
+        var openTime = new TimeOnly(11, 0);
+        var closeTime = new TimeOnly(23, 0);
+        var changed = false;
+
+        foreach (var shop in shops)
+        {
+            if (shop.OpeningHours.Count > 0)
+                continue;
+
+            var blocks = Enum.GetValues<DayOfWeek>()
+                .Select(day => OpeningHoursTimeBlock.Create(shop.Id, day, openTime, closeTime))
+                .ToList();
+
+            shop.SetOpeningHours(blocks);
+            await context.OpeningHoursTimeBlocks.AddRangeAsync(blocks, cancellationToken);
+            changed = true;
+
+            logger.LogInformation(
+                "Seed: Set default opening hours (11:00-23:00 daily) for shop '{Slug}'.", shop.Slug);
+        }
+
+        if (changed)
+            await context.SaveChangesAsync(cancellationToken);
     }
 
     private async Task<IReadOnlyList<MenuCategory>> SeedMenuCategoriesAsync(

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopRepository.cs
@@ -31,6 +31,14 @@ public sealed class ShopRepository(BrandDbContext dbContext, IMessageBus message
             .ToListAsync(cancellationToken);
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyList<Shop>> GetActiveAsync(CancellationToken cancellationToken = default)
+        => await dbContext.Shops
+            .Include(s => s.OpeningHours)
+            .Where(s => s.IsActive)
+            .OrderBy(s => s.Name)
+            .ToListAsync(cancellationToken);
+
+    /// <inheritdoc/>
     public async Task AddAsync(Shop shop, CancellationToken cancellationToken = default)
         => await dbContext.Shops.AddAsync(shop, cancellationToken);
 

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetOrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetOrderTests.cs
@@ -85,6 +85,17 @@ public sealed class GetOrderTests(IntegrationTestBase fixture)
         // Trigger default lifecycle creation (lazy-initialised on first GET)
         await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
 
+        // US-FP-071: online orders require an open shop — give it an always-open schedule.
+        var openingHours = new
+        {
+            TimeBlocks = Enumerable.Range(0, 7)
+                .Select(day => new { DayOfWeek = day, OpenTime = "00:00", CloseTime = "23:59" })
+                .ToArray()
+        };
+        var hoursResponse = await client.PutAsJsonAsync(
+            $"/api/brands/{brandSlug}/shops/{shop.Id}/opening-hours", openingHours);
+        await Assert.That(hoursResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
         return shop.Id;
     }
 
@@ -109,6 +120,7 @@ public sealed class GetOrderTests(IntegrationTestBase fixture)
         var request = new
         {
             OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
             CustomerName = "Tracking Tester",
             Items = new[]
             {

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/ListActiveOrdersTests.cs
@@ -61,6 +61,17 @@ public sealed class ListActiveOrdersTests(IntegrationTestBase fixture)
         // Trigger default lifecycle creation (lazy-initialised on first GET)
         await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
 
+        // US-FP-071: online orders require an open shop — give it an always-open schedule.
+        var openingHours = new
+        {
+            TimeBlocks = Enumerable.Range(0, 7)
+                .Select(day => new { DayOfWeek = day, OpenTime = "00:00", CloseTime = "23:59" })
+                .ToArray()
+        };
+        var hoursResponse = await client.PutAsJsonAsync(
+            $"/api/brands/{brandSlug}/shops/{shop.Id}/opening-hours", openingHours);
+        await Assert.That(hoursResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
         return shop.Id;
     }
 

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
@@ -40,8 +40,12 @@ public sealed class PlaceOrderTests(IntegrationTestBase fixture)
 
     // ── Setup helpers ─────────────────────────────────────────────────────────
 
-    /// <summary>Creates a shop and triggers order lifecycle initialisation.</summary>
-    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    /// <summary>
+    /// Creates a shop and triggers order lifecycle initialisation.
+    /// By default the shop is given an always-open weekly schedule so it accepts online
+    /// orders (US-FP-071). Pass <paramref name="open"/> = false to leave it closed.
+    /// </summary>
+    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug, bool open = true)
     {
         var request = new
         {
@@ -68,7 +72,24 @@ public sealed class PlaceOrderTests(IntegrationTestBase fixture)
         // Trigger default lifecycle creation (lazy-initialised on first GET)
         await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
 
+        if (open)
+            await SetAlwaysOpenAsync(client, brandSlug, shop.Id);
+
         return shop.Id;
+    }
+
+    /// <summary>Sets an always-open weekly schedule (00:00–23:59 every day) so the shop accepts online orders.</summary>
+    private async Task SetAlwaysOpenAsync(HttpClient client, string brandSlug, Guid shopId)
+    {
+        var request = new
+        {
+            TimeBlocks = Enumerable.Range(0, 7)
+                .Select(day => new { DayOfWeek = day, OpenTime = "00:00", CloseTime = "23:59" })
+                .ToArray()
+        };
+        var response = await client.PutAsJsonAsync(
+            $"/api/brands/{brandSlug}/shops/{shopId}/opening-hours", request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
 
     /// <summary>Creates a simple product and returns its ID and gross price.</summary>
@@ -90,6 +111,34 @@ public sealed class PlaceOrderTests(IntegrationTestBase fixture)
         var product = await response.Content.ReadFromJsonAsync<ProductResponse>();
         await Assert.That(product).IsNotNull();
         return (product!.Id, product.BasePrice.Amount);
+    }
+
+    // ── Closed shop — online orders rejected (US-FP-071 / #127) ───────────────
+
+    [Test]
+    public async Task PlaceOrder_WhenShopClosed_Returns400()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        // A shop with no opening hours is always closed.
+        var shopId = await CreateShopAsync(client, brand, open: false);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 3.50m, name: "Closed Shop Frietje");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = "Too Early",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
     }
 
     // ── Happy path — Pickup (6% VAT) ─────────────────────────────────────────

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTests.cs
@@ -613,4 +613,99 @@ public sealed class PlaceOrderTests(IntegrationTestBase fixture)
         await Assert.That(order).IsNotNull();
         await Assert.That(order!.PaymentMethod).IsEqualTo("CreditCard");
     }
+
+    // ── Guest contact fields (US-FP-017) ─────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_WithEmailAndPhone_PersistsAndReturnsContactFields()
+    {
+        // Verifies that optional CustomerEmail and CustomerPhone are stored and returned.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.50m, name: "Friet met email");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = "Lieselot Pieters",
+            CustomerEmail = "lieselot@example.com",
+            CustomerPhone = "+32 478 12 34 56",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.CustomerName).IsEqualTo("Lieselot Pieters");
+        await Assert.That(order.CustomerEmail).IsEqualTo("lieselot@example.com");
+        await Assert.That(order.CustomerPhone).IsEqualTo("+32 478 12 34 56");
+    }
+
+    [Test]
+    public async Task PlaceOrder_WithoutEmailAndPhone_StillSucceeds()
+    {
+        // Regression: ensures that omitting email and phone does not break order placement.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 3.00m, name: "Friet zonder contact");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            // CustomerEmail and CustomerPhone intentionally omitted
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.CustomerEmail).IsNull();
+        await Assert.That(order.CustomerPhone).IsNull();
+    }
+
+    [Test]
+    public async Task PlaceOrder_WithInvalidEmail_Returns400()
+    {
+        // Verifies that a malformed email address is rejected by the FluentValidation rule.
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        var (productId, _) = await CreateProductAsync(client, brand, price: 2.00m, name: "Friet ongeldig email");
+
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = (string?)null,
+            CustomerEmail = "not-a-valid-email",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
 }

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -17,6 +17,8 @@ export type PaymentMethod = 'CashAtPickup' | 'CreditCard' | 'Bancontact';
 export interface CreateOrderRequest {
   orderType: OrderType;
   customerName?: string | null;
+  customerEmail?: string | null;
+  customerPhone?: string | null;
   items: OrderItemRequest[];
   paymentMethod: PaymentMethod;
 }
@@ -50,6 +52,10 @@ export interface OrderResponse {
   orderType: OrderType;
   statusName: string;
   customerName: string | null;
+  /** Optional email for digital receipt (US-FP-017). */
+  customerEmail?: string | null;
+  /** Optional phone number (US-FP-017). */
+  customerPhone?: string | null;
   items: OrderItemResponse[];
   vatRatePercent: number;
   subtotalGross: number;

--- a/src/frontend/src/api/shops.ts
+++ b/src/frontend/src/api/shops.ts
@@ -1,5 +1,21 @@
 import { apiClient } from './client';
-import type { Shop } from '../types/common';
+import type { Shop, ShopAddress } from '../types/common';
+
+// ---------------------------------------------------------------------------
+// Storefront-only shop DTO (returned by GET /brands/:brandSlug/shops/active)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lightweight shop response used by the storefront chooser.
+ * Mirrors the backend StorefrontShopResponse DTO.
+ */
+export interface StorefrontShop {
+  id: string;
+  name: string;
+  slug: string;
+  address: ShopAddress;
+  isOpen: boolean;
+}
 
 export interface CreateShopRequest {
   name: string;
@@ -55,4 +71,14 @@ export const shopsApi = {
     apiClient
       .post<void>(`/brands/${brandSlug}/shops/${id}/activate`)
       .then(() => undefined),
+
+  /**
+   * Lists all active shops for a brand, including real-time isOpen status.
+   * Used by the storefront shop chooser (US-FP-071).
+   * Endpoint: GET /api/brands/:brandSlug/shops/active
+   */
+  listActive: (brandSlug: string): Promise<StorefrontShop[]> =>
+    apiClient
+      .get<StorefrontShop[]>(`/brands/${brandSlug}/shops/active`)
+      .then((r) => r.data),
 };

--- a/src/frontend/src/features/storefront/__tests__/ShopChooserPage.test.tsx
+++ b/src/frontend/src/features/storefront/__tests__/ShopChooserPage.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for ShopChooserPage (US-FP-071):
+ * - renders shop cards
+ * - auto-redirects when exactly one shop is active
+ * - shows empty state when no shops
+ */
+import { beforeAll, describe, it, expect, vi, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import i18next from 'i18next';
+import '../../../i18n/config';
+import type { StorefrontShop } from '@api/shops';
+
+// ---------------------------------------------------------------------------
+// Mock useActiveShops at the module level
+// ---------------------------------------------------------------------------
+
+vi.mock('../hooks/useActiveShops', () => ({
+  useActiveShops: vi.fn(),
+}));
+
+// Import after mock registration
+// eslint-disable-next-line import/first
+import { useActiveShops } from '../hooks/useActiveShops';
+// eslint-disable-next-line import/first
+import { ShopChooserPage } from '../pages/ShopChooserPage';
+
+// ---------------------------------------------------------------------------
+// i18n bootstrap
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await i18next.changeLanguage('nl');
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeShop(overrides: Partial<StorefrontShop> = {}): StorefrontShop {
+  return {
+    id: 'shop-1',
+    name: 'Frietjes Gent',
+    slug: 'gent',
+    address: {
+      street: 'Korenmarkt',
+      number: '1',
+      city: 'Gent',
+      postalCode: '9000',
+      country: 'BE',
+    },
+    isOpen: true,
+    ...overrides,
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+interface WrapperOptions {
+  shops?: StorefrontShop[];
+  loading?: boolean;
+  error?: boolean;
+}
+
+function renderChooser(options: WrapperOptions = {}) {
+  const { shops = [], loading = false, error = false } = options;
+
+  (useActiveShops as Mock).mockReturnValue({
+    data: shops,
+    isLoading: loading,
+    isError: error,
+  });
+
+  const queryClient = makeQueryClient();
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/frietjes/nl/shops']}>
+        <Routes>
+          <Route path="/:brandSlug/:lang/shops" element={<ShopChooserPage />} />
+          <Route path="/:brandSlug/:lang/:shopSlug/menu" element={<div>MenuPage</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ShopChooserPage', () => {
+  it('shows loading state while fetching', () => {
+    renderChooser({ loading: true });
+    expect(screen.getByText(i18next.t('loading'))).toBeInTheDocument();
+  });
+
+  it('shows error state on fetch failure', () => {
+    renderChooser({ error: true });
+    expect(screen.getByText(i18next.t('error'))).toBeInTheDocument();
+  });
+
+  it('shows empty state when no shops are available', () => {
+    renderChooser({ shops: [] });
+    expect(screen.getByText(i18next.t('storefront.shopChooser.noShops'))).toBeInTheDocument();
+  });
+
+  it('renders a card for each shop when multiple shops exist', () => {
+    const shops = [
+      makeShop({ id: 'shop-1', name: 'Frietjes Gent', slug: 'gent' }),
+      makeShop({ id: 'shop-2', name: 'Frietjes Brugge', slug: 'brugge' }),
+    ];
+    renderChooser({ shops });
+    expect(screen.getByText('Frietjes Gent')).toBeInTheDocument();
+    expect(screen.getByText('Frietjes Brugge')).toBeInTheDocument();
+  });
+
+  it('renders the shop address in each card', () => {
+    // Single shop with a known address — also tests that auto-redirect resolves the address
+    // by checking the chooser renders it (two-shop scenario avoids redirect interference)
+    const shops = [
+      makeShop({ id: 'shop-1', slug: 'gent' }),
+      makeShop({
+        id: 'shop-2',
+        slug: 'brugge',
+        name: 'Frietjes Brugge',
+        address: {
+          street: 'Markt',
+          number: '10',
+          city: 'Brugge',
+          postalCode: '8000',
+          country: 'BE',
+        },
+      }),
+    ];
+    renderChooser({ shops });
+    // Both addresses should appear
+    expect(screen.getByText(/Korenmarkt 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Markt 10/)).toBeInTheDocument();
+  });
+
+  it('auto-redirects to menu when exactly one shop is active', () => {
+    const shops = [makeShop({ slug: 'gent' })];
+    renderChooser({ shops });
+    // Should render the MenuPage stub after the redirect
+    expect(screen.getByText('MenuPage')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/storefront/__tests__/ShopResolver.test.tsx
+++ b/src/frontend/src/features/storefront/__tests__/ShopResolver.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for ShopResolver (US-FP-071):
+ * - resolves :shopSlug to a shop and provides it via context
+ * - redirects to shop chooser when slug is not found
+ * - shows loading / error states
+ */
+import { beforeAll, describe, it, expect, vi, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import i18next from 'i18next';
+import '../../../i18n/config';
+import type { StorefrontShop } from '@api/shops';
+
+// ---------------------------------------------------------------------------
+// Mock useActiveShops at the module level so imports see the mocked version
+// ---------------------------------------------------------------------------
+
+vi.mock('../hooks/useActiveShops', () => ({
+  useActiveShops: vi.fn(),
+}));
+
+// We need to import AFTER the mock is registered
+// eslint-disable-next-line import/first
+import { useActiveShops } from '../hooks/useActiveShops';
+// eslint-disable-next-line import/first
+import { ShopResolver } from '../context/ShopContext';
+// eslint-disable-next-line import/first
+import { useResolvedShop } from '../hooks/useResolvedShop';
+
+// ---------------------------------------------------------------------------
+// i18n bootstrap
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await i18next.changeLanguage('nl');
+});
+
+// ---------------------------------------------------------------------------
+// Test child that reads from ShopContext
+// ---------------------------------------------------------------------------
+
+function ShopInfo() {
+  const shop = useResolvedShop();
+  return (
+    <div>
+      <span data-testid="shop-id">{shop.id}</span>
+      <span data-testid="shop-name">{shop.name}</span>
+      <span data-testid="shop-slug">{shop.slug}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeShop(overrides: Partial<StorefrontShop> = {}): StorefrontShop {
+  return {
+    id: 'shop-1',
+    name: 'Frietjes Gent',
+    slug: 'gent',
+    address: {
+      street: 'Korenmarkt',
+      number: '1',
+      city: 'Gent',
+      postalCode: '9000',
+      country: 'BE',
+    },
+    isOpen: true,
+    ...overrides,
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+interface WrapperOptions {
+  shops?: StorefrontShop[];
+  loading?: boolean;
+  error?: boolean;
+  initialPath?: string;
+}
+
+function renderResolver(options: WrapperOptions = {}) {
+  const { shops = [], loading = false, error = false, initialPath = '/frietjes/nl/gent' } = options;
+
+  (useActiveShops as Mock).mockReturnValue({
+    data: shops,
+    isLoading: loading,
+    isError: error,
+  });
+
+  const queryClient = makeQueryClient();
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/:brandSlug/:lang/:shopSlug" element={<ShopResolver />}>
+            <Route index element={<ShopInfo />} />
+          </Route>
+          <Route path="/:brandSlug/:lang/shops" element={<div>ShopChooser</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ShopResolver', () => {
+  it('shows loading state while fetching shops', () => {
+    renderResolver({ loading: true });
+    expect(screen.getByText(i18next.t('loading'))).toBeInTheDocument();
+  });
+
+  it('shows error state when the fetch fails', () => {
+    renderResolver({ error: true });
+    expect(screen.getByText(i18next.t('error'))).toBeInTheDocument();
+  });
+
+  it('redirects to shop chooser when slug is not found', () => {
+    // shops list does not contain 'gent'
+    renderResolver({ shops: [makeShop({ slug: 'brugge' })], initialPath: '/frietjes/nl/gent' });
+    expect(screen.getByText('ShopChooser')).toBeInTheDocument();
+  });
+
+  it('provides resolved shop to children when slug matches', () => {
+    renderResolver({
+      shops: [makeShop({ id: 'shop-42', slug: 'gent', name: 'Frietjes Gent' })],
+      initialPath: '/frietjes/nl/gent',
+    });
+    expect(screen.getByTestId('shop-id')).toHaveTextContent('shop-42');
+    expect(screen.getByTestId('shop-name')).toHaveTextContent('Frietjes Gent');
+    expect(screen.getByTestId('shop-slug')).toHaveTextContent('gent');
+  });
+
+  it('matches slug case-sensitively', () => {
+    // 'Gent' !== 'gent' — should not match and redirect to chooser
+    renderResolver({
+      shops: [makeShop({ slug: 'Gent' })],
+      initialPath: '/frietjes/nl/gent',
+    });
+    expect(screen.getByText('ShopChooser')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/storefront/components/CartDrawer.tsx
+++ b/src/frontend/src/features/storefront/components/CartDrawer.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useCart, type CartItem } from '../context/CartContext';
+import { useResolvedShop } from '../hooks/useResolvedShop';
 
 interface CartDrawerProps {
   isOpen: boolean;
@@ -16,10 +17,12 @@ export function CartDrawer({ isOpen, onClose }: CartDrawerProps) {
   const { brandSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
   const navigate = useNavigate();
   const { state, updateQuantity, removeItem, cartTotal, cartItemCount, getModifierKey } = useCart();
+  // shopSlug comes from the ShopResolver layout route above MenuPage
+  const shop = useResolvedShop();
 
   function handleGoToCheckout() {
     onClose();
-    void navigate(`/${brandSlug}/${lang}/checkout`);
+    void navigate(`/${brandSlug}/${lang}/${shop.slug}/checkout`);
   }
 
   function formatCurrency(amount: number): string {

--- a/src/frontend/src/features/storefront/context/ShopContext.tsx
+++ b/src/frontend/src/features/storefront/context/ShopContext.tsx
@@ -1,0 +1,69 @@
+import { useParams, Outlet, Navigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useActiveShops } from '../hooks/useActiveShops';
+import { ShopContext } from './shopContextValue';
+import type { ResolvedShop } from './shopContextValue';
+
+// Re-export the type so callers can import from a single place
+export type { ResolvedShop };
+export { ShopContext };
+
+// ---------------------------------------------------------------------------
+// ShopResolver — layout route component
+// ---------------------------------------------------------------------------
+
+/**
+ * Layout route that resolves :shopSlug to a full shop object once.
+ * Renders an <Outlet /> for children once the shop is found.
+ *
+ * - Shows a loading state while the shops list is fetching.
+ * - Redirects to /shops if the slug cannot be matched (shop deactivated etc).
+ */
+export function ShopResolver() {
+  const { brandSlug, lang, shopSlug } = useParams<{
+    brandSlug: string;
+    lang: string;
+    shopSlug: string;
+  }>();
+
+  const { t } = useTranslation('common');
+  const resolvedBrandSlug = brandSlug ?? '';
+  const resolvedLang = lang ?? 'nl';
+  const { data: shops, isLoading, isError } = useActiveShops(resolvedBrandSlug);
+
+  if (isLoading) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#6b7280' }}>{t('loading')}</p>
+      </main>
+    );
+  }
+
+  if (isError) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#ef4444' }}>{t('error')}</p>
+      </main>
+    );
+  }
+
+  const shop = shops?.find((s) => s.slug === shopSlug);
+
+  if (!shop) {
+    // Slug not found — redirect back to shop chooser
+    return <Navigate to={`/${resolvedBrandSlug}/${resolvedLang}/shops`} replace />;
+  }
+
+  const resolved: ResolvedShop = {
+    id: shop.id,
+    name: shop.name,
+    slug: shop.slug,
+    isOpen: shop.isOpen,
+  };
+
+  return (
+    <ShopContext.Provider value={resolved}>
+      <Outlet />
+    </ShopContext.Provider>
+  );
+}

--- a/src/frontend/src/features/storefront/context/shopContextValue.ts
+++ b/src/frontend/src/features/storefront/context/shopContextValue.ts
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+
+// ---------------------------------------------------------------------------
+// ResolvedShop type and context
+// ---------------------------------------------------------------------------
+
+/**
+ * The resolved shop available to all children of a :shopSlug route.
+ * Provides the stable id needed for API calls and the cart.
+ */
+export interface ResolvedShop {
+  id: string;
+  name: string;
+  slug: string;
+  isOpen: boolean;
+}
+
+/**
+ * Context value set by ShopResolver and consumed by useResolvedShop.
+ * Separated from the layout component to keep react-refresh happy.
+ */
+export const ShopContext = createContext<ResolvedShop | null>(null);

--- a/src/frontend/src/features/storefront/hooks/useActiveShops.ts
+++ b/src/frontend/src/features/storefront/hooks/useActiveShops.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { shopsApi } from '@api/shops';
+import type { StorefrontShop } from '@api/shops';
+
+/**
+ * Fetches the list of active shops for a brand.
+ * Used by the storefront shop chooser page (US-FP-071).
+ *
+ * Cache key: ['activeShops', brandSlug]
+ * Stale after 60 s — isOpen is real-time but re-fetching every minute is enough
+ * for the chooser; MenuPage's ShopStatusBadge handles per-shop live refresh.
+ */
+export function useActiveShops(brandSlug: string) {
+  return useQuery<StorefrontShop[]>({
+    queryKey: ['activeShops', brandSlug],
+    queryFn: () => shopsApi.listActive(brandSlug),
+    enabled: brandSlug.length > 0,
+    staleTime: 60_000,
+  });
+}

--- a/src/frontend/src/features/storefront/hooks/useResolvedShop.ts
+++ b/src/frontend/src/features/storefront/hooks/useResolvedShop.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+import { ShopContext } from '../context/shopContextValue';
+import type { ResolvedShop } from '../context/shopContextValue';
+
+// Re-export the type for consumers that only need it
+export type { ResolvedShop };
+
+/**
+ * Returns the resolved shop from the nearest ShopResolver ancestor.
+ * Throws if called outside a ShopResolver — callers within :shopSlug routes
+ * are always inside one.
+ */
+export function useResolvedShop(): ResolvedShop {
+  const ctx = useContext(ShopContext);
+  if (ctx === null) {
+    throw new Error('useResolvedShop must be used within a ShopResolver route.');
+  }
+  return ctx;
+}

--- a/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
+++ b/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useAuth } from '@/auth/useAuth';
 import { CartProvider, useCart } from '../context/CartContext';
+import { useResolvedShop } from '../hooks/useResolvedShop';
 import { useCreateOrder } from '../hooks/useCreateOrder';
 import { MockPaymentScreen } from '../components/MockPaymentScreen';
 import type { OrderType } from '@api/orders';
@@ -17,6 +18,15 @@ import type { OrderType } from '@api/orders';
 const checkoutSchema = z.object({
   orderType: z.enum(['Pickup', 'EatIn', 'Delivery']),
   customerName: z.string().trim().optional(),
+  customerEmail: z
+    .string()
+    .trim()
+    .optional()
+    .refine(
+      (v) => !v || z.string().email().safeParse(v).success,
+      { message: 'Please enter a valid email address.' },
+    ),
+  customerPhone: z.string().trim().optional(),
   paymentMethod: z.enum(['CashAtPickup', 'CreditCard', 'Bancontact']),
 });
 
@@ -29,9 +39,10 @@ type CheckoutFormValues = z.infer<typeof checkoutSchema>;
 interface CheckoutFormProps {
   brandSlug: string;
   shopId: string;
+  shopSlug: string;
 }
 
-function CheckoutForm({ brandSlug, shopId }: CheckoutFormProps) {
+function CheckoutForm({ brandSlug, shopId, shopSlug }: CheckoutFormProps) {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
   const { brandSlug: paramSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
@@ -45,9 +56,9 @@ function CheckoutForm({ brandSlug, shopId }: CheckoutFormProps) {
   // Redirect to menu if cart is empty
   useEffect(() => {
     if (state.items.length === 0) {
-      void navigate(`/${paramSlug}/${lang}/shops/${shopId}/menu`, { replace: true });
+      void navigate(`/${paramSlug}/${lang}/${shopSlug}/menu`, { replace: true });
     }
-  }, [state.items.length, navigate, paramSlug, lang, shopId]);
+  }, [state.items.length, navigate, paramSlug, lang, shopSlug]);
 
   const {
     register,
@@ -90,16 +101,16 @@ function CheckoutForm({ brandSlug, shopId }: CheckoutFormProps) {
     const result = await createOrder.mutateAsync({
       orderType: values.orderType as OrderType,
       customerName: values.customerName ?? null,
+      customerEmail: values.customerEmail || null,
+      customerPhone: values.customerPhone || null,
       items: orderItems,
       paymentMethod: values.paymentMethod,
     });
 
-    // Save the shopId mapping so OrderConfirmationPage can reconstruct the API route
-    sessionStorage.setItem(`order-shop:${brandSlug}:${result.id}`, result.shopId);
     clearCart();
 
     if (values.paymentMethod === 'CashAtPickup') {
-      void navigate(`/${paramSlug}/${lang}/order/${result.id}`);
+      void navigate(`/${paramSlug}/${lang}/${shopSlug}/order/${result.id}`);
     } else {
       // Online payment methods: show mock processing screen first
       setPendingOrderId(result.id);
@@ -109,7 +120,7 @@ function CheckoutForm({ brandSlug, shopId }: CheckoutFormProps) {
 
   function handleMockPaymentComplete() {
     setShowMockPayment(false);
-    void navigate(`/${paramSlug}/${lang}/order/${pendingOrderId}`);
+    void navigate(`/${paramSlug}/${lang}/${shopSlug}/order/${pendingOrderId}`);
   }
 
   if (state.items.length === 0) {
@@ -229,6 +240,82 @@ function CheckoutForm({ brandSlug, shopId }: CheckoutFormProps) {
             type="text"
             {...register('customerName')}
             placeholder={t('storefront.checkout.customerNamePlaceholder')}
+            style={{
+              width: '100%',
+              padding: '0.625rem 0.875rem',
+              borderRadius: '0.375rem',
+              border: '1px solid #d1d5db',
+              fontSize: '0.9375rem',
+              color: '#111827',
+              boxSizing: 'border-box',
+            }}
+          />
+        </div>
+
+        {/* Customer email (optional, for digital receipt) */}
+        <div style={{ marginBottom: '1.5rem' }}>
+          <label
+            htmlFor="customerEmail"
+            style={{
+              display: 'block',
+              fontSize: '0.9375rem',
+              fontWeight: 600,
+              color: '#374151',
+              marginBottom: '0.375rem',
+            }}
+          >
+            {t('storefront.checkout.customerEmailLabel')}
+            <span style={{ fontWeight: 400, color: '#6b7280', marginLeft: '0.25rem' }}>
+              ({t('storefront.checkout.optional')})
+            </span>
+          </label>
+          <input
+            id="customerEmail"
+            type="email"
+            {...register('customerEmail')}
+            placeholder={t('storefront.checkout.customerEmailPlaceholder')}
+            style={{
+              width: '100%',
+              padding: '0.625rem 0.875rem',
+              borderRadius: '0.375rem',
+              border: `1px solid ${errors.customerEmail ? '#ef4444' : '#d1d5db'}`,
+              fontSize: '0.9375rem',
+              color: '#111827',
+              boxSizing: 'border-box',
+            }}
+          />
+          {errors.customerEmail && (
+            <p style={{ color: '#ef4444', fontSize: '0.8125rem', marginTop: '0.25rem' }}>
+              {errors.customerEmail.message}
+            </p>
+          )}
+          <p style={{ color: '#6b7280', fontSize: '0.8125rem', marginTop: '0.25rem' }}>
+            {t('storefront.checkout.customerEmailHelper')}
+          </p>
+        </div>
+
+        {/* Customer phone (optional) */}
+        <div style={{ marginBottom: '1.5rem' }}>
+          <label
+            htmlFor="customerPhone"
+            style={{
+              display: 'block',
+              fontSize: '0.9375rem',
+              fontWeight: 600,
+              color: '#374151',
+              marginBottom: '0.375rem',
+            }}
+          >
+            {t('storefront.checkout.customerPhoneLabel')}
+            <span style={{ fontWeight: 400, color: '#6b7280', marginLeft: '0.25rem' }}>
+              ({t('storefront.checkout.optional')})
+            </span>
+          </label>
+          <input
+            id="customerPhone"
+            type="tel"
+            {...register('customerPhone')}
+            placeholder={t('storefront.checkout.customerPhonePlaceholder')}
             style={{
               width: '100%',
               padding: '0.625rem 0.875rem',
@@ -417,27 +504,17 @@ function CheckoutForm({ brandSlug, shopId }: CheckoutFormProps) {
 }
 
 // ---------------------------------------------------------------------------
-// CheckoutPage — wraps form in CartProvider
+// CheckoutPage — reads shop from ShopContext, wraps form in CartProvider
 // ---------------------------------------------------------------------------
 
 export function CheckoutPage() {
   const { brandSlug } = useParams<{ brandSlug: string }>();
+  const { t } = useTranslation('common');
+  // shopId and shopSlug come from the resolved ShopContext (set by ShopResolver).
+  const shop = useResolvedShop();
   const resolvedBrandSlug = brandSlug ?? '';
 
-  return <CheckoutPageInner brandSlug={resolvedBrandSlug} />;
-}
-
-/**
- * Inner component that creates a CartProvider by reading the shopId from localStorage
- * directly (before CartContext is available). This avoids a chicken-and-egg problem.
- */
-function CheckoutPageInner({ brandSlug }: { brandSlug: string }) {
-  const { t } = useTranslation('common');
-
-  // Find the first cart key in localStorage for this brand
-  const shopId = findActiveShopId(brandSlug);
-
-  if (!shopId) {
+  if (!shop.id) {
     return (
       <main style={{ maxWidth: '36rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
         <h1 style={{ fontSize: '1.75rem', fontWeight: 800, color: '#111827', marginBottom: '1rem' }}>
@@ -449,32 +526,12 @@ function CheckoutPageInner({ brandSlug }: { brandSlug: string }) {
   }
 
   return (
-    <CartProvider brandSlug={brandSlug} shopId={shopId}>
-      <CheckoutForm brandSlug={brandSlug} shopId={shopId} />
+    <CartProvider brandSlug={resolvedBrandSlug} shopId={shop.id}>
+      <CheckoutForm
+        brandSlug={resolvedBrandSlug}
+        shopId={shop.id}
+        shopSlug={shop.slug}
+      />
     </CartProvider>
   );
-}
-
-/**
- * Scans localStorage for a cart belonging to the given brandSlug.
- * Returns the first shopId found, or null if no cart exists.
- */
-function findActiveShopId(brandSlug: string): string | null {
-  const prefix = `cart:${brandSlug}:`;
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key?.startsWith(prefix)) {
-      try {
-        const raw = localStorage.getItem(key);
-        if (!raw) continue;
-        const parsed = JSON.parse(raw) as { shopId?: string; items?: unknown[] };
-        if (parsed.shopId && Array.isArray(parsed.items) && parsed.items.length > 0) {
-          return parsed.shopId;
-        }
-      } catch {
-        continue;
-      }
-    }
-  }
-  return null;
 }

--- a/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
+++ b/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
@@ -40,9 +40,10 @@ interface CheckoutFormProps {
   brandSlug: string;
   shopId: string;
   shopSlug: string;
+  shopIsOpen: boolean;
 }
 
-function CheckoutForm({ brandSlug, shopId, shopSlug }: CheckoutFormProps) {
+function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen }: CheckoutFormProps) {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
   const { brandSlug: paramSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
@@ -92,6 +93,9 @@ function CheckoutForm({ brandSlug, shopId, shopSlug }: CheckoutFormProps) {
   }, 0);
 
   async function onSubmit(values: CheckoutFormValues) {
+    // Guard: a closed shop does not accept online orders (mirrors the backend check).
+    if (!shopIsOpen) return;
+
     const orderItems = state.items.map((item) => ({
       productId: item.productId,
       quantity: item.quantity,
@@ -136,6 +140,23 @@ function CheckoutForm({ brandSlug, shopId, shopSlug }: CheckoutFormProps) {
       <h1 style={{ fontSize: '1.75rem', fontWeight: 800, color: '#111827', marginBottom: '1.5rem' }}>
         {t('storefront.checkout.title')}
       </h1>
+
+      {!shopIsOpen && (
+        <div
+          role="alert"
+          style={{
+            padding: '0.75rem 1rem',
+            borderRadius: '0.375rem',
+            background: '#fef2f2',
+            border: '1px solid #fecaca',
+            color: '#991b1b',
+            fontSize: '0.875rem',
+            marginBottom: '1.5rem',
+          }}
+        >
+          {t('storefront.checkout.shopClosed')}
+        </div>
+      )}
 
       <form onSubmit={(e) => { void handleSubmit(onSubmit)(e); }} noValidate>
         {/* Order type selection */}
@@ -480,7 +501,7 @@ function CheckoutForm({ brandSlug, shopId, shopSlug }: CheckoutFormProps) {
         {/* Submit */}
         <button
           type="submit"
-          disabled={isSubmitting || createOrder.isPending}
+          disabled={isSubmitting || createOrder.isPending || !shopIsOpen}
           style={{
             width: '100%',
             padding: '0.875rem',
@@ -490,8 +511,8 @@ function CheckoutForm({ brandSlug, shopId, shopSlug }: CheckoutFormProps) {
             color: '#fff',
             fontWeight: 700,
             fontSize: '1rem',
-            cursor: isSubmitting || createOrder.isPending ? 'not-allowed' : 'pointer',
-            opacity: isSubmitting || createOrder.isPending ? 0.7 : 1,
+            cursor: isSubmitting || createOrder.isPending || !shopIsOpen ? 'not-allowed' : 'pointer',
+            opacity: isSubmitting || createOrder.isPending || !shopIsOpen ? 0.7 : 1,
           }}
         >
           {isSubmitting || createOrder.isPending
@@ -531,6 +552,7 @@ export function CheckoutPage() {
         brandSlug={resolvedBrandSlug}
         shopId={shop.id}
         shopSlug={shop.slug}
+        shopIsOpen={shop.isOpen}
       />
     </CartProvider>
   );

--- a/src/frontend/src/features/storefront/pages/LegacyShopIdRedirect.tsx
+++ b/src/frontend/src/features/storefront/pages/LegacyShopIdRedirect.tsx
@@ -1,0 +1,45 @@
+// Back-compat redirect: old GUID-based route `shops/:shopId/menu`
+// → slug-based route `/:brandSlug/:lang/:shopSlug/menu`.
+// Part of US-FP-071: keeps any saved/bookmarked old URLs working.
+
+import { useParams, Navigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useActiveShops } from '../hooks/useActiveShops';
+
+/**
+ * Resolves an old :shopId (GUID) to the corresponding slug and redirects.
+ * If the shop is not found (e.g. deactivated), falls back to the shop chooser.
+ */
+export function LegacyShopIdRedirect() {
+  const { brandSlug, lang, shopId } = useParams<{
+    brandSlug: string;
+    lang: string;
+    shopId: string;
+  }>();
+
+  const { t } = useTranslation('common');
+  const resolvedBrandSlug = brandSlug ?? '';
+  const resolvedLang = lang ?? 'nl';
+  const { data: shops, isLoading, isError } = useActiveShops(resolvedBrandSlug);
+
+  if (isLoading) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#6b7280' }}>{t('loading')}</p>
+      </main>
+    );
+  }
+
+  if (isError) {
+    return <Navigate to={`/${resolvedBrandSlug}/${resolvedLang}/shops`} replace />;
+  }
+
+  const shop = shops?.find((s) => s.id === shopId);
+
+  if (!shop) {
+    // Unknown GUID — fall back to chooser
+    return <Navigate to={`/${resolvedBrandSlug}/${resolvedLang}/shops`} replace />;
+  }
+
+  return <Navigate to={`/${resolvedBrandSlug}/${resolvedLang}/${shop.slug}/menu`} replace />;
+}

--- a/src/frontend/src/features/storefront/pages/MenuPage.tsx
+++ b/src/frontend/src/features/storefront/pages/MenuPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { ProductListItem } from '@/types/common';
 import { CartProvider, useCart, type CartModifier } from '../context/CartContext';
+import { useResolvedShop } from '../hooks/useResolvedShop';
 import { ProductCard } from '../components/ProductCard';
 import { ModifierModal } from '../components/ModifierModal';
 import { CartDrawer } from '../components/CartDrawer';
@@ -255,18 +256,20 @@ function MenuContent({ brandSlug }: MenuContentProps) {
 }
 
 // ---------------------------------------------------------------------------
-// MenuPage — wraps content in CartProvider
+// MenuPage — wraps content in CartProvider, reads shop from ShopContext
 // ---------------------------------------------------------------------------
 
 export function MenuPage() {
-  const { brandSlug, shopId } = useParams<{ brandSlug: string; shopId: string }>();
+  const { brandSlug } = useParams<{ brandSlug: string }>();
+  // shopId comes from the resolved ShopContext (set by ShopResolver layout route).
+  const shop = useResolvedShop();
 
-  if (!brandSlug || !shopId) {
-    return <p>Invalid route: brandSlug and shopId are required.</p>;
+  if (!brandSlug) {
+    return <p>Invalid route: brandSlug is required.</p>;
   }
 
   return (
-    <CartProvider brandSlug={brandSlug} shopId={shopId}>
+    <CartProvider brandSlug={brandSlug} shopId={shop.id}>
       <MenuContent brandSlug={brandSlug} />
     </CartProvider>
   );

--- a/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ordersApi } from '@api/orders';
 import type { OrderResponse } from '@api/orders';
 import { useOrderUpdates } from '@api/useOrderUpdates';
+import { useResolvedShop } from '../hooks/useResolvedShop';
 
 // ---------------------------------------------------------------------------
 // Query
@@ -31,20 +32,15 @@ export function OrderConfirmationPage() {
     orderId: string;
   }>();
 
+  // shopId comes from the resolved ShopContext (set by ShopResolver layout route).
+  const shop = useResolvedShop();
+
   const resolvedBrandSlug = brandSlug ?? '';
   const resolvedOrderId = orderId ?? '';
 
-  // We need shopId for the API call — attempt to recover it from orderId query if possible.
-  // Since the backend returns the order at GET /brands/{brandSlug}/shops/{shopId}/orders/{orderId}
-  // and we don't have shopId in this route, we use the ordersApi.getByOrderId approach which
-  // is scoped differently. For now, we store shopId in localStorage after checkout or use
-  // a separate route. Per the contract, we'll use a simpler approach: retrieve from
-  // the session storage key we save at checkout.
-  const shopId = recoverShopId(resolvedBrandSlug, resolvedOrderId);
-
   const { data: order, isLoading, isError } = useOrderDetails(
     resolvedBrandSlug,
-    shopId ?? '',
+    shop.id,
     resolvedOrderId,
   );
 
@@ -333,32 +329,4 @@ function TotalRow({ label, value, bold }: TotalRowProps) {
       <span>{value}</span>
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Helpers — recover shopId from localStorage after checkout
-// ---------------------------------------------------------------------------
-
-/**
- * After a successful order, the cart is cleared but we may still have the shopId
- * saved under a separate key in sessionStorage that CheckoutPage wrote before clearing.
- * Falls back to scanning localStorage cart keys for this brand.
- */
-function recoverShopId(brandSlug: string, orderId: string): string | null {
-  // Try sessionStorage key first
-  const sessionKey = `order-shop:${brandSlug}:${orderId}`;
-  const fromSession = sessionStorage.getItem(sessionKey);
-  if (fromSession) return fromSession;
-
-  // Fall back to scanning any remaining cart entries for this brand
-  const prefix = `cart:${brandSlug}:`;
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key?.startsWith(prefix)) {
-      const shopId = key.slice(prefix.length);
-      if (shopId) return shopId;
-    }
-  }
-
-  return null;
 }

--- a/src/frontend/src/features/storefront/pages/OrderTrackingPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderTrackingPage.tsx
@@ -1,6 +1,6 @@
 // Order tracking page — shows the shop's configured lifecycle as a visual
 // stepper and subscribes to real-time status updates via SignalR.
-// Accessible to guests (no RequireAuth) via /:brandSlug/:lang/order/:orderId/track.
+// Accessible to guests (no RequireAuth) via /:brandSlug/:lang/:shopSlug/order/:orderId/track.
 
 import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
@@ -10,6 +10,7 @@ import { ordersApi } from '@api/orders';
 import type { OrderTrackingResponse } from '@api/orders';
 import { useOrderUpdates } from '@api/useOrderUpdates';
 import { OrderStatusStepper } from '../components/OrderStatusStepper';
+import { useResolvedShop } from '../hooks/useResolvedShop';
 
 // ---------------------------------------------------------------------------
 // Query hook
@@ -36,15 +37,15 @@ export function OrderTrackingPage() {
     orderId: string;
   }>();
 
+  // shopId comes from the resolved ShopContext (set by ShopResolver layout route).
+  const shop = useResolvedShop();
+
   const resolvedBrandSlug = brandSlug ?? '';
   const resolvedOrderId = orderId ?? '';
 
-  // Recover shopId from sessionStorage — written by CheckoutPage after order placement.
-  const shopId = recoverShopId(resolvedBrandSlug, resolvedOrderId) ?? '';
-
   const { data, isLoading, isError } = useOrderTracking(
     resolvedBrandSlug,
-    shopId,
+    shop.id,
     resolvedOrderId,
   );
 
@@ -247,30 +248,4 @@ function MetaCard({ label, value }: MetaCardProps) {
       <p style={{ margin: 0, fontSize: '1rem', fontWeight: 700, color: '#111827' }}>{value}</p>
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Helpers — recover shopId from sessionStorage after checkout
-// ---------------------------------------------------------------------------
-
-/**
- * The CheckoutPage writes `sessionStorage.setItem(\`order-shop:\${brandSlug}:\${orderId}\`, shopId)`
- * immediately after a successful order submission. We read that key here.
- */
-function recoverShopId(brandSlug: string, orderId: string): string | null {
-  const sessionKey = `order-shop:${brandSlug}:${orderId}`;
-  const fromSession = sessionStorage.getItem(sessionKey);
-  if (fromSession) return fromSession;
-
-  // Fall back to scanning any remaining cart entries for this brand.
-  const prefix = `cart:${brandSlug}:`;
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key?.startsWith(prefix)) {
-      const shopId = key.slice(prefix.length);
-      if (shopId) return shopId;
-    }
-  }
-
-  return null;
 }

--- a/src/frontend/src/features/storefront/pages/ShopChooserPage.tsx
+++ b/src/frontend/src/features/storefront/pages/ShopChooserPage.tsx
@@ -1,0 +1,147 @@
+// Shop chooser page — lists all active shops for the brand.
+// If exactly one shop is active, auto-redirects straight to its menu.
+// Part of US-FP-071: shop selection and slug-based routing.
+
+import { useParams, Navigate, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useActiveShops } from '../hooks/useActiveShops';
+import { ShopStatusBadge } from '../components/ShopStatusBadge';
+
+/**
+ * Renders a card for each active shop.
+ * Tapping a card navigates to /:brandSlug/:lang/:shopSlug/menu.
+ */
+export function ShopChooserPage() {
+  const { t } = useTranslation('common');
+  const { brandSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
+
+  const resolvedBrandSlug = brandSlug ?? '';
+  const resolvedLang = lang ?? 'nl';
+  const { data: shops, isLoading, isError } = useActiveShops(resolvedBrandSlug);
+
+  // Loading
+  if (isLoading) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#6b7280' }}>{t('loading')}</p>
+      </main>
+    );
+  }
+
+  // Error
+  if (isError) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <p style={{ color: '#ef4444' }}>{t('error')}</p>
+      </main>
+    );
+  }
+
+  // Auto-redirect when exactly one shop is active
+  const singleShop = shops?.length === 1 ? shops[0] : undefined;
+  if (singleShop) {
+    return (
+      <Navigate
+        to={`/${resolvedBrandSlug}/${resolvedLang}/${singleShop.slug}/menu`}
+        replace
+      />
+    );
+  }
+
+  // At this point data is loaded: normalise to an array (undefined → empty)
+  const activeShops = shops ?? [];
+
+  // Empty state
+  if (activeShops.length === 0) {
+    return (
+      <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+        <h1
+          style={{ fontSize: '1.75rem', fontWeight: 800, color: '#111827', marginBottom: '1.5rem' }}
+        >
+          {t('storefront.shopChooser.title')}
+        </h1>
+        <p style={{ color: '#6b7280' }}>{t('storefront.shopChooser.noShops')}</p>
+      </main>
+    );
+  }
+
+  // Multi-shop chooser
+  return (
+    <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      <h1
+        style={{
+          fontSize: '1.75rem',
+          fontWeight: 800,
+          color: '#111827',
+          marginBottom: '0.5rem',
+        }}
+      >
+        {t('storefront.shopChooser.title')}
+      </h1>
+      <p style={{ color: '#6b7280', marginBottom: '1.5rem', fontSize: '0.9375rem' }}>
+        {t('storefront.shopChooser.subtitle')}
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {activeShops.map((shop) => (
+          <Link
+            key={shop.id}
+            to={`/${resolvedBrandSlug}/${resolvedLang}/${shop.slug}/menu`}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+            aria-label={t('storefront.shopChooser.selectShop', { name: shop.name })}
+          >
+            <div
+              style={{
+                padding: '1.25rem 1.5rem',
+                border: '2px solid #e5e7eb',
+                borderRadius: '0.75rem',
+                background: '#fff',
+                cursor: 'pointer',
+                transition: 'border-color 0.15s, box-shadow 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLDivElement).style.borderColor =
+                  'var(--brand-color-primary, #111827)';
+                (e.currentTarget as HTMLDivElement).style.boxShadow =
+                  '0 2px 8px rgba(0,0,0,0.08)';
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLDivElement).style.borderColor = '#e5e7eb';
+                (e.currentTarget as HTMLDivElement).style.boxShadow = 'none';
+              }}
+            >
+              {/* Shop name + status badge */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: '0.75rem',
+                  marginBottom: '0.5rem',
+                }}
+              >
+                <span style={{ fontSize: '1.0625rem', fontWeight: 700, color: '#111827' }}>
+                  {shop.name}
+                </span>
+                <ShopStatusBadge brandSlug={resolvedBrandSlug} shopId={shop.id} />
+              </div>
+
+              {/* Address */}
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: '0.875rem',
+                  color: '#6b7280',
+                  lineHeight: 1.5,
+                }}
+              >
+                {shop.address.street} {shop.address.number}, {shop.address.postalCode}{' '}
+                {shop.address.city}
+              </p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/frontend/src/features/storefront/routes.tsx
+++ b/src/frontend/src/features/storefront/routes.tsx
@@ -1,9 +1,12 @@
-// Storefront route module. Wired up by US-FP-016 + US-FP-017 (online + guest ordering).
+// Storefront route module. Updated by US-FP-071 to add slug-based shop routing.
 
 import { lazy } from 'react';
+import { Navigate } from 'react-router-dom';
 import type { RouteObject } from 'react-router-dom';
 import { SuspenseWrapper } from '@components/SuspenseWrapper';
-import { Home } from './pages/Home';
+import { ShopChooserPage } from './pages/ShopChooserPage';
+import { LegacyShopIdRedirect } from './pages/LegacyShopIdRedirect';
+import { ShopResolver } from './context/ShopContext';
 
 // Lazy-load heavy storefront pages for code-splitting
 const LazyMenuPage = lazy(() =>
@@ -28,46 +31,77 @@ const LazyOrderTrackingPage = lazy(() =>
  * inside the ThemeProvider layout route.
  *
  * ThemeProvider is applied as a layout route in router.tsx — do NOT wrap again here.
+ *
+ * Route tree:
+ *   index                         → redirect to shops
+ *   shops                         → ShopChooserPage (lists active shops)
+ *   shops/:shopId/menu            → LegacyShopIdRedirect (back-compat GUID route)
+ *   :shopSlug                     → ShopResolver (layout route, resolves slug → shop)
+ *     :shopSlug/menu              → MenuPage
+ *     :shopSlug/checkout          → CheckoutPage
+ *     :shopSlug/order/:orderId    → OrderConfirmationPage
+ *     :shopSlug/order/:orderId/track → OrderTrackingPage
  */
 export const storefrontRoutes: RouteObject[] = [
   {
+    // Index: redirect to the shop chooser.
+    // ShopChooserPage will auto-redirect to the menu if only one shop exists.
     index: true,
-    element: <Home />,
+    element: <Navigate to="shops" replace />,
   },
   {
-    // Menu page for a specific shop: browse categories and products, add to cart
+    // Shop chooser: display all active shops as selectable cards.
+    path: 'shops',
+    element: <ShopChooserPage />,
+  },
+  {
+    // Back-compat: old GUID-based route used before US-FP-071.
+    // Looks up the shop slug by id and redirects to the slug route.
     path: 'shops/:shopId/menu',
-    element: (
-      <SuspenseWrapper>
-        <LazyMenuPage />
-      </SuspenseWrapper>
-    ),
+    element: <LegacyShopIdRedirect />,
   },
   {
-    // Checkout page: review cart, select order type, submit order
-    path: 'checkout',
-    element: (
-      <SuspenseWrapper>
-        <LazyCheckoutPage />
-      </SuspenseWrapper>
-    ),
-  },
-  {
-    // Order confirmation page: show order details and real-time status via SignalR
-    path: 'order/:orderId',
-    element: (
-      <SuspenseWrapper>
-        <LazyOrderConfirmationPage />
-      </SuspenseWrapper>
-    ),
-  },
-  {
-    // Order tracking page: visual lifecycle stepper with real-time SignalR updates (US-FP-063)
-    path: 'order/:orderId/track',
-    element: (
-      <SuspenseWrapper>
-        <LazyOrderTrackingPage />
-      </SuspenseWrapper>
-    ),
+    // ShopResolver layout route: resolves :shopSlug param to a shop object
+    // and makes it available to all children via ShopContext.
+    path: ':shopSlug',
+    element: <ShopResolver />,
+    children: [
+      {
+        // Menu page: browse categories and products, add to cart
+        path: 'menu',
+        element: (
+          <SuspenseWrapper>
+            <LazyMenuPage />
+          </SuspenseWrapper>
+        ),
+      },
+      {
+        // Checkout: review cart, select order type, submit
+        path: 'checkout',
+        element: (
+          <SuspenseWrapper>
+            <LazyCheckoutPage />
+          </SuspenseWrapper>
+        ),
+      },
+      {
+        // Order confirmation: show order details and real-time status via SignalR
+        path: 'order/:orderId',
+        element: (
+          <SuspenseWrapper>
+            <LazyOrderConfirmationPage />
+          </SuspenseWrapper>
+        ),
+      },
+      {
+        // Order tracking: visual lifecycle stepper with real-time SignalR updates
+        path: 'order/:orderId/track',
+        element: (
+          <SuspenseWrapper>
+            <LazyOrderTrackingPage />
+          </SuspenseWrapper>
+        ),
+      },
+    ],
   },
 ];

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -4,6 +4,12 @@
   "error": "Ein Fehler ist aufgetreten",
   "storefront": {
     "description": "Sehen Sie unsere Speisekarte und geben Sie Ihre Bestellung auf.",
+    "shopChooser": {
+      "title": "Filiale auswählen",
+      "subtitle": "Wählen Sie die Filiale aus, bei der Sie bestellen möchten.",
+      "noShops": "Derzeit sind keine Filialen verfügbar.",
+      "selectShop": "{{name}} auswählen"
+    },
     "languageSelector": {
       "ariaLabel": "Sprache wählen"
     },
@@ -48,6 +54,11 @@
       },
       "customerNameLabel": "Name",
       "customerNamePlaceholder": "Ihr Name (optional)",
+      "customerEmailLabel": "E-Mail-Adresse",
+      "customerEmailPlaceholder": "ihre@email.be",
+      "customerEmailHelper": "Geben Sie Ihre E-Mail-Adresse für einen digitalen Kassenbon ein.",
+      "customerPhoneLabel": "Telefonnummer",
+      "customerPhonePlaceholder": "z.B. +32 478 12 34 56",
       "optional": "optional",
       "orderSummary": "Bestellübersicht",
       "subtotal": "Zwischensumme",

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -80,7 +80,8 @@
       "placeOrder": "Bestellung aufgeben",
       "placing": "Wird aufgegeben…",
       "submitError": "Bestellung fehlgeschlagen. Bitte erneut versuchen.",
-      "cartEmpty": "Ihr Warenkorb ist leer."
+      "cartEmpty": "Ihr Warenkorb ist leer.",
+      "shopClosed": "Dieser Shop ist derzeit geschlossen und nimmt keine Online-Bestellungen an."
     },
     "order": {
       "confirmed": "Bestellung bestätigt!",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -4,6 +4,12 @@
   "error": "Une erreur s'est produite",
   "storefront": {
     "description": "Consultez notre menu et passez votre commande.",
+    "shopChooser": {
+      "title": "Choisir un établissement",
+      "subtitle": "Sélectionnez l'établissement où vous souhaitez commander.",
+      "noShops": "Aucun établissement n'est disponible pour le moment.",
+      "selectShop": "Sélectionner {{name}}"
+    },
     "languageSelector": {
       "ariaLabel": "Choisir la langue"
     },
@@ -48,6 +54,11 @@
       },
       "customerNameLabel": "Nom",
       "customerNamePlaceholder": "Votre nom (optionnel)",
+      "customerEmailLabel": "Adresse e-mail",
+      "customerEmailPlaceholder": "votre@email.be",
+      "customerEmailHelper": "Saisissez votre e-mail pour recevoir un reçu numérique.",
+      "customerPhoneLabel": "Numéro de téléphone",
+      "customerPhonePlaceholder": "p.ex. +32 478 12 34 56",
       "optional": "optionnel",
       "orderSummary": "Récapitulatif de commande",
       "subtotal": "Sous-total",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -80,7 +80,8 @@
       "placeOrder": "Passer la commande",
       "placing": "En cours…",
       "submitError": "Échec de la commande. Veuillez réessayer.",
-      "cartEmpty": "Votre panier est vide."
+      "cartEmpty": "Votre panier est vide.",
+      "shopClosed": "Ce magasin est actuellement fermé et n'accepte pas de commandes en ligne."
     },
     "order": {
       "confirmed": "Commande confirmée !",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -4,6 +4,12 @@
   "error": "Er is iets misgegaan",
   "storefront": {
     "description": "Bekijk ons menu en plaats uw bestelling.",
+    "shopChooser": {
+      "title": "Kies een vestiging",
+      "subtitle": "Selecteer de vestiging waar u wilt bestellen.",
+      "noShops": "Er zijn momenteel geen vestigingen beschikbaar.",
+      "selectShop": "Selecteer {{name}}"
+    },
     "languageSelector": {
       "ariaLabel": "Taal selecteren"
     },
@@ -48,6 +54,11 @@
       },
       "customerNameLabel": "Naam",
       "customerNamePlaceholder": "Uw naam (optioneel)",
+      "customerEmailLabel": "E-mailadres",
+      "customerEmailPlaceholder": "uw@email.be",
+      "customerEmailHelper": "Vul uw e-mailadres in voor een digitale bon.",
+      "customerPhoneLabel": "Telefoonnummer",
+      "customerPhonePlaceholder": "bijv. +32 478 12 34 56",
       "optional": "optioneel",
       "orderSummary": "Besteloverzicht",
       "subtotal": "Subtotaal",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -80,7 +80,8 @@
       "placeOrder": "Bestelling plaatsen",
       "placing": "Bezig met plaatsen…",
       "submitError": "Bestelling plaatsen mislukt. Probeer opnieuw.",
-      "cartEmpty": "Uw winkelwagen is leeg."
+      "cartEmpty": "Uw winkelwagen is leeg.",
+      "shopClosed": "Deze winkel is momenteel gesloten en accepteert geen online bestellingen."
     },
     "order": {
       "confirmed": "Bestelling bevestigd!",


### PR DESCRIPTION
## Summary

Bundles two storefront stories that ship together:

- **US-FP-071 — Storefront shop selection & slug-based routing** (#127). Adds the missing storefront *entry point*. Previously the landing page was a stub and a shop's menu was only reachable via a hand-typed GUID URL, so a real customer could not start an online order. This adds a shop chooser and puts shop context in the route.
- **US-FP-017 — Optional email & phone at guest checkout** (#17). The one remaining acceptance gap for guest ordering.

## US-FP-071
- Backend: `GET /api/brands/{brandSlug}/shops/active` (`AllowAnonymous`) → active shops with `slug` + real-time open/closed status. Reuses the existing `Shop.Slug` (no migration).
- Frontend: shop chooser at `/:brandSlug/:lang/shops`; order flow nested under `:shopSlug` (`/menu`, `/checkout`, `/order/:id`, `/order/:id/track`); a `ShopResolver` layout resolves slug→shop via context.
- Removes the `localStorage`/`sessionStorage` `shopId` recovery hacks (`findActiveShopId`, `recoverShopId`, `order-shop:`).
- Old GUID route `shops/:shopId/menu` redirects to the slug route; single active shop auto-forwards to its menu.

## US-FP-017
- `Order` aggregate gains optional `CustomerEmail` / `CustomerPhone` (migration `AddCustomerContactToOrder`); email format-validated only when provided.
- Checkout form + DTOs + NL/FR/DE i18n; all strictly optional.

## Verification
- ✅ Frontend `type-check` + `build` clean; **302 FE tests pass**.
- ✅ Backend integration `PlaceOrderTests` pass (with/without/invalid email+phone).
- ✅ New endpoint confirmed **live at runtime**: `GET /shops/active` → 200 with 3 shops + slugs (also confirms `/shops/active` out-ranks `/shops/{id}`).

## Known caveats / follow-ups (not blockers)
- ⚠️ The **UI happy-path has not been clicked through in a browser** yet (no browser-automation tool available in this session). Wiring is covered by code review + build + the static navigable-path review, but a human/Playwright pass is recommended before merge.
- ⚠️ **BFF auth on `/api`**: a raw guest call through the BFF returns 401 (mock auth masks this in dev). Confirm the public storefront actually works for unauthenticated guests in prod — relates to the RBAC gap in #69.
- ⚠️ Open AC for #127: *closed* shops are shown but ordering may not be blocked when a shop is closed — needs confirming.
- 📝 `src/frontend/CLAUDE.md` Storefront section still lists the old `shops/:shopId/menu` route — small doc follow-up.

## Stories
Implements #17 and #127. (Recommend keeping both open until the storefront UI is verified end-to-end in a browser.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
