### PR TITLE
feat(orders): advance order status from the kitchen display (US-FP-023)

### DIFF
--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/AdvanceOrderStatusEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/AdvanceOrderStatusEndpoint.cs
@@ -1,0 +1,69 @@
+using FastEndpoints;
+using FluentValidation.Results;
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record AdvanceOrderStatusRequest(
+    [property: RouteParam] string BrandSlug,
+    [property: RouteParam] Guid ShopId,
+    [property: RouteParam] Guid OrderId,
+    Guid ToStatusId);
+
+/// <summary>
+/// Advances an order to the next status in the shop's lifecycle (US-FP-023).
+/// Backs the "tap to advance" action on the kitchen display. The transition must be
+/// configured in the shop's <c>OrderLifecycleConfig</c>; the change is pushed in real
+/// time to kitchen displays, the POS, and the customer's tracking page via SignalR.
+/// </summary>
+public sealed class AdvanceOrderStatusEndpoint(IOrderService orderService)
+    : Endpoint<AdvanceOrderStatusRequest, OrderResponse>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}/status";
+
+    public override void Configure()
+    {
+        Post(Route);
+        // TODO (US-FP-039/069): require a staff role once per-endpoint RBAC is enforced.
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<AdvanceOrderStatusRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Advance an order to the next lifecycle status (kitchen display)";
+            s.Description =
+                "Moves the order to the requested status, provided the transition is " +
+                "configured in the shop's order lifecycle. Pushes a real-time update to " +
+                "connected kitchen displays, POS, and the customer's tracking page.";
+            s.Response<OrderResponse>(200, "Order status advanced successfully.");
+            s.Response(400, "The requested transition is not allowed for this shop.");
+            s.Response(404, "Order, target status, brand, or shop not found.");
+        });
+    }
+
+    public override async Task HandleAsync(AdvanceOrderStatusRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var response = await orderService.AdvanceOrderStatusAsync(
+                req.ShopId, req.OrderId, req.ToStatusId, ct);
+
+            await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            await HttpContext.Response.SendNotFoundAsync(ct);
+            Logger.LogInformation("Advance-status 404: {Message}", ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            var failures = new List<ValidationFailure> { new("toStatusId", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+        catch (ArgumentException ex)
+        {
+            var failures = new List<ValidationFailure> { new("toStatusId", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/IOrderService.cs
@@ -44,4 +44,27 @@ public interface IOrderService
         CreateInStoreOrderRequest request,
         Guid? createdByStaffId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Advances an order to a new status in the shop's configured lifecycle (US-FP-023).
+    /// Validates that a transition from the order's current status to
+    /// <paramref name="toStatusId"/> is allowed before applying it, then persists the
+    /// change — which dispatches <c>OrderStatusChangedEvent</c> for real-time notification.
+    /// </summary>
+    /// <param name="shopId">The shop the order belongs to (from the route).</param>
+    /// <param name="orderId">The order to advance.</param>
+    /// <param name="toStatusId">The target lifecycle status's identifier.</param>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when the order does not exist for the shop, or the target status id is
+    /// not part of the shop's lifecycle.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the shop has no lifecycle config, the order's current status is not
+    /// in the lifecycle, or the requested transition is not configured.
+    /// </exception>
+    Task<OrderResponse> AdvanceOrderStatusAsync(
+        Guid shopId,
+        Guid orderId,
+        Guid toStatusId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -100,6 +100,49 @@ public sealed class OrderService(
             cancellationToken);
     }
 
+    public async Task<OrderResponse> AdvanceOrderStatusAsync(
+        Guid shopId,
+        Guid orderId,
+        Guid toStatusId,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Load the order and confirm it belongs to the shop named in the route.
+        var order = await orderRepository.GetByIdAsync(orderId, cancellationToken);
+        if (order is null || order.ShopId != shopId)
+            throw new KeyNotFoundException(
+                $"Order with id '{orderId}' was not found for shop '{shopId}'.");
+
+        // 2. Load the shop's lifecycle config (statuses + allowed transitions).
+        var lifecycleConfig = await orderLifecycleConfigRepository.GetByShopIdAsync(shopId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                "This shop has no order lifecycle configuration.");
+
+        // 3. Resolve the current status by name (orders store the denormalised status name).
+        var currentStatus = lifecycleConfig.Statuses.FirstOrDefault(s => s.Name == order.StatusName)
+            ?? throw new InvalidOperationException(
+                $"The order's current status '{order.StatusName}' is not part of the shop's lifecycle.");
+
+        // 4. Resolve the requested target status.
+        var targetStatus = lifecycleConfig.Statuses.FirstOrDefault(s => s.Id == toStatusId)
+            ?? throw new KeyNotFoundException(
+                $"Status with id '{toStatusId}' was not found in the shop's lifecycle.");
+
+        // 5. The transition must be explicitly configured (current → target).
+        var transitionAllowed = lifecycleConfig.Transitions.Any(
+            t => t.FromStatusId == currentStatus.Id && t.ToStatusId == targetStatus.Id);
+        if (!transitionAllowed)
+            throw new InvalidOperationException(
+                $"Cannot advance order from '{currentStatus.Name}' to '{targetStatus.Name}': " +
+                "no such transition is configured for this shop.");
+
+        // 6. Apply the change (raises OrderStatusChangedEvent) and persist —
+        //    SaveChangesAsync dispatches the event via Wolverine → SignalR.
+        order.AdvanceTo(targetStatus.Name);
+        await orderRepository.SaveChangesAsync(cancellationToken);
+
+        return MapToResponse(order);
+    }
+
     // ── Private helpers ──────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
@@ -146,4 +146,36 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
 
         return order;
     }
+
+    /// <summary>
+    /// Advances the order to a new lifecycle status (US-FP-023).
+    /// Raises <see cref="OrderStatusChangedEvent"/> so the change propagates via
+    /// Wolverine/SignalR to the kitchen display, POS, and the customer's tracking page.
+    /// </summary>
+    /// <remarks>
+    /// Whether the transition is <em>allowed</em> (i.e. configured in the shop's
+    /// <c>OrderLifecycleConfig</c>) is a cross-aggregate concern enforced by the
+    /// application service before this method is called. The aggregate only guards
+    /// the invariants it owns: a non-empty, genuinely different status name.
+    /// </remarks>
+    public void AdvanceTo(string newStatusName)
+    {
+        if (string.IsNullOrWhiteSpace(newStatusName))
+            throw new ArgumentException("Status name is required.", nameof(newStatusName));
+
+        if (string.Equals(newStatusName, StatusName, StringComparison.Ordinal))
+            throw new InvalidOperationException($"Order is already in status '{StatusName}'.");
+
+        var previousStatus = StatusName;
+        StatusName = newStatusName;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        AddDomainEvent(new OrderStatusChangedEvent(
+            Id,
+            ShopId,
+            BrandSlug,
+            previousStatus,
+            newStatusName,
+            CustomerName));
+    }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/AdvanceOrderStatusTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/AdvanceOrderStatusTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Net.Http.Json;
+using TheMillionthFoodOrderApp.Application.OrderLifecycle;
+using TheMillionthFoodOrderApp.Application.Orders.Dtos;
+using TheMillionthFoodOrderApp.Application.Products;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Orders;
+
+/// <summary>
+/// Integration tests for POST /api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}/status —
+/// the kitchen "advance order status" action (US-FP-023).
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class AdvanceOrderStatusTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string ShopsUrl(string brandSlug) => $"/api/brands/{brandSlug}/shops";
+    private static string ProductsUrl(string brandSlug) => $"/api/brands/{brandSlug}/products";
+    private static string OrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders";
+    private static string LifecycleUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+    private static string AdvanceUrl(string brandSlug, Guid shopId, Guid orderId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}/status";
+
+    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            Name = $"Test Shop {Guid.NewGuid().ToString("N")[..8]}",
+            Slug = $"shop-{Guid.NewGuid().ToString("N")[..8]}",
+            Address = new
+            {
+                Street = "Frietstraat",
+                Number = "1",
+                City = "Brussel",
+                PostalCode = "1000",
+                Country = "BE"
+            },
+            ContactEmail = "shop@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var response = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var shop = await response.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+
+        // Trigger default lifecycle creation (lazy-initialised on first GET).
+        await client.GetAsync(LifecycleUrl(brandSlug, shop!.Id));
+
+        // Online orders require an open shop — give it an always-open schedule.
+        var openingHours = new
+        {
+            TimeBlocks = Enumerable.Range(0, 7)
+                .Select(day => new { DayOfWeek = day, OpenTime = "00:00", CloseTime = "23:59" })
+                .ToArray()
+        };
+        var hoursResponse = await client.PutAsJsonAsync(
+            $"/api/brands/{brandSlug}/shops/{shop.Id}/opening-hours", openingHours);
+        await Assert.That(hoursResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        return shop.Id;
+    }
+
+    private async Task<Guid> CreateProductAsync(HttpClient client, string brandSlug, string name)
+    {
+        var request = new
+        {
+            BasePrice = 3.00m,
+            Translations = new[] { new { LanguageCode = "nl", Name = name, Description = (string?)null } }
+        };
+
+        var response = await client.PostAsJsonAsync(ProductsUrl(brandSlug), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var product = await response.Content.ReadFromJsonAsync<ProductResponse>();
+        await Assert.That(product).IsNotNull();
+        return product!.Id;
+    }
+
+    private async Task<OrderResponse> PlaceOrderAsync(
+        HttpClient client, string brandSlug, Guid shopId, Guid productId)
+    {
+        var request = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerName = "Status Test",
+            Items = new[]
+            {
+                new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync(OrdersUrl(brandSlug, shopId), request);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        return order!;
+    }
+
+    private async Task<OrderLifecycleResponse> GetLifecycleAsync(
+        HttpClient client, string brandSlug, Guid shopId)
+    {
+        var response = await client.GetAsync(LifecycleUrl(brandSlug, shopId));
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        var lifecycle = await response.Content.ReadFromJsonAsync<OrderLifecycleResponse>();
+        await Assert.That(lifecycle).IsNotNull();
+        return lifecycle!;
+    }
+
+    private static Guid StatusId(OrderLifecycleResponse lifecycle, string name) =>
+        lifecycle.Statuses.Single(s => s.Name == name).Id;
+
+    // ── Tests ───────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Advance_AllowedTransition_Returns200AndUpdatesStatus()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "Frietje");
+        var order = await PlaceOrderAsync(client, brand, shopId, productId);
+        await Assert.That(order.StatusName).IsEqualTo("Placed");
+
+        var lifecycle = await GetLifecycleAsync(client, brand, shopId);
+        var confirmedId = StatusId(lifecycle, "Confirmed");
+
+        var response = await client.PostAsJsonAsync(
+            AdvanceUrl(brand, shopId, order.Id), new { ToStatusId = confirmedId });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(updated).IsNotNull();
+        await Assert.That(updated!.StatusName).IsEqualTo("Confirmed");
+    }
+
+    [Test]
+    public async Task Advance_DisallowedTransition_Returns400()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "Frikandel");
+        var order = await PlaceOrderAsync(client, brand, shopId, productId);
+
+        var lifecycle = await GetLifecycleAsync(client, brand, shopId);
+        // No direct transition exists from "Placed" to "Ready" in the default lifecycle.
+        var readyId = StatusId(lifecycle, "Ready");
+
+        var response = await client.PostAsJsonAsync(
+            AdvanceUrl(brand, shopId, order.Id), new { ToStatusId = readyId });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Advance_UnknownStatusId_Returns404()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, "Bicky");
+        var order = await PlaceOrderAsync(client, brand, shopId, productId);
+
+        var response = await client.PostAsJsonAsync(
+            AdvanceUrl(brand, shopId, order.Id), new { ToStatusId = Guid.NewGuid() });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task Advance_NonExistentOrder_Returns404()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.DeltaSlug;
+        var shopId = await CreateShopAsync(client, brand);
+        var lifecycle = await GetLifecycleAsync(client, brand, shopId);
+        var confirmedId = StatusId(lifecycle, "Confirmed");
+
+        var response = await client.PostAsJsonAsync(
+            AdvanceUrl(brand, shopId, Guid.NewGuid()), new { ToStatusId = confirmedId });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+}

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -176,6 +176,25 @@ export const ordersApi = {
       .then((r) => r.data.orders),
 
   /**
+   * Advance an order to the next status in the shop's lifecycle (US-FP-023).
+   * Only transitions configured for the shop are accepted; the server pushes the
+   * change to kitchen displays and the customer's tracking page via SignalR.
+   * Route: POST /brands/{brandSlug}/shops/{shopId}/orders/{orderId}/status
+   */
+  advanceStatus: (
+    brandSlug: string,
+    shopId: string,
+    orderId: string,
+    toStatusId: string,
+  ): Promise<OrderResponse> =>
+    apiClient
+      .post<OrderResponse>(
+        `/brands/${brandSlug}/shops/${shopId}/orders/${orderId}/status`,
+        { toStatusId },
+      )
+      .then((r) => r.data),
+
+  /**
    * Create an in-store order via the POS interface (staff-only).
    * Route: POST /brands/{brandSlug}/shops/{shopId}/orders/in-store
    */

--- a/src/frontend/src/api/signalr.ts
+++ b/src/frontend/src/api/signalr.ts
@@ -18,6 +18,12 @@ let connection: HubConnection | null = null;
  *
  * Auth: cookies are sent automatically on the WebSocket handshake
  * (Vite proxies /api to BFF, which forwards the bearer token to the API).
+ *
+ * CSRF: the BFF rejects authenticated POSTs under /api without the `X-CSRF: 1`
+ * header (see CsrfHeaderMiddleware). SignalR's negotiate is such a POST, so we
+ * send the header here — matching the axios client (`src/api/client.ts`).
+ * The header applies to the HTTP negotiate/long-polling/SSE requests; the
+ * WebSocket upgrade itself is a GET and is not CSRF-checked.
  */
 export function getOrderHubConnection(): HubConnection {
   if (connection !== null) {
@@ -25,7 +31,9 @@ export function getOrderHubConnection(): HubConnection {
   }
 
   connection = new HubConnectionBuilder()
-    .withUrl('/api/hubs/orders')
+    .withUrl('/api/hubs/orders', {
+      headers: { 'X-CSRF': '1' },
+    })
     .withAutomaticReconnect([0, 2000, 10000, 30000])
     .configureLogging(
       import.meta.env.DEV ? LogLevel.Information : LogLevel.Warning,

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -1,8 +1,16 @@
 import { useTranslation } from 'react-i18next';
-import type { OrderResponse, OrderType } from '@api/orders';
+import type { OrderResponse, OrderStatusResponse, OrderType } from '@api/orders';
 
 interface KitchenOrderCardProps {
   order: OrderResponse;
+  /** Statuses the order can advance to next (computed from the shop's lifecycle). */
+  nextStatuses?: OrderStatusResponse[];
+  /** Called with the target status id when a staff member taps an advance button. */
+  onAdvance?: (toStatusId: string) => void;
+  /** True while this order's advance request is in flight — disables the buttons. */
+  isAdvancing?: boolean;
+  /** True when the last advance attempt for this order failed. */
+  advanceError?: boolean;
 }
 
 const orderTypeColor: Record<OrderType, string> = {
@@ -25,7 +33,13 @@ function formatRelative(iso: string, now: number): string {
   return `${hours}h ${minutes % 60}m`;
 }
 
-export function KitchenOrderCard({ order }: KitchenOrderCardProps) {
+export function KitchenOrderCard({
+  order,
+  nextStatuses = [],
+  onAdvance,
+  isAdvancing = false,
+  advanceError = false,
+}: KitchenOrderCardProps) {
   const { t } = useTranslation('common');
   const typeLabel = t(`pos.kitchen.orderType.${order.orderType}`);
   const typeColor = orderTypeColor[order.orderType];
@@ -112,6 +126,20 @@ export function KitchenOrderCard({ order }: KitchenOrderCardProps) {
             {t('pos.kitchen.customer', { name: order.customerName })}
           </span>
         )}
+        <span
+          data-testid="kitchen-order-status"
+          style={{
+            padding: '0.25rem 0.625rem',
+            background: '#f3f4f6',
+            color: '#374151',
+            border: '1px solid #d1d5db',
+            borderRadius: '999px',
+            fontSize: '0.8125rem',
+            fontWeight: 700,
+          }}
+        >
+          {t('pos.kitchen.status', { name: order.statusName })}
+        </span>
       </div>
 
       <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: '0.375rem' }}>
@@ -143,6 +171,44 @@ export function KitchenOrderCard({ order }: KitchenOrderCardProps) {
           </li>
         ))}
       </ul>
+
+      {(nextStatuses.length > 0 || advanceError) && (
+        <footer style={{ marginTop: 'auto', display: 'grid', gap: '0.5rem' }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {nextStatuses.map((status) => (
+              <button
+                key={status.id}
+                type="button"
+                data-testid="kitchen-advance-button"
+                disabled={isAdvancing || onAdvance === undefined}
+                onClick={() => onAdvance?.(status.id)}
+                style={{
+                  flex: '1 1 auto',
+                  padding: '0.625rem 0.75rem',
+                  background: status.colorHex ?? '#111827',
+                  color: '#ffffff',
+                  border: 'none',
+                  borderRadius: '0.5rem',
+                  fontSize: '0.9375rem',
+                  fontWeight: 700,
+                  cursor: isAdvancing ? 'wait' : 'pointer',
+                  opacity: isAdvancing ? 0.6 : 1,
+                }}
+              >
+                {t('pos.kitchen.advanceTo', { status: status.name })}
+              </button>
+            ))}
+          </div>
+          {advanceError && (
+            <p
+              data-testid="kitchen-advance-error"
+              style={{ margin: 0, color: '#dc2626', fontSize: '0.8125rem', fontWeight: 600 }}
+            >
+              {t('pos.kitchen.advanceError')}
+            </p>
+          )}
+        </footer>
+      )}
     </article>
   );
 }

--- a/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
+++ b/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
@@ -1,7 +1,11 @@
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useActiveOrders } from '../hooks/useActiveOrders';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useActiveOrders, activeOrdersQueryKey } from '../hooks/useActiveOrders';
 import { KitchenOrderCard } from '../components/KitchenOrderCard';
+import { orderLifecycleApi } from '@api/orderLifecycle';
+import { ordersApi, type OrderStatusResponse } from '@api/orders';
 import type { ConnectionStatus } from '@api/useSignalR';
 
 const connectionColor: Record<ConnectionStatus, string> = {
@@ -21,11 +25,58 @@ export function KitchenDisplay() {
 
   const resolvedBrand = brandSlug ?? '';
   const resolvedShop = shopId ?? '';
+  const hasShop = resolvedBrand.length > 0 && resolvedShop.length > 0;
+
+  const queryClient = useQueryClient();
 
   const { orders, isLoading, isError, connectionStatus } = useActiveOrders(
     resolvedBrand,
     resolvedShop,
   );
+
+  // The shop's lifecycle drives which "advance" buttons each card shows. It rarely
+  // changes, so fetch it once and keep it warm for the kitchen session.
+  const lifecycleQuery = useQuery({
+    queryKey: ['order-lifecycle', resolvedBrand, resolvedShop],
+    queryFn: () => orderLifecycleApi.get(resolvedBrand, resolvedShop),
+    enabled: hasShop,
+    staleTime: 5 * 60_000,
+  });
+
+  // Map each status name → the statuses reachable from it (sorted by lifecycle order).
+  // Orders carry only the denormalised status name, so we key by name.
+  const nextStatusesByName = useMemo(() => {
+    const map = new Map<string, OrderStatusResponse[]>();
+    const lifecycle = lifecycleQuery.data;
+    if (!lifecycle) return map;
+
+    const byId = new Map(lifecycle.statuses.map((s) => [s.id, s]));
+    for (const status of lifecycle.statuses) {
+      const next = lifecycle.transitions
+        .filter((tr) => tr.fromStatusId === status.id)
+        .map((tr) => byId.get(tr.toStatusId))
+        .filter((s): s is OrderStatusResponse => s !== undefined)
+        .sort((a, b) => a.sortOrder - b.sortOrder);
+      map.set(status.name, next);
+    }
+    return map;
+  }, [lifecycleQuery.data]);
+
+  // Tracks which order's last advance attempt failed, so we surface the error on
+  // that specific card rather than globally.
+  const [failedOrderId, setFailedOrderId] = useState<string | null>(null);
+
+  const advanceMutation = useMutation({
+    mutationFn: ({ orderId, toStatusId }: { orderId: string; toStatusId: string }) =>
+      ordersApi.advanceStatus(resolvedBrand, resolvedShop, orderId, toStatusId),
+    onMutate: () => setFailedOrderId(null),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: activeOrdersQueryKey(resolvedBrand, resolvedShop),
+      });
+    },
+    onError: (_error, variables) => setFailedOrderId(variables.orderId),
+  });
 
   return (
     <main
@@ -115,7 +166,19 @@ export function KitchenDisplay() {
           data-testid="kitchen-order-grid"
         >
           {orders.map((order) => (
-            <KitchenOrderCard key={order.id} order={order} />
+            <KitchenOrderCard
+              key={order.id}
+              order={order}
+              nextStatuses={nextStatusesByName.get(order.statusName) ?? []}
+              onAdvance={(toStatusId) =>
+                advanceMutation.mutate({ orderId: order.id, toStatusId })
+              }
+              isAdvancing={
+                advanceMutation.isPending &&
+                advanceMutation.variables?.orderId === order.id
+              }
+              advanceError={failedOrderId === order.id}
+            />
           ))}
         </section>
       )}

--- a/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
+++ b/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Routes, Route } from 'react-router-dom';
 import { http, HttpResponse } from 'msw';
 
@@ -166,5 +167,48 @@ describe('KitchenDisplay', () => {
   it('renders the connection status indicator', async () => {
     renderPage();
     expect(await screen.findByTestId('kitchen-connection-status')).toBeInTheDocument();
+  });
+
+  it('renders an advance button per allowed next status and posts the transition on tap', async () => {
+    const advanceCalls: Array<{ orderId: string; toStatusId: string }> = [];
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({
+          orders: [makeOrder({ id: 'a', orderNumber: '0001' })],
+        }),
+      ),
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/order-lifecycle`, () =>
+        HttpResponse.json({
+          shopId,
+          statuses: [
+            { id: 's-placed', name: 'Placed', systemKey: 'placed', sortOrder: 0, isEnabled: true, isTerminal: false, colorHex: null },
+            { id: 's-prep', name: 'Preparing', systemKey: 'preparing', sortOrder: 1, isEnabled: true, isTerminal: false, colorHex: '#f59e0b' },
+          ],
+          transitions: [{ id: 't1', fromStatusId: 's-placed', toStatusId: 's-prep' }],
+        }),
+      ),
+      http.post(
+        `/api/brands/${brandSlug}/shops/${shopId}/orders/:orderId/status`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { toStatusId: string };
+          advanceCalls.push({ orderId: String(params.orderId), toStatusId: body.toStatusId });
+          return HttpResponse.json({
+            ...makeOrder({ id: 'a', orderNumber: '0001' }),
+            statusName: 'Preparing',
+          });
+        },
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const advanceBtn = await screen.findByTestId('kitchen-advance-button');
+    expect(advanceBtn).toHaveTextContent('Preparing');
+
+    await user.click(advanceBtn);
+
+    await waitFor(() => expect(advanceCalls).toHaveLength(1));
+    expect(advanceCalls[0]).toEqual({ orderId: 'a', toStatusId: 's-prep' });
   });
 });

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -113,6 +113,9 @@
       "customer": "Kunde: {{name}}",
       "table": "Tisch {{number}}",
       "timeSlot": "Zeitfenster: {{value}}",
+      "status": "Status: {{name}}",
+      "advanceTo": "→ {{status}}",
+      "advanceError": "Status konnte nicht aktualisiert werden. Bitte erneut versuchen.",
       "orderType": {
         "Pickup": "Abholung",
         "EatIn": "Vor Ort",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -113,6 +113,9 @@
       "customer": "Client : {{name}}",
       "table": "Table {{number}}",
       "timeSlot": "Créneau : {{value}}",
+      "status": "Statut : {{name}}",
+      "advanceTo": "→ {{status}}",
+      "advanceError": "Échec de la mise à jour du statut. Réessayez.",
       "orderType": {
         "Pickup": "À emporter",
         "EatIn": "Sur place",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -113,6 +113,9 @@
       "customer": "Klant: {{name}}",
       "table": "Tafel {{number}}",
       "timeSlot": "Tijdslot: {{value}}",
+      "status": "Status: {{name}}",
+      "advanceTo": "→ {{status}}",
+      "advanceError": "Status bijwerken mislukt. Probeer opnieuw.",
       "orderType": {
         "Pickup": "Afhalen",
         "EatIn": "Ter plaatse",


### PR DESCRIPTION
Closes #23.

Adds the production "advance order status" action for kitchen staff — the keystone that completes the order lifecycle loop. Replaces the dev-only `simulate-status-change` endpoint. The kitchen-display read path (US-FP-027), SignalR plumbing (US-FP-068), and the customer tracking page (US-FP-063) already existed; this wires the missing write path + UI.

## Changes

**Backend**
- `Order.AdvanceTo(newStatusName)` — updates status, raises `OrderStatusChangedEvent`.
- `OrderService.AdvanceOrderStatusAsync` — loads the order + shop `OrderLifecycleConfig`, validates the current→target transition is configured, then applies + persists (dispatches the event via Wolverine → SignalR).
- New endpoint `POST /api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}/status` (body `{ toStatusId }`). Maps not-found → 404, disallowed transition → 400.

**Frontend**
- `ordersApi.advanceStatus`.
- `KitchenDisplay` fetches the shop lifecycle, computes the allowed next statuses per order, and renders one advance button per transition + a current-status chip. Advancing fires a mutation that invalidates the active-orders query (SignalR also pushes).
- i18n keys (nl/fr/de).

**Also fixed (`fix(signalr)` commit):** real-time was broken app-wide — the BFF CSRF middleware (`5dd483f`) returned `403 csrf_required` on the SignalR negotiate POST because the client didn't send the `X-CSRF: 1` header the axios client uses. Added it to the hub negotiate, keeping CSRF protection intact. This restores live updates for the kitchen display, order tracking, and confirmation pages.

## Acceptance criteria (all verified live in-browser)
- [x] Kitchen display shows orders with items, modifiers, order type, and table number
- [x] Kitchen staff can tap to advance an order to the next status
- [x] Status change reflected in real time on the customer's tracking page (verified: kitchen advance → tracking stepper moved with no reload)
- [x] Status change triggers the notification pipeline (`OrderStatusChangedHandler` → SignalR; push notifications remain US-FP-057)

## Verification
- Frontend `pnpm build` clean (tsc strict); POS tests 45/45.
- Backend `dotnet build` 0 errors; 4 new TUnit integration tests pass (allowed→200, disallowed→400, unknown status→404, missing order→404).
- API smoke test against the seeded brand: Placed→Confirmed 200, Confirmed→Ready 400.
- Live: advanced an order on the kitchen display and watched the customer tracking page update in real time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)