### PR TITLE
feat(orders): print kitchen order tickets (US-FP-028)

### DIFF
--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -1,7 +1,7 @@
 # User Story Dependency Tree & Progress Tracker
 
 > Generated from [frietjes-platform.md](./extract-prd/user-stories/frietjes-platform.md)
-> Last updated: 2026-06-03 (statuses reconciled against GitHub issue acceptance criteria — see "Status Accuracy" below)
+> Last updated: 2026-06-04 (US-FP-023 + US-FP-071 verified done; online-channel cluster unblocked — see "Status Accuracy" below)
 
 ## Progress Legend
 
@@ -13,19 +13,23 @@
 
 ---
 
-## Status Accuracy & AC Verification (2026-06-03)
+## Status Accuracy & AC Verification (2026-06-04)
 
-> **Tracking caveat:** GitHub issues are *not* closed when work merges, and this tree had drifted. Statuses below were re-verified on 2026-06-03 by checking each open issue's **acceptance-criteria checklist** against the actual code (backend + frontend). Treat the issue tracker's open/closed state as unreliable on its own — verify against ACs.
+> **Tracking caveat:** GitHub issues are *not* closed when work merges, and this tree had drifted. Statuses below were re-verified by checking each open issue's **acceptance-criteria checklist** against the actual code (backend + frontend). Treat the issue tracker's open/closed state as unreliable on its own — verify against ACs.
 
-**⚠ Online-ordering journey has NO entry point (found 2026-06-03).** The storefront landing page (`Home.tsx`) is a stub — no shop list, no menu link. The menu only renders at `…/shops/{shopId}/menu` where `shopId` is a **database GUID**, and nothing in the storefront ever links there (only `CartDrawer`→`/checkout` and a checkout-empty redirect back). `shopId` is then carried through checkout/confirmation via `localStorage`/`sessionStorage` hacks (see the "For now" TODO in `OrderConfirmationPage.tsx`). **A real customer cannot reach the order flow.** Therefore **US-FP-016 / 038 / 058 / 063 are component-complete but NOT user-reachable** — downgraded from ✅ to 🚧; do NOT close their issues. Missing work: a storefront entry / shop-discovery page (list the brand's shops → link to menu), human-readable shop slugs instead of GUIDs, and `shopId` carried in the route rather than storage. **Now tracked as US-FP-071 (#127)** — a shop-selection page at `/{brand}/{lang}/shops` plus shop-slug-scoped storefront routes (`{shopSlug}/menu` → checkout/order), removing the localStorage shopId hack. This is the top-priority gap for the entire online channel.
+**✅ Online-ordering entry point RESOLVED (2026-06-04).** US-FP-071 (shop selection + shop-slug-scoped storefront routes) merged via **PR #128** and was runtime-verified. The storefront now has a real customer journey: `/{brand}/{lang}/shops` chooser → `{shopSlug}/menu` → checkout → payment → order tracking, with the localStorage `shopId` hack removed. This unblocks the cluster that was previously "component-complete but NOT user-reachable" — **US-FP-016 / 017 / 038 / 058 / 063 restored to ✅.** (Historical note: this gap was found 2026-06-03 — `Home.tsx` was a stub and the menu only rendered at a GUID-based route nothing linked to.)
 
-**Changed this session (2026-06-03):**
+**Changed 2026-06-04:**
+- **US-FP-071** → ✅ done. Shop chooser + shop-slug routes; FE/BE verified at runtime. PR #128 merged.
+- **US-FP-023** → ✅ done. Status-advance endpoint + kitchen-card button shipped (commit `adf18f2`); SignalR negotiate CSRF fix (`7fb5299`). The keystone is complete.
+- **US-FP-016 / 017 / 038 / 058 / 063** → ✅ — entry-point blocker resolved by 071; these were already component-complete.
+- **US-FP-028** → ✅ done. Per-shop `TicketPrinterEnabled` flag (admin toggle on ShopEdit); kitchen display auto-prints new orders via a hidden print iframe when enabled, plus a manual reprint button on every order card. Ticket carries order number, items+modifiers, type, table (eat-in), time slot (when present), timestamp.
+
+**Changed 2026-06-03:**
 - **US-FP-018** → ✅ done. Functionally complete; ticket-printer scope reclassified to US-FP-028. GitHub #18 closed.
-- **US-FP-017** → email + phone at checkout implemented and **build-verified** (working tree, uncommitted; migration `AddCustomerContactToOrder`). Its own ACs are now met, but it shares the entry-point blocker — stays 🚧 until US-FP-071 (#127) lands.
 
 **Partial (🚧) — specific remaining gaps:**
 - **US-FP-069** — per-endpoint RBAC not enforced (62 endpoints `AllowAnonymous`; roles only checked at the BFF proxy). ⚠ security hardening needed before production.
-- **US-FP-023** — keystone. SignalR/tracking plumbing all exists; missing only the status-advance endpoint + kitchen-card button (today just a dev-only Simulate endpoint).
 - **US-FP-024** — table-number capture + 21% VAT done; missing `Shop.IsEatInEnabled` gating + group-kitchen-cards-by-table.
 - **US-FP-037** — mock auth + BFF login work; customer self-registration not implemented.
 - **US-FP-039** — session timeout configurable; missing dynamic per-brand login UI, role-based redirect, failed-login errors.
@@ -122,10 +126,10 @@ Once brands + shops exist, these streams are **independent of each other**.
 |--------|-------|-------------|------------|
 | ✅ | **US-FP-046** | Apply Belgian VAT rates | 022 |
 | ✅ | **US-FP-068** | Real-time updates (SignalR/SSE) | — (infra, can start in L1) |
-| 🚧 | **US-FP-016** | Place an online order — ⚠ no storefront entry point (shop discovery missing) | 005, 006, 007, 014, 022, 046 |
-| 🚧 | **US-FP-071** | Shop selection + shop-scoped routes (`/shops` chooser → `{shopSlug}/menu` → checkout/order) — #127 — implemented on branch `feat/us-fp-071-shop-selection`; FE build verified, BE compiles (per review); runtime NOT yet verified | 002, 005 |
-| 🚧 | **US-FP-058** | Complete payment flow (mocked) — built but unreachable (blocked by 016 entry point) | 016 |
-| 🚧 | **US-FP-017** | Place an order as a guest | 016 |
+| ✅ | **US-FP-016** | Place an online order | 005, 006, 007, 014, 022, 046 |
+| ✅ | **US-FP-071** | Shop selection + shop-scoped routes (`/shops` chooser → `{shopSlug}/menu` → checkout/order) — #127 (PR #128), runtime-verified | 002, 005 |
+| ✅ | **US-FP-058** | Complete payment flow (mocked) | 016 |
+| ✅ | **US-FP-017** | Place an order as a guest | 016 |
 | ✅ | **US-FP-018** | Place an in-store order (POS) | 016 |
 
 ---
@@ -139,15 +143,15 @@ Once ordering works, these streams are **all independent**.
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
 | ✅ | **US-FP-027** | View order on kitchen display | 022, 068 |
-| 🚧 | **US-FP-023** | Update order status (kitchen) | 022, 027 |
-| ⬜ | **US-FP-028** | Print order ticket (incl. in-store POS ticket, reclassified from US-FP-018) | 022 |
+| ✅ | **US-FP-023** | Update order status (kitchen) | 022, 027 |
+| ✅ | **US-FP-028** | Print order ticket (incl. in-store POS ticket, reclassified from US-FP-018) | 022 |
 | ⬜ | **US-FP-026** | Configure order notifications | 022 |
 
 ### Stream F: Customer Experience
 
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
-| 🚧 | **US-FP-063** | Track current order status — built but unreachable (blocked by 016 entry point) | 022, 068 |
+| ✅ | **US-FP-063** | Track current order status | 022, 068 |
 | ⬜ | **US-FP-062** | View order history | 016, 037 |
 | 🚧 | **US-FP-024** | Eat-in ordering with table number | 016, 066 |
 | ⬜ | **US-FP-025** | QR code table ordering | 024, 065 |
@@ -225,7 +229,7 @@ Once ordering works, these streams are **all independent**.
 |--------|-------|-------------|------------|
 | 🚧 | **US-FP-060** | Platform admin dashboard | 001, reporting |
 | ⬜ | **US-FP-045** | View inventory signals | 012, 013 |
-| 🚧 | **US-FP-038** | Guest checkout (refinement) — built but unreachable (blocked by 016 entry point) | 017 |
+| ✅ | **US-FP-038** | Guest checkout (refinement) | 017 |
 
 ---
 
@@ -236,7 +240,7 @@ L0: [069🚧] → [061✅] → [001✅] → [070✅] → [004✅] → [002✅]
 
 L1: [A: Products✅]  [B: Auth/Staff🚧]  [C: Shop Config🚧]  [D: Branding✅]  ← 4 parallel
          │                │                  │
-L2: [046✅ VAT] [068✅ Realtime] → [016🚧 ⚠no entry point] → [058🚧 018✅ 017🚧]   ← ordering core
+L2: [046✅ VAT] [068✅ Realtime] → [071✅ entry] → [016✅ → 058✅ 018✅ 017✅]   ← ordering core ✅
                                         │
 L3: [E: Kitchen] [F: Customer] [G: Shop Mgmt] [H: Loyalty] [I: Reports]      ← 5 parallel
          │            │

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
@@ -10,7 +10,8 @@ public sealed record UpdateShopRequest(
     string Name,
     AddressRequest Address,
     string ContactEmail,
-    string? ContactPhone);
+    string? ContactPhone,
+    bool TicketPrinterEnabled);
 
 public sealed class UpdateShopRequestValidator : Validator<UpdateShopRequest>
 {
@@ -88,7 +89,8 @@ public sealed class UpdateShopEndpoint(IShopService shopService)
                     req.Address.PostalCode,
                     req.Address.Country),
                 req.ContactEmail,
-                req.ContactPhone);
+                req.ContactPhone,
+                req.TicketPrinterEnabled);
 
             var response = await shopService.UpdateShopAsync(req.Id, appRequest, ct);
 

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
@@ -11,7 +11,8 @@ public sealed record UpdateShopRequest(
     string Name,
     AddressRequest Address,
     string ContactEmail,
-    string? ContactPhone);
+    string? ContactPhone,
+    bool TicketPrinterEnabled);
 
 public sealed record AddressRequest(
     string Street,
@@ -35,6 +36,7 @@ public sealed record ShopResponse(
     string ContactEmail,
     string? ContactPhone,
     bool IsActive,
+    bool TicketPrinterEnabled,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);
 

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
@@ -30,7 +30,11 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
 
         var shop = await shopRepository.UpdateAsync(
             id,
-            s => s.UpdateMetadata(request.Name, address, request.ContactEmail, request.ContactPhone),
+            s =>
+            {
+                s.UpdateMetadata(request.Name, address, request.ContactEmail, request.ContactPhone);
+                s.SetTicketPrinterEnabled(request.TicketPrinterEnabled);
+            },
             cancellationToken);
 
         if (shop is null)
@@ -96,6 +100,7 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
             shop.ContactEmail,
             shop.ContactPhone,
             shop.IsActive,
+            shop.TicketPrinterEnabled,
             shop.CreatedAt,
             shop.UpdatedAt);
 

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Shop.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Shop.cs
@@ -24,6 +24,13 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
     /// </summary>
     public string TimeZoneId { get; private set; } = "Europe/Brussels";
 
+    /// <summary>
+    /// When true, new orders are automatically printed to the shop's ticket printer
+    /// on the kitchen display (US-FP-028). Off by default. Note: the kitchen display
+    /// device drives the actual browser print; this flag gates whether it does so.
+    /// </summary>
+    public bool TicketPrinterEnabled { get; private set; }
+
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
 
@@ -74,6 +81,18 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
         Address = address;
         ContactEmail = contactEmail;
         ContactPhone = contactPhone;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Enables or disables automatic ticket printing for new orders (US-FP-028).
+    /// </summary>
+    public void SetTicketPrinterEnabled(bool enabled)
+    {
+        if (TicketPrinterEnabled == enabled)
+            return;
+
+        TicketPrinterEnabled = enabled;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604052931_AddTicketPrinterEnabledToShop.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604052931_AddTicketPrinterEnabledToShop.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604052931_AddTicketPrinterEnabledToShop")]
+    partial class AddTicketPrinterEnabledToShop
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604052931_AddTicketPrinterEnabledToShop.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604052931_AddTicketPrinterEnabledToShop.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddTicketPrinterEnabledToShop : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "TicketPrinterEnabled",
+                table: "Shops",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TicketPrinterEnabled",
+                table: "Shops");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
@@ -115,6 +115,10 @@ public sealed class BrandDbSeeder(
                 _ => throw new InvalidOperationException($"Unknown seed slug: {slug}")
             };
 
+            // Demo: auto-print new orders so the kitchen ticket flow (US-FP-028) is visible
+            // out of the box. Toggle off per shop in admin if it gets noisy.
+            shop.SetTicketPrinterEnabled(true);
+
             await context.Shops.AddAsync(shop, cancellationToken);
             logger.LogInformation("Seed: Created shop '{Name}' (slug: {Slug}).", shop.Name, shop.Slug);
         }

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopConfiguration.cs
@@ -39,6 +39,10 @@ public sealed class ShopConfiguration : IEntityTypeConfiguration<Shop>
             .HasMaxLength(100)
             .HasDefaultValue("Europe/Brussels");
 
+        builder.Property(s => s.TicketPrinterEnabled)
+            .IsRequired()
+            .HasDefaultValue(false);
+
         builder.Property(s => s.CreatedAt)
             .IsRequired();
 

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/ShopTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/ShopTests.cs
@@ -111,6 +111,39 @@ public sealed class ShopTests
         await Assert.That(shop.ContactPhone).IsNull();
     }
 
+    // ── SetTicketPrinterEnabled ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task Create_TicketPrinterEnabled_DefaultsToFalse()
+    {
+        var shop = CreateValidShop();
+
+        await Assert.That(shop.TicketPrinterEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task SetTicketPrinterEnabled_True_EnablesAndBumpsUpdatedAt()
+    {
+        var shop = CreateValidShop();
+        var originalUpdatedAt = shop.UpdatedAt;
+
+        shop.SetTicketPrinterEnabled(true);
+
+        await Assert.That(shop.TicketPrinterEnabled).IsTrue();
+        await Assert.That(shop.UpdatedAt).IsGreaterThanOrEqualTo(originalUpdatedAt);
+    }
+
+    [Test]
+    public async Task SetTicketPrinterEnabled_CanToggleBackToFalse()
+    {
+        var shop = CreateValidShop();
+        shop.SetTicketPrinterEnabled(true);
+
+        shop.SetTicketPrinterEnabled(false);
+
+        await Assert.That(shop.TicketPrinterEnabled).IsFalse();
+    }
+
     // ── Deactivate ────────────────────────────────────────────────────────────
 
     [Test]

--- a/src/frontend/src/api/__tests__/shops.test.ts
+++ b/src/frontend/src/api/__tests__/shops.test.ts
@@ -77,6 +77,7 @@ describe('shopsApi', () => {
         name: 'Gent Centrum Updated',
         address: SHOP_ADDRESS,
         contactEmail: 'gent-updated@frietjes.be',
+        ticketPrinterEnabled: false,
       });
 
       expect(shop).toMatchObject({ name: 'Gent Centrum Updated' });

--- a/src/frontend/src/api/shops.ts
+++ b/src/frontend/src/api/shops.ts
@@ -42,6 +42,8 @@ export interface UpdateShopRequest {
   };
   contactEmail: string;
   contactPhone?: string;
+  /** Auto-print new orders on the kitchen display (US-FP-028). */
+  ticketPrinterEnabled: boolean;
 }
 
 /**

--- a/src/frontend/src/features/admin/pages/ShopEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ShopEdit.tsx
@@ -41,6 +41,7 @@ export function ShopEdit() {
       address: { street: '', number: '', city: '', postalCode: '', country: 'BE' },
       contactEmail: '',
       contactPhone: '',
+      ticketPrinterEnabled: false,
     },
     toFormValues: (shop) => ({
       name: shop.name,
@@ -53,6 +54,7 @@ export function ShopEdit() {
       },
       contactEmail: shop.contactEmail,
       contactPhone: shop.contactPhone ?? '',
+      ticketPrinterEnabled: shop.ticketPrinterEnabled,
     }),
     toUpdatePayload: (values) => ({
       name: values.name.trim(),
@@ -64,6 +66,7 @@ export function ShopEdit() {
         country: values.address.country.trim() || 'BE',
       },
       contactEmail: values.contactEmail.trim(),
+      ticketPrinterEnabled: values.ticketPrinterEnabled,
       ...(values.contactPhone.trim().length > 0
         ? { contactPhone: values.contactPhone.trim() }
         : {}),
@@ -258,6 +261,30 @@ export function ShopEdit() {
             {...register('contactPhone')}
             style={inputStyle(false)}
           />
+        </div>
+
+        {/* Order settings */}
+        <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.75rem', marginTop: '1.5rem' }}>
+          Order settings
+        </p>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label
+            htmlFor="ticketPrinterEnabled"
+            style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: 'pointer' }}
+          >
+            <input
+              id="ticketPrinterEnabled"
+              type="checkbox"
+              {...register('ticketPrinterEnabled')}
+              style={{ marginTop: '0.2rem', width: '1rem', height: '1rem' }}
+            />
+            <span>
+              <span style={{ fontWeight: 500 }}>Auto-print order tickets</span>
+              <span style={{ display: 'block', fontSize: '0.75rem', color: '#6b7280', marginTop: '0.125rem' }}>
+                New orders print automatically on the kitchen display. Staff can also reprint any ticket manually.
+              </span>
+            </span>
+          </label>
         </div>
 
         {/* Quick links to shop config pages */}

--- a/src/frontend/src/features/admin/pages/__tests__/ShopEdit.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ShopEdit.test.tsx
@@ -27,6 +27,7 @@ const mockShop = {
   contactEmail: 'gent@frietjes.be',
   contactPhone: null,
   isActive: true,
+  ticketPrinterEnabled: false,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
 };
@@ -111,6 +112,30 @@ describe('ShopEdit', () => {
       name: 'Frietjes Gent Updated',
       address: expect.objectContaining({ city: 'Gent' }),
     });
+  });
+
+  it('toggles the ticket-printer setting and includes it in the payload', async () => {
+    const user = userEvent.setup();
+
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.put('/api/brands/:brandSlug/shops/:id', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ ...mockShop, ticketPrinterEnabled: true });
+      }),
+    );
+
+    renderPage();
+
+    const printerToggle = await screen.findByLabelText(/auto-print order tickets/i);
+    expect(printerToggle).not.toBeChecked();
+    await user.click(printerToggle);
+    expect(printerToggle).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+    expect(capturedBody).toMatchObject({ ticketPrinterEnabled: true });
   });
 
   it('shows a validation error when name is cleared', async () => {

--- a/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
+++ b/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
@@ -11,6 +11,7 @@ export const shopEditSchema = z.object({
   }),
   contactEmail: z.string().email({ message: 'Enter a valid email address.' }),
   contactPhone: z.string(),
+  ticketPrinterEnabled: z.boolean(),
 });
 
 export type ShopEditFormValues = z.infer<typeof shopEditSchema>;

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -11,6 +11,8 @@ interface KitchenOrderCardProps {
   isAdvancing?: boolean;
   /** True when the last advance attempt for this order failed. */
   advanceError?: boolean;
+  /** Called when staff taps "print ticket" — reprints this order's kitchen ticket (US-FP-028). */
+  onReprint?: () => void;
 }
 
 const orderTypeColor: Record<OrderType, string> = {
@@ -39,6 +41,7 @@ export function KitchenOrderCard({
   onAdvance,
   isAdvancing = false,
   advanceError = false,
+  onReprint,
 }: KitchenOrderCardProps) {
   const { t } = useTranslation('common');
   const typeLabel = t(`pos.kitchen.orderType.${order.orderType}`);
@@ -71,9 +74,32 @@ export function KitchenOrderCard({
         }}
       >
         <h2 style={{ fontSize: '1.75rem', fontWeight: 800, margin: 0 }}>#{order.orderNumber}</h2>
-        <div style={{ fontSize: '0.875rem', color: '#6b7280', textAlign: 'right' }}>
-          <div style={{ fontWeight: 600 }}>{formatRelative(order.createdAt, now)}</div>
-          <div>{formatTime(order.createdAt)}</div>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+          <div style={{ fontSize: '0.875rem', color: '#6b7280', textAlign: 'right' }}>
+            <div style={{ fontWeight: 600 }}>{formatRelative(order.createdAt, now)}</div>
+            <div>{formatTime(order.createdAt)}</div>
+          </div>
+          {onReprint && (
+            <button
+              type="button"
+              data-testid="kitchen-reprint-button"
+              onClick={onReprint}
+              title={t('pos.kitchen.reprint')}
+              aria-label={t('pos.kitchen.reprint')}
+              style={{
+                padding: '0.25rem 0.5rem',
+                background: '#f3f4f6',
+                color: '#374151',
+                border: '1px solid #d1d5db',
+                borderRadius: '0.375rem',
+                fontSize: '1rem',
+                lineHeight: 1,
+                cursor: 'pointer',
+              }}
+            >
+              🖨
+            </button>
+          )}
         </div>
       </header>
 

--- a/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
+++ b/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
@@ -1,11 +1,13 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useActiveOrders, activeOrdersQueryKey } from '../hooks/useActiveOrders';
 import { KitchenOrderCard } from '../components/KitchenOrderCard';
+import { printTicket } from '../utils/printTicket';
 import { orderLifecycleApi } from '@api/orderLifecycle';
-import { ordersApi, type OrderStatusResponse } from '@api/orders';
+import { ordersApi, type OrderResponse, type OrderStatusResponse } from '@api/orders';
+import { shopsApi } from '@api/shops';
 import type { ConnectionStatus } from '@api/useSignalR';
 
 const connectionColor: Record<ConnectionStatus, string> = {
@@ -42,6 +44,49 @@ export function KitchenDisplay() {
     enabled: hasShop,
     staleTime: 5 * 60_000,
   });
+
+  // The shop's ticket-printer setting gates auto-printing (US-FP-028).
+  const shopQuery = useQuery({
+    queryKey: ['shop', resolvedBrand, resolvedShop],
+    queryFn: () => shopsApi.get(resolvedBrand, resolvedShop),
+    enabled: hasShop,
+    staleTime: 5 * 60_000,
+  });
+  const autoPrintEnabled = shopQuery.data?.ticketPrinterEnabled === true;
+
+  // Reprints (and auto-prints) a single order's kitchen ticket via a hidden iframe.
+  const printOrder = useCallback(
+    (order: OrderResponse) => {
+      printTicket(order, {
+        heading: t('pos.kitchen.ticket.heading'),
+        orderType: t(`pos.kitchen.orderType.${order.orderType}`),
+        table: t('pos.kitchen.ticket.table'),
+        timeSlot: t('pos.kitchen.ticket.timeSlot'),
+        placedAt: t('pos.kitchen.ticket.placedAt'),
+        customer: t('pos.kitchen.ticket.customer'),
+      });
+    },
+    [t],
+  );
+
+  // Auto-print orders that appear after the initial load. The first successful
+  // fetch only seeds the "seen" set so we never reprint the existing backlog;
+  // thereafter any newly-arriving order prints once when the setting is enabled.
+  const seenOrderIds = useRef<Set<string>>(new Set());
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (orders === undefined) return;
+    if (!seeded.current) {
+      seenOrderIds.current = new Set(orders.map((o) => o.id));
+      seeded.current = true;
+      return;
+    }
+    for (const order of orders) {
+      if (seenOrderIds.current.has(order.id)) continue;
+      seenOrderIds.current.add(order.id);
+      if (autoPrintEnabled) printOrder(order);
+    }
+  }, [orders, autoPrintEnabled, printOrder]);
 
   // Map each status name → the statuses reachable from it (sorted by lifecycle order).
   // Orders carry only the denormalised status name, so we key by name.
@@ -178,6 +223,7 @@ export function KitchenDisplay() {
                 advanceMutation.variables?.orderId === order.id
               }
               advanceError={failedOrderId === order.id}
+              onReprint={() => printOrder(order)}
             />
           ))}
         </section>

--- a/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
+++ b/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
@@ -9,16 +9,42 @@ import { server } from '../../../../test/msw/server';
 import '../../../../i18n/config';
 
 // The SignalR hub is exercised end-to-end elsewhere — for the kitchen page we mock
-// it so the test never touches a real WebSocket. Keep this mock at module-top so it
-// applies before the component imports it.
+// it so the test never touches a real WebSocket. We capture the onStatusChange
+// callback so a test can simulate a new order arriving over the hub.
+let triggerStatusChange: (() => void) | undefined;
 vi.mock('../../../../api/useOrderUpdates', () => ({
-  useOrderUpdates: () => ({ status: 'connected' as const }),
+  useOrderUpdates: (opts: { onStatusChange?: () => void }) => {
+    triggerStatusChange = opts.onStatusChange;
+    return { status: 'connected' as const };
+  },
 }));
 
+// printTicket drives a real iframe + window.print(), neither of which exist in
+// jsdom — mock it so we can assert *what* would print without side effects.
+vi.mock('../../utils/printTicket', () => ({ printTicket: vi.fn() }));
+
 import { KitchenDisplay } from '../KitchenDisplay';
+import { printTicket } from '../../utils/printTicket';
+
+const printTicketMock = vi.mocked(printTicket);
 
 const brandSlug = 'frietjes';
 const shopId = '00000000-0000-0000-0000-000000000001';
+
+function shopResponse(ticketPrinterEnabled: boolean) {
+  return {
+    id: shopId,
+    name: 'Frietjes Gent',
+    slug: 'frietjes-gent',
+    address: { street: 'Veldstraat', number: '42', city: 'Gent', postalCode: '9000', country: 'BE' },
+    contactEmail: 'gent@frietjes.be',
+    contactPhone: null,
+    isActive: true,
+    ticketPrinterEnabled,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  };
+}
 
 function makeOrder(overrides: Partial<{
   id: string;
@@ -78,9 +104,15 @@ function renderPage() {
 
 describe('KitchenDisplay', () => {
   beforeEach(() => {
+    triggerStatusChange = undefined;
+    printTicketMock.mockClear();
     server.use(
       http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
         HttpResponse.json({ orders: [] }),
+      ),
+      // Ticket printing off by default so most tests never trigger auto-print.
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
+        HttpResponse.json(shopResponse(false)),
       ),
     );
   });
@@ -210,5 +242,65 @@ describe('KitchenDisplay', () => {
 
     await waitFor(() => expect(advanceCalls).toHaveLength(1));
     expect(advanceCalls[0]).toEqual({ orderId: 'a', toStatusId: 's-prep' });
+  });
+
+  it('reprints a ticket when the print button on a card is tapped', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({ orders: [makeOrder({ id: 'a', orderNumber: '0001' })] }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const reprintBtn = await screen.findByTestId('kitchen-reprint-button');
+    await user.click(reprintBtn);
+
+    expect(printTicketMock).toHaveBeenCalledTimes(1);
+    expect(printTicketMock.mock.calls[0]![0]).toMatchObject({ id: 'a', orderNumber: '0001' });
+  });
+
+  it('auto-prints a newly arrived order when ticket printing is enabled', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
+        HttpResponse.json(shopResponse(true)),
+      ),
+    );
+
+    renderPage();
+
+    // Initial load is empty — seeds the "seen" set without printing.
+    await screen.findByTestId('kitchen-empty');
+    expect(printTicketMock).not.toHaveBeenCalled();
+
+    // A new order arrives; the next refetch (triggered by the hub) returns it.
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({ orders: [makeOrder({ id: 'new-1', orderNumber: '0042' })] }),
+      ),
+    );
+    triggerStatusChange?.();
+
+    await waitFor(() => expect(printTicketMock).toHaveBeenCalledTimes(1));
+    expect(printTicketMock.mock.calls[0]![0]).toMatchObject({ id: 'new-1', orderNumber: '0042' });
+  });
+
+  it('does not auto-print the existing backlog on first load', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
+        HttpResponse.json(shopResponse(true)),
+      ),
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({ orders: [makeOrder({ id: 'a', orderNumber: '0001' })] }),
+      ),
+    );
+
+    renderPage();
+
+    await screen.findByTestId('kitchen-order-card');
+    // Give the auto-print effect a chance to (incorrectly) fire.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(printTicketMock).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/features/pos/utils/__tests__/printTicket.test.ts
+++ b/src/frontend/src/features/pos/utils/__tests__/printTicket.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { buildTicketHtml, type TicketLabels } from '../printTicket';
+import type { OrderResponse } from '@api/orders';
+
+const labels: TicketLabels = {
+  heading: 'Order ticket',
+  orderType: 'Eat-in',
+  table: 'Table',
+  timeSlot: 'Time slot',
+  placedAt: 'Placed',
+  customer: 'Customer',
+};
+
+function makeOrder(overrides: Partial<OrderResponse> = {}): OrderResponse {
+  return {
+    id: 'order-1',
+    orderNumber: '0042',
+    shopId: 'shop-1',
+    brandSlug: 'frietjes',
+    orderType: 'EatIn',
+    statusName: 'Placed',
+    customerName: null,
+    items: [
+      {
+        productId: 'p1',
+        productName: 'Frietje Speciaal',
+        quantity: 2,
+        unitGrossPrice: 3.5,
+        unitNetPrice: 3.3,
+        unitVatAmount: 0.2,
+        lineTotal: 7,
+        selectedModifiers: [
+          { modifierId: 'm1', modifierName: 'Extra mayo', priceAdjustment: 0 },
+        ],
+      },
+    ],
+    vatRatePercent: 21,
+    subtotalGross: 7,
+    totalVatAmount: 1.2,
+    totalNet: 5.8,
+    totalGross: 7,
+    createdAt: '2026-06-04T10:15:00Z',
+    paymentMethod: 'CashAtPickup',
+    ...overrides,
+  };
+}
+
+describe('buildTicketHtml', () => {
+  it('includes the order number, items, quantities, and modifiers', () => {
+    const html = buildTicketHtml(makeOrder(), labels);
+    expect(html).toContain('#0042');
+    expect(html).toContain('Frietje Speciaal');
+    expect(html).toContain('2×');
+    expect(html).toContain('+ Extra mayo');
+  });
+
+  it('includes the order type and a timestamp', () => {
+    const html = buildTicketHtml(makeOrder(), labels);
+    expect(html).toContain('Eat-in');
+    expect(html).toContain('Placed:');
+  });
+
+  it('renders the table number only for orders that have one', () => {
+    expect(buildTicketHtml(makeOrder({ tableNumber: 5 }), labels)).toContain('Table: 5');
+    // Default order omits tableNumber entirely (Pickup-style).
+    expect(buildTicketHtml(makeOrder(), labels)).not.toContain('Table:');
+  });
+
+  it('renders the time slot only when present', () => {
+    expect(buildTicketHtml(makeOrder({ timeSlot: '18:30' }), labels)).toContain('Time slot: 18:30');
+    expect(buildTicketHtml(makeOrder({ timeSlot: null }), labels)).not.toContain('Time slot:');
+  });
+
+  it('renders the customer name when present', () => {
+    expect(buildTicketHtml(makeOrder({ customerName: 'Alice' }), labels)).toContain('Customer: Alice');
+  });
+
+  it('escapes HTML in user-controlled fields to prevent markup injection', () => {
+    const html = buildTicketHtml(
+      makeOrder({ customerName: '<script>alert(1)</script>' }),
+      labels,
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/src/frontend/src/features/pos/utils/printTicket.ts
+++ b/src/frontend/src/features/pos/utils/printTicket.ts
@@ -1,0 +1,156 @@
+import type { OrderResponse } from '@api/orders';
+
+/**
+ * Localised, pre-resolved labels for the printed ticket. Kept caller-supplied so
+ * the print utility stays i18n-agnostic and easy to unit test.
+ */
+export interface TicketLabels {
+  /** Heading printed at the top of the ticket, e.g. "Order ticket". */
+  heading: string;
+  /** Resolved order-type text, e.g. "Eat-in" / "Afhalen". */
+  orderType: string;
+  /** Label preceding the table number, e.g. "Table". */
+  table: string;
+  /** Label preceding the time slot, e.g. "Time slot". */
+  timeSlot: string;
+  /** Label preceding the timestamp, e.g. "Placed". */
+  placedAt: string;
+  /** Label preceding the customer name, e.g. "Customer". */
+  customer: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Builds a self-contained HTML document for an order ticket, styled for a
+ * narrow (~72mm) thermal/kitchen printer. Pure function — returned markup is
+ * what gets written to the print iframe (US-FP-028).
+ *
+ * Includes order number, items with modifiers, order type, table number
+ * (eat-in only), time slot (when present), and the order timestamp.
+ */
+export function buildTicketHtml(order: OrderResponse, labels: TicketLabels): string {
+  const placed = new Date(order.createdAt);
+  const placedText = Number.isNaN(placed.getTime())
+    ? order.createdAt
+    : placed.toLocaleString('nl-BE', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+
+  const metaRows: string[] = [`<div class="meta">${escapeHtml(labels.orderType)}</div>`];
+
+  if (order.tableNumber != null) {
+    metaRows.push(
+      `<div class="meta">${escapeHtml(labels.table)}: ${escapeHtml(String(order.tableNumber))}</div>`,
+    );
+  }
+  if (order.timeSlot != null && order.timeSlot.length > 0) {
+    metaRows.push(
+      `<div class="meta">${escapeHtml(labels.timeSlot)}: ${escapeHtml(order.timeSlot)}</div>`,
+    );
+  }
+  if (order.customerName != null && order.customerName.length > 0) {
+    metaRows.push(
+      `<div class="meta">${escapeHtml(labels.customer)}: ${escapeHtml(order.customerName)}</div>`,
+    );
+  }
+  metaRows.push(`<div class="meta">${escapeHtml(labels.placedAt)}: ${escapeHtml(placedText)}</div>`);
+
+  const itemRows = order.items
+    .map((item) => {
+      const modifiers = item.selectedModifiers
+        .map((m) => `<div class="mod">+ ${escapeHtml(m.modifierName)}</div>`)
+        .join('');
+      return `<li class="item">
+          <div class="item-line"><span class="qty">${item.quantity}×</span><span class="name">${escapeHtml(item.productName)}</span></div>
+          ${modifiers}
+        </li>`;
+    })
+    .join('');
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>${escapeHtml(labels.heading)} ${escapeHtml(order.orderNumber)}</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'Courier New', monospace; width: 72mm; padding: 4mm; color: #000; }
+  .heading { text-align: center; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; }
+  .number { text-align: center; font-size: 28px; font-weight: 700; margin: 2mm 0; }
+  .meta { font-size: 12px; }
+  hr { border: none; border-top: 1px dashed #000; margin: 3mm 0; }
+  ul { list-style: none; }
+  .item { margin-bottom: 2mm; }
+  .item-line { display: flex; gap: 2mm; font-size: 14px; font-weight: 700; }
+  .qty { min-width: 7mm; }
+  .mod { font-size: 12px; padding-left: 9mm; font-weight: 400; }
+  @page { margin: 0; }
+</style>
+</head>
+<body>
+  <div class="heading">${escapeHtml(labels.heading)}</div>
+  <div class="number">#${escapeHtml(order.orderNumber)}</div>
+  ${metaRows.join('\n  ')}
+  <hr />
+  <ul>${itemRows}</ul>
+</body>
+</html>`;
+}
+
+/**
+ * Prints an order ticket via a transient hidden iframe so the surrounding app
+ * UI is never affected by print styles. No-ops outside the browser (tests/SSR).
+ *
+ * Each call isolates one ticket, which lets the kitchen display queue several
+ * auto-prints without them bleeding into one another.
+ */
+export function printTicket(order: OrderResponse, labels: TicketLabels): void {
+  if (typeof document === 'undefined') return;
+
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('aria-hidden', 'true');
+  iframe.style.position = 'fixed';
+  iframe.style.right = '0';
+  iframe.style.bottom = '0';
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframe.style.border = '0';
+
+  iframe.addEventListener('load', () => {
+    const frameWindow = iframe.contentWindow;
+    if (frameWindow == null) {
+      iframe.remove();
+      return;
+    }
+    try {
+      frameWindow.focus();
+      frameWindow.print();
+    } finally {
+      // Give the print dialog time to grab the document before tearing it down.
+      window.setTimeout(() => iframe.remove(), 1000);
+    }
+  });
+
+  document.body.appendChild(iframe);
+
+  const doc = iframe.contentWindow?.document ?? iframe.contentDocument;
+  if (doc == null) {
+    iframe.remove();
+    return;
+  }
+  doc.open();
+  doc.write(buildTicketHtml(order, labels));
+  doc.close();
+}

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -116,10 +116,18 @@
       "status": "Status: {{name}}",
       "advanceTo": "→ {{status}}",
       "advanceError": "Status konnte nicht aktualisiert werden. Bitte erneut versuchen.",
+      "reprint": "Bon drucken",
       "orderType": {
         "Pickup": "Abholung",
         "EatIn": "Vor Ort",
         "Delivery": "Lieferung"
+      },
+      "ticket": {
+        "heading": "Bestellbon",
+        "table": "Tisch",
+        "timeSlot": "Zeitfenster",
+        "placedAt": "Aufgegeben",
+        "customer": "Kunde"
       },
       "connection": {
         "connected": "Live",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -116,10 +116,18 @@
       "status": "Statut : {{name}}",
       "advanceTo": "→ {{status}}",
       "advanceError": "Échec de la mise à jour du statut. Réessayez.",
+      "reprint": "Imprimer le ticket",
       "orderType": {
         "Pickup": "À emporter",
         "EatIn": "Sur place",
         "Delivery": "Livraison"
+      },
+      "ticket": {
+        "heading": "Ticket de commande",
+        "table": "Table",
+        "timeSlot": "Créneau",
+        "placedAt": "Passée le",
+        "customer": "Client"
       },
       "connection": {
         "connected": "En direct",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -116,10 +116,18 @@
       "status": "Status: {{name}}",
       "advanceTo": "→ {{status}}",
       "advanceError": "Status bijwerken mislukt. Probeer opnieuw.",
+      "reprint": "Bon afdrukken",
       "orderType": {
         "Pickup": "Afhalen",
         "EatIn": "Ter plaatse",
         "Delivery": "Bezorging"
+      },
+      "ticket": {
+        "heading": "Bestelbon",
+        "table": "Tafel",
+        "timeSlot": "Tijdslot",
+        "placedAt": "Geplaatst",
+        "customer": "Klant"
       },
       "connection": {
         "connected": "Live",

--- a/src/frontend/src/types/common.ts
+++ b/src/frontend/src/types/common.ts
@@ -76,6 +76,8 @@ export interface Shop {
   contactEmail: string;
   contactPhone: string | null;
   isActive: boolean;
+  /** When true, new orders auto-print on the kitchen display (US-FP-028). */
+  ticketPrinterEnabled: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## US-FP-028 — Print order ticket

Implements automatic + manual kitchen ticket printing.

### Acceptance criteria
- [x] When ticket printing is enabled, new orders trigger automatic printing
- [x] Ticket includes order number, items with modifiers, order type, table number (eat-in), time slot (when present), timestamp
- [x] Counter Staff can manually reprint a ticket from the in-store interface

### What changed
**Backend**
- `Shop.TicketPrinterEnabled` (default off) + `SetTicketPrinterEnabled()`; EF config + brand-DB migration `AddTicketPrinterEnabledToShop`
- Threaded through `ShopResponse`, `UpdateShopRequest`, `ShopService`, `UpdateShopEndpoint`
- Seeder enables it for dev shops on fresh databases

**Frontend**
- Admin ShopEdit: "Auto-print order tickets" toggle
- `printTicket.ts`: pure, HTML-escaped `buildTicketHtml()` (thermal-receipt layout) printed via a transient hidden iframe so app styles never interfere
- Kitchen display auto-prints newly arrived orders when enabled (seeds the existing backlog so history never reprints) + a 🖨 manual reprint button on every order card
- i18n keys for NL/FR/DE

### Verification
- Backend: Release build green; 25/25 Shop unit tests (3 new for the flag)
- Frontend: `tsc` + build clean; ticket-builder suite + kitchen auto-print/no-backlog/reprint tests + admin toggle test
- **Live full-stack check**: migration applied to SQL; admin toggle persists through the BFF (CSRF path); a real order auto-printed via SignalR; manual reprint fired — all confirmed against the running app

### Scope note
Server-side notification configuration more broadly remains US-FP-026; this PR adds only the per-shop printer toggle needed for US-FP-028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)