### PR TITLE
feat(orders): configure per-shop order notifications (US-FP-026)

### DIFF
--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -1,7 +1,7 @@
 # User Story Dependency Tree & Progress Tracker
 
 > Generated from [frietjes-platform.md](./extract-prd/user-stories/frietjes-platform.md)
-> Last updated: 2026-06-04 (US-FP-023 + US-FP-071 verified done; online-channel cluster unblocked — see "Status Accuracy" below)
+> Last updated: 2026-06-04 (US-FP-026 order notifications done; US-FP-023 + US-FP-071 verified done; online-channel cluster unblocked — see "Status Accuracy" below)
 
 ## Progress Legend
 
@@ -24,6 +24,7 @@
 - **US-FP-023** → ✅ done. Status-advance endpoint + kitchen-card button shipped (commit `adf18f2`); SignalR negotiate CSRF fix (`7fb5299`). The keystone is complete.
 - **US-FP-016 / 017 / 038 / 058 / 063** → ✅ — entry-point blocker resolved by 071; these were already component-complete.
 - **US-FP-028** → ✅ done. Per-shop `TicketPrinterEnabled` flag (admin toggle on ShopEdit); kitchen display auto-prints new orders via a hidden print iframe when enabled, plus a manual reprint button on every order card. Ticket carries order number, items+modifiers, type, table (eat-in), time slot (when present), timestamp.
+- **US-FP-026** → ✅ done. Per-shop notification settings extended to four independent channels — `KitchenDisplayEnabled` (new-order highlight on the board), `TicketPrinterEnabled` (US-FP-028), `PushNotificationEnabled` (browser Notification API), `SoundAlertEnabled` (Web Audio chime). Admin toggles on ShopEdit; all channels hook the kitchen display's single new-order detection loop, so both online and in-store orders fire them (AC4 — shared `OrderService.CreateOrderCoreAsync` → `OrderCreatedHandler` → SignalR). Sound/push are armed once via an "enable alerts" control (browser gesture/permission policy).
 
 **Changed 2026-06-03:**
 - **US-FP-018** → ✅ done. Functionally complete; ticket-printer scope reclassified to US-FP-028. GitHub #18 closed.
@@ -39,7 +40,7 @@
 - **US-FP-060** — brand CRUD done; missing shop-count metrics + true platform-level dashboard.
 - **US-FP-067** — custom-domain field stored; missing DNS instructions, SSL provisioning, host→brand routing.
 
-**Everything else not marked ✅/🚧 below is not started** (33 stories).
+**Everything else not marked ✅/🚧 below is not started** (32 stories).
 
 ---
 
@@ -145,7 +146,7 @@ Once ordering works, these streams are **all independent**.
 | ✅ | **US-FP-027** | View order on kitchen display | 022, 068 |
 | ✅ | **US-FP-023** | Update order status (kitchen) | 022, 027 |
 | ✅ | **US-FP-028** | Print order ticket (incl. in-store POS ticket, reclassified from US-FP-018) | 022 |
-| ⬜ | **US-FP-026** | Configure order notifications | 022 |
+| ✅ | **US-FP-026** | Configure order notifications | 022 |
 
 ### Stream F: Customer Experience
 

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
@@ -11,7 +11,10 @@ public sealed record UpdateShopRequest(
     AddressRequest Address,
     string ContactEmail,
     string? ContactPhone,
-    bool TicketPrinterEnabled);
+    bool KitchenDisplayEnabled,
+    bool TicketPrinterEnabled,
+    bool PushNotificationEnabled,
+    bool SoundAlertEnabled);
 
 public sealed class UpdateShopRequestValidator : Validator<UpdateShopRequest>
 {
@@ -90,7 +93,10 @@ public sealed class UpdateShopEndpoint(IShopService shopService)
                     req.Address.Country),
                 req.ContactEmail,
                 req.ContactPhone,
-                req.TicketPrinterEnabled);
+                req.KitchenDisplayEnabled,
+                req.TicketPrinterEnabled,
+                req.PushNotificationEnabled,
+                req.SoundAlertEnabled);
 
             var response = await shopService.UpdateShopAsync(req.Id, appRequest, ct);
 

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
@@ -12,7 +12,10 @@ public sealed record UpdateShopRequest(
     AddressRequest Address,
     string ContactEmail,
     string? ContactPhone,
-    bool TicketPrinterEnabled);
+    bool KitchenDisplayEnabled,
+    bool TicketPrinterEnabled,
+    bool PushNotificationEnabled,
+    bool SoundAlertEnabled);
 
 public sealed record AddressRequest(
     string Street,
@@ -36,7 +39,10 @@ public sealed record ShopResponse(
     string ContactEmail,
     string? ContactPhone,
     bool IsActive,
+    bool KitchenDisplayEnabled,
     bool TicketPrinterEnabled,
+    bool PushNotificationEnabled,
+    bool SoundAlertEnabled,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);
 

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
@@ -33,7 +33,10 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
             s =>
             {
                 s.UpdateMetadata(request.Name, address, request.ContactEmail, request.ContactPhone);
+                s.SetKitchenDisplayEnabled(request.KitchenDisplayEnabled);
                 s.SetTicketPrinterEnabled(request.TicketPrinterEnabled);
+                s.SetPushNotificationEnabled(request.PushNotificationEnabled);
+                s.SetSoundAlertEnabled(request.SoundAlertEnabled);
             },
             cancellationToken);
 
@@ -100,7 +103,10 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
             shop.ContactEmail,
             shop.ContactPhone,
             shop.IsActive,
+            shop.KitchenDisplayEnabled,
             shop.TicketPrinterEnabled,
+            shop.PushNotificationEnabled,
+            shop.SoundAlertEnabled,
             shop.CreatedAt,
             shop.UpdatedAt);
 

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Shop.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Shop.cs
@@ -25,11 +25,32 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
     public string TimeZoneId { get; private set; } = "Europe/Brussels";
 
     /// <summary>
+    /// When true, newly-arrived orders are highlighted on the kitchen display as a
+    /// visual notification (US-FP-026). Off by default. The board always lists orders
+    /// (US-FP-027); this flag only gates the new-order highlight notification.
+    /// </summary>
+    public bool KitchenDisplayEnabled { get; private set; }
+
+    /// <summary>
     /// When true, new orders are automatically printed to the shop's ticket printer
     /// on the kitchen display (US-FP-028). Off by default. Note: the kitchen display
     /// device drives the actual browser print; this flag gates whether it does so.
     /// </summary>
     public bool TicketPrinterEnabled { get; private set; }
+
+    /// <summary>
+    /// When true, the kitchen display raises a browser push notification for each new
+    /// order (US-FP-026). Off by default. The notification is surfaced by the display
+    /// device; this flag gates whether it does so.
+    /// </summary>
+    public bool PushNotificationEnabled { get; private set; }
+
+    /// <summary>
+    /// When true, the kitchen display plays a sound alert for each new order
+    /// (US-FP-026). Off by default. The display device plays the sound; this flag
+    /// gates whether it does so.
+    /// </summary>
+    public bool SoundAlertEnabled { get; private set; }
 
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
@@ -85,6 +106,18 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
     }
 
     /// <summary>
+    /// Enables or disables the new-order highlight on the kitchen display (US-FP-026).
+    /// </summary>
+    public void SetKitchenDisplayEnabled(bool enabled)
+    {
+        if (KitchenDisplayEnabled == enabled)
+            return;
+
+        KitchenDisplayEnabled = enabled;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
     /// Enables or disables automatic ticket printing for new orders (US-FP-028).
     /// </summary>
     public void SetTicketPrinterEnabled(bool enabled)
@@ -93,6 +126,30 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
             return;
 
         TicketPrinterEnabled = enabled;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Enables or disables browser push notifications for new orders (US-FP-026).
+    /// </summary>
+    public void SetPushNotificationEnabled(bool enabled)
+    {
+        if (PushNotificationEnabled == enabled)
+            return;
+
+        PushNotificationEnabled = enabled;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Enables or disables the sound alert for new orders (US-FP-026).
+    /// </summary>
+    public void SetSoundAlertEnabled(bool enabled)
+    {
+        if (SoundAlertEnabled == enabled)
+            return;
+
+        SoundAlertEnabled = enabled;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604061358_AddShopNotificationSettings.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604061358_AddShopNotificationSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604061358_AddShopNotificationSettings")]
+    partial class AddShopNotificationSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604061358_AddShopNotificationSettings.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604061358_AddShopNotificationSettings.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddShopNotificationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "KitchenDisplayEnabled",
+                table: "Shops",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PushNotificationEnabled",
+                table: "Shops",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "SoundAlertEnabled",
+                table: "Shops",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KitchenDisplayEnabled",
+                table: "Shops");
+
+            migrationBuilder.DropColumn(
+                name: "PushNotificationEnabled",
+                table: "Shops");
+
+            migrationBuilder.DropColumn(
+                name: "SoundAlertEnabled",
+                table: "Shops");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Seeding/BrandDbSeeder.cs
@@ -115,9 +115,13 @@ public sealed class BrandDbSeeder(
                 _ => throw new InvalidOperationException($"Unknown seed slug: {slug}")
             };
 
-            // Demo: auto-print new orders so the kitchen ticket flow (US-FP-028) is visible
-            // out of the box. Toggle off per shop in admin if it gets noisy.
+            // Demo: turn the order-notification channels on so the kitchen flows
+            // (US-FP-026 highlight/push/sound, US-FP-028 ticket print) are visible out of
+            // the box. Toggle off per shop in admin if any get noisy.
+            shop.SetKitchenDisplayEnabled(true);
             shop.SetTicketPrinterEnabled(true);
+            shop.SetPushNotificationEnabled(true);
+            shop.SetSoundAlertEnabled(true);
 
             await context.Shops.AddAsync(shop, cancellationToken);
             logger.LogInformation("Seed: Created shop '{Name}' (slug: {Slug}).", shop.Name, shop.Slug);

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopConfiguration.cs
@@ -39,7 +39,19 @@ public sealed class ShopConfiguration : IEntityTypeConfiguration<Shop>
             .HasMaxLength(100)
             .HasDefaultValue("Europe/Brussels");
 
+        builder.Property(s => s.KitchenDisplayEnabled)
+            .IsRequired()
+            .HasDefaultValue(false);
+
         builder.Property(s => s.TicketPrinterEnabled)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(s => s.PushNotificationEnabled)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(s => s.SoundAlertEnabled)
             .IsRequired()
             .HasDefaultValue(false);
 

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/ShopTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/ShopTests.cs
@@ -144,6 +144,103 @@ public sealed class ShopTests
         await Assert.That(shop.TicketPrinterEnabled).IsFalse();
     }
 
+    // ── Notification settings (US-FP-026) ───────────────────────────────────────
+
+    [Test]
+    public async Task Create_NotificationChannels_AllDefaultToFalse()
+    {
+        var shop = CreateValidShop();
+
+        await Assert.That(shop.KitchenDisplayEnabled).IsFalse();
+        await Assert.That(shop.TicketPrinterEnabled).IsFalse();
+        await Assert.That(shop.PushNotificationEnabled).IsFalse();
+        await Assert.That(shop.SoundAlertEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task SetKitchenDisplayEnabled_True_EnablesAndBumpsUpdatedAt()
+    {
+        var shop = CreateValidShop();
+        var originalUpdatedAt = shop.UpdatedAt;
+
+        shop.SetKitchenDisplayEnabled(true);
+
+        await Assert.That(shop.KitchenDisplayEnabled).IsTrue();
+        await Assert.That(shop.UpdatedAt).IsGreaterThanOrEqualTo(originalUpdatedAt);
+    }
+
+    [Test]
+    public async Task SetKitchenDisplayEnabled_CanToggleBackToFalse()
+    {
+        var shop = CreateValidShop();
+        shop.SetKitchenDisplayEnabled(true);
+
+        shop.SetKitchenDisplayEnabled(false);
+
+        await Assert.That(shop.KitchenDisplayEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task SetPushNotificationEnabled_True_EnablesAndBumpsUpdatedAt()
+    {
+        var shop = CreateValidShop();
+        var originalUpdatedAt = shop.UpdatedAt;
+
+        shop.SetPushNotificationEnabled(true);
+
+        await Assert.That(shop.PushNotificationEnabled).IsTrue();
+        await Assert.That(shop.UpdatedAt).IsGreaterThanOrEqualTo(originalUpdatedAt);
+    }
+
+    [Test]
+    public async Task SetPushNotificationEnabled_CanToggleBackToFalse()
+    {
+        var shop = CreateValidShop();
+        shop.SetPushNotificationEnabled(true);
+
+        shop.SetPushNotificationEnabled(false);
+
+        await Assert.That(shop.PushNotificationEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task SetSoundAlertEnabled_True_EnablesAndBumpsUpdatedAt()
+    {
+        var shop = CreateValidShop();
+        var originalUpdatedAt = shop.UpdatedAt;
+
+        shop.SetSoundAlertEnabled(true);
+
+        await Assert.That(shop.SoundAlertEnabled).IsTrue();
+        await Assert.That(shop.UpdatedAt).IsGreaterThanOrEqualTo(originalUpdatedAt);
+    }
+
+    [Test]
+    public async Task SetSoundAlertEnabled_CanToggleBackToFalse()
+    {
+        var shop = CreateValidShop();
+        shop.SetSoundAlertEnabled(true);
+
+        shop.SetSoundAlertEnabled(false);
+
+        await Assert.That(shop.SoundAlertEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task SetNotificationChannels_AreIndependent()
+    {
+        var shop = CreateValidShop();
+
+        shop.SetKitchenDisplayEnabled(true);
+        shop.SetSoundAlertEnabled(true);
+
+        // Only the two toggled channels flip; the others stay off (AC: independent + multiple at once).
+        await Assert.That(shop.KitchenDisplayEnabled).IsTrue();
+        await Assert.That(shop.SoundAlertEnabled).IsTrue();
+        await Assert.That(shop.TicketPrinterEnabled).IsFalse();
+        await Assert.That(shop.PushNotificationEnabled).IsFalse();
+    }
+
     // ── Deactivate ────────────────────────────────────────────────────────────
 
     [Test]

--- a/src/frontend/src/api/__tests__/shops.test.ts
+++ b/src/frontend/src/api/__tests__/shops.test.ts
@@ -77,7 +77,10 @@ describe('shopsApi', () => {
         name: 'Gent Centrum Updated',
         address: SHOP_ADDRESS,
         contactEmail: 'gent-updated@frietjes.be',
+        kitchenDisplayEnabled: false,
         ticketPrinterEnabled: false,
+        pushNotificationEnabled: false,
+        soundAlertEnabled: false,
       });
 
       expect(shop).toMatchObject({ name: 'Gent Centrum Updated' });

--- a/src/frontend/src/api/shops.ts
+++ b/src/frontend/src/api/shops.ts
@@ -42,8 +42,14 @@ export interface UpdateShopRequest {
   };
   contactEmail: string;
   contactPhone?: string;
+  /** Highlight new orders on the kitchen display (US-FP-026). */
+  kitchenDisplayEnabled: boolean;
   /** Auto-print new orders on the kitchen display (US-FP-028). */
   ticketPrinterEnabled: boolean;
+  /** Raise a browser push notification per new order (US-FP-026). */
+  pushNotificationEnabled: boolean;
+  /** Play a sound alert per new order (US-FP-026). */
+  soundAlertEnabled: boolean;
 }
 
 /**

--- a/src/frontend/src/features/admin/pages/ShopEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ShopEdit.tsx
@@ -41,7 +41,10 @@ export function ShopEdit() {
       address: { street: '', number: '', city: '', postalCode: '', country: 'BE' },
       contactEmail: '',
       contactPhone: '',
+      kitchenDisplayEnabled: false,
       ticketPrinterEnabled: false,
+      pushNotificationEnabled: false,
+      soundAlertEnabled: false,
     },
     toFormValues: (shop) => ({
       name: shop.name,
@@ -54,7 +57,10 @@ export function ShopEdit() {
       },
       contactEmail: shop.contactEmail,
       contactPhone: shop.contactPhone ?? '',
+      kitchenDisplayEnabled: shop.kitchenDisplayEnabled,
       ticketPrinterEnabled: shop.ticketPrinterEnabled,
+      pushNotificationEnabled: shop.pushNotificationEnabled,
+      soundAlertEnabled: shop.soundAlertEnabled,
     }),
     toUpdatePayload: (values) => ({
       name: values.name.trim(),
@@ -66,7 +72,10 @@ export function ShopEdit() {
         country: values.address.country.trim() || 'BE',
       },
       contactEmail: values.contactEmail.trim(),
+      kitchenDisplayEnabled: values.kitchenDisplayEnabled,
       ticketPrinterEnabled: values.ticketPrinterEnabled,
+      pushNotificationEnabled: values.pushNotificationEnabled,
+      soundAlertEnabled: values.soundAlertEnabled,
       ...(values.contactPhone.trim().length > 0
         ? { contactPhone: values.contactPhone.trim() }
         : {}),
@@ -263,10 +272,33 @@ export function ShopEdit() {
           />
         </div>
 
-        {/* Order settings */}
-        <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.75rem', marginTop: '1.5rem' }}>
-          Order settings
+        {/* Order notifications (US-FP-026) — independent per-shop channels */}
+        <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.25rem', marginTop: '1.5rem' }}>
+          Order notifications
         </p>
+        <p style={{ fontSize: '0.75rem', color: '#6b7280', marginBottom: '0.75rem' }}>
+          Choose how this shop is alerted to new orders. Any combination can be active, and both online and
+          in-store orders trigger the enabled methods.
+        </p>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label
+            htmlFor="kitchenDisplayEnabled"
+            style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: 'pointer' }}
+          >
+            <input
+              id="kitchenDisplayEnabled"
+              type="checkbox"
+              {...register('kitchenDisplayEnabled')}
+              style={{ marginTop: '0.2rem', width: '1rem', height: '1rem' }}
+            />
+            <span>
+              <span style={{ fontWeight: 500 }}>Highlight new orders on the kitchen display</span>
+              <span style={{ display: 'block', fontSize: '0.75rem', color: '#6b7280', marginTop: '0.125rem' }}>
+                Newly-arrived orders are briefly highlighted on the kitchen display screen.
+              </span>
+            </span>
+          </label>
+        </div>
         <div style={{ marginBottom: '0.5rem' }}>
           <label
             htmlFor="ticketPrinterEnabled"
@@ -282,6 +314,45 @@ export function ShopEdit() {
               <span style={{ fontWeight: 500 }}>Auto-print order tickets</span>
               <span style={{ display: 'block', fontSize: '0.75rem', color: '#6b7280', marginTop: '0.125rem' }}>
                 New orders print automatically on the kitchen display. Staff can also reprint any ticket manually.
+              </span>
+            </span>
+          </label>
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label
+            htmlFor="pushNotificationEnabled"
+            style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: 'pointer' }}
+          >
+            <input
+              id="pushNotificationEnabled"
+              type="checkbox"
+              {...register('pushNotificationEnabled')}
+              style={{ marginTop: '0.2rem', width: '1rem', height: '1rem' }}
+            />
+            <span>
+              <span style={{ fontWeight: 500 }}>Push notifications for new orders</span>
+              <span style={{ display: 'block', fontSize: '0.75rem', color: '#6b7280', marginTop: '0.125rem' }}>
+                The kitchen display shows a desktop notification when a new order arrives. Staff must allow
+                notifications in the browser.
+              </span>
+            </span>
+          </label>
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label
+            htmlFor="soundAlertEnabled"
+            style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: 'pointer' }}
+          >
+            <input
+              id="soundAlertEnabled"
+              type="checkbox"
+              {...register('soundAlertEnabled')}
+              style={{ marginTop: '0.2rem', width: '1rem', height: '1rem' }}
+            />
+            <span>
+              <span style={{ fontWeight: 500 }}>Sound alert for new orders</span>
+              <span style={{ display: 'block', fontSize: '0.75rem', color: '#6b7280', marginTop: '0.125rem' }}>
+                The kitchen display plays a chime when a new order arrives. Staff must enable sound on the display.
               </span>
             </span>
           </label>

--- a/src/frontend/src/features/admin/pages/__tests__/ShopEdit.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ShopEdit.test.tsx
@@ -27,7 +27,10 @@ const mockShop = {
   contactEmail: 'gent@frietjes.be',
   contactPhone: null,
   isActive: true,
+  kitchenDisplayEnabled: false,
   ticketPrinterEnabled: false,
+  pushNotificationEnabled: false,
+  soundAlertEnabled: false,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
 };
@@ -136,6 +139,48 @@ describe('ShopEdit', () => {
 
     await waitFor(() => expect(capturedBody).not.toBeNull());
     expect(capturedBody).toMatchObject({ ticketPrinterEnabled: true });
+  });
+
+  it('renders all four notification channel toggles', async () => {
+    renderPage();
+
+    expect(await screen.findByLabelText(/highlight new orders on the kitchen display/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/auto-print order tickets/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/push notifications for new orders/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sound alert for new orders/i)).toBeInTheDocument();
+  });
+
+  it('toggles the new notification channels independently and includes them in the payload', async () => {
+    const user = userEvent.setup();
+
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.put('/api/brands/:brandSlug/shops/:id', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(mockShop);
+      }),
+    );
+
+    renderPage();
+
+    // Enable kitchen-display highlight and sound, but leave push off — channels are independent.
+    const kitchenToggle = await screen.findByLabelText(/highlight new orders on the kitchen display/i);
+    const soundToggle = screen.getByLabelText(/sound alert for new orders/i);
+    await user.click(kitchenToggle);
+    await user.click(soundToggle);
+    expect(kitchenToggle).toBeChecked();
+    expect(soundToggle).toBeChecked();
+    expect(screen.getByLabelText(/push notifications for new orders/i)).not.toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+    expect(capturedBody).toMatchObject({
+      kitchenDisplayEnabled: true,
+      soundAlertEnabled: true,
+      pushNotificationEnabled: false,
+      ticketPrinterEnabled: false,
+    });
   });
 
   it('shows a validation error when name is cleared', async () => {

--- a/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
+++ b/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
@@ -11,7 +11,10 @@ export const shopEditSchema = z.object({
   }),
   contactEmail: z.string().email({ message: 'Enter a valid email address.' }),
   contactPhone: z.string(),
+  kitchenDisplayEnabled: z.boolean(),
   ticketPrinterEnabled: z.boolean(),
+  pushNotificationEnabled: z.boolean(),
+  soundAlertEnabled: z.boolean(),
 });
 
 export type ShopEditFormValues = z.infer<typeof shopEditSchema>;

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -13,6 +13,8 @@ interface KitchenOrderCardProps {
   advanceError?: boolean;
   /** Called when staff taps "print ticket" — reprints this order's kitchen ticket (US-FP-028). */
   onReprint?: () => void;
+  /** True to briefly highlight a newly-arrived order on the kitchen display (US-FP-026). */
+  highlight?: boolean;
 }
 
 const orderTypeColor: Record<OrderType, string> = {
@@ -42,6 +44,7 @@ export function KitchenOrderCard({
   isAdvancing = false,
   advanceError = false,
   onReprint,
+  highlight = false,
 }: KitchenOrderCardProps) {
   const { t } = useTranslation('common');
   const typeLabel = t(`pos.kitchen.orderType.${order.orderType}`);
@@ -53,15 +56,19 @@ export function KitchenOrderCard({
   return (
     <article
       data-testid="kitchen-order-card"
+      data-highlight={highlight ? 'true' : undefined}
       style={{
         display: 'flex',
         flexDirection: 'column',
         gap: '0.75rem',
         padding: '1rem',
-        background: '#ffffff',
+        background: highlight ? '#eff6ff' : '#ffffff',
         borderRadius: '0.75rem',
-        border: '1px solid #e5e7eb',
-        boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+        border: highlight ? '2px solid #2563eb' : '1px solid #e5e7eb',
+        boxShadow: highlight
+          ? '0 0 0 3px rgba(37,99,235,0.25)'
+          : '0 1px 2px rgba(0,0,0,0.05)',
+        transition: 'box-shadow 0.3s ease, border-color 0.3s ease, background 0.3s ease',
         minHeight: '12rem',
       }}
     >

--- a/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
+++ b/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
@@ -5,6 +5,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useActiveOrders, activeOrdersQueryKey } from '../hooks/useActiveOrders';
 import { KitchenOrderCard } from '../components/KitchenOrderCard';
 import { printTicket } from '../utils/printTicket';
+import { playNewOrderSound, primeAudioAlerts } from '../utils/playNewOrderSound';
+import {
+  notificationPermission,
+  requestNotificationPermission,
+  showNewOrderNotification,
+} from '../utils/notifyNewOrder';
 import { orderLifecycleApi } from '@api/orderLifecycle';
 import { ordersApi, type OrderResponse, type OrderStatusResponse } from '@api/orders';
 import { shopsApi } from '@api/shops';
@@ -16,6 +22,9 @@ const connectionColor: Record<ConnectionStatus, string> = {
   reconnecting: '#d97706',
   disconnected: '#dc2626',
 };
+
+// How long a newly-arrived order stays highlighted on the board (US-FP-026).
+const HIGHLIGHT_MS = 8000;
 
 export function KitchenDisplay() {
   const { t } = useTranslation('common');
@@ -45,14 +54,18 @@ export function KitchenDisplay() {
     staleTime: 5 * 60_000,
   });
 
-  // The shop's ticket-printer setting gates auto-printing (US-FP-028).
+  // The shop's notification settings gate each new-order channel (US-FP-026 /
+  // US-FP-028). Each is independent and any combination can be active at once.
   const shopQuery = useQuery({
     queryKey: ['shop', resolvedBrand, resolvedShop],
     queryFn: () => shopsApi.get(resolvedBrand, resolvedShop),
     enabled: hasShop,
     staleTime: 5 * 60_000,
   });
+  const highlightEnabled = shopQuery.data?.kitchenDisplayEnabled === true;
   const autoPrintEnabled = shopQuery.data?.ticketPrinterEnabled === true;
+  const pushEnabled = shopQuery.data?.pushNotificationEnabled === true;
+  const soundEnabled = shopQuery.data?.soundAlertEnabled === true;
 
   // Reprints (and auto-prints) a single order's kitchen ticket via a hidden iframe.
   const printOrder = useCallback(
@@ -69,9 +82,32 @@ export function KitchenDisplay() {
     [t],
   );
 
-  // Auto-print orders that appear after the initial load. The first successful
-  // fetch only seeds the "seen" set so we never reprint the existing backlog;
-  // thereafter any newly-arriving order prints once when the setting is enabled.
+  const notifyOrder = useCallback(
+    (order: OrderResponse) => {
+      showNewOrderNotification(
+        t('pos.kitchen.newOrderTitle'),
+        t('pos.kitchen.newOrderBody', { number: order.orderNumber }),
+        order.id,
+      );
+    },
+    [t],
+  );
+
+  // Newly-arrived order ids currently highlighted on the board (US-FP-026); each
+  // clears itself after HIGHLIGHT_MS. Timers are tracked so we can cancel on unmount.
+  const [highlightedIds, setHighlightedIds] = useState<Set<string>>(new Set());
+  const highlightTimers = useRef<Map<string, number>>(new Map());
+  useEffect(() => {
+    const timers = highlightTimers.current;
+    return () => {
+      for (const timer of timers.values()) window.clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
+
+  // React to orders that appear after the initial load. The first successful fetch
+  // only seeds the "seen" set so the existing backlog never triggers a reaction;
+  // thereafter each newly-arriving order fires every enabled channel exactly once.
   const seenOrderIds = useRef<Set<string>>(new Set());
   const seeded = useRef(false);
   useEffect(() => {
@@ -81,12 +117,50 @@ export function KitchenDisplay() {
       seeded.current = true;
       return;
     }
+    const arrived: OrderResponse[] = [];
     for (const order of orders) {
       if (seenOrderIds.current.has(order.id)) continue;
       seenOrderIds.current.add(order.id);
+      arrived.push(order);
       if (autoPrintEnabled) printOrder(order);
+      if (pushEnabled) notifyOrder(order);
     }
-  }, [orders, autoPrintEnabled, printOrder]);
+    if (arrived.length === 0) return;
+    // One chime per batch — several orders landing together shouldn't stack alarms.
+    if (soundEnabled) playNewOrderSound();
+    if (highlightEnabled) {
+      setHighlightedIds((prev) => {
+        const next = new Set(prev);
+        for (const order of arrived) next.add(order.id);
+        return next;
+      });
+      for (const order of arrived) {
+        const existing = highlightTimers.current.get(order.id);
+        if (existing !== undefined) window.clearTimeout(existing);
+        const timer = window.setTimeout(() => {
+          setHighlightedIds((prev) => {
+            if (!prev.has(order.id)) return prev;
+            const next = new Set(prev);
+            next.delete(order.id);
+            return next;
+          });
+          highlightTimers.current.delete(order.id);
+        }, HIGHLIGHT_MS);
+        highlightTimers.current.set(order.id, timer);
+      }
+    }
+  }, [orders, autoPrintEnabled, pushEnabled, soundEnabled, highlightEnabled, printOrder, notifyOrder]);
+
+  // Sound and push both need a user gesture (autoplay + permission policies), so
+  // staff arm them once via a header control before any auto-fired alert.
+  const [alertsArmed, setAlertsArmed] = useState(false);
+  const armAlerts = useCallback(async () => {
+    if (soundEnabled) primeAudioAlerts();
+    if (pushEnabled) await requestNotificationPermission();
+    setAlertsArmed(true);
+  }, [soundEnabled, pushEnabled]);
+  const needsArming =
+    !alertsArmed && (soundEnabled || (pushEnabled && notificationPermission() !== 'granted'));
 
   // Map each status name → the statuses reachable from it (sorted by lifecycle order).
   // Orders carry only the denormalised status name, so we key by name.
@@ -146,30 +220,51 @@ export function KitchenDisplay() {
         <h1 style={{ fontSize: '1.75rem', fontWeight: 800, margin: 0 }}>
           {t('pos.kitchen.title')}
         </h1>
-        <div
-          data-testid="kitchen-connection-status"
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-            padding: '0.375rem 0.75rem',
-            background: '#f3f4f6',
-            borderRadius: '999px',
-            fontSize: '0.8125rem',
-            fontWeight: 600,
-            color: '#374151',
-          }}
-        >
-          <span
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: '0.75rem' }}>
+          {needsArming && (
+            <button
+              type="button"
+              data-testid="kitchen-enable-alerts"
+              onClick={() => void armAlerts()}
+              style={{
+                padding: '0.375rem 0.875rem',
+                background: '#2563eb',
+                color: '#ffffff',
+                border: 'none',
+                borderRadius: '999px',
+                fontSize: '0.8125rem',
+                fontWeight: 700,
+                cursor: 'pointer',
+              }}
+            >
+              🔔 {t('pos.kitchen.enableAlerts')}
+            </button>
+          )}
+          <div
+            data-testid="kitchen-connection-status"
             style={{
-              width: '0.625rem',
-              height: '0.625rem',
-              borderRadius: '50%',
-              background: connectionColor[connectionStatus],
-              display: 'inline-block',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              padding: '0.375rem 0.75rem',
+              background: '#f3f4f6',
+              borderRadius: '999px',
+              fontSize: '0.8125rem',
+              fontWeight: 600,
+              color: '#374151',
             }}
-          />
-          {t(`pos.kitchen.connection.${connectionStatus}`)}
+          >
+            <span
+              style={{
+                width: '0.625rem',
+                height: '0.625rem',
+                borderRadius: '50%',
+                background: connectionColor[connectionStatus],
+                display: 'inline-block',
+              }}
+            />
+            {t(`pos.kitchen.connection.${connectionStatus}`)}
+          </div>
         </div>
       </header>
 
@@ -224,6 +319,7 @@ export function KitchenDisplay() {
               }
               advanceError={failedOrderId === order.id}
               onReprint={() => printOrder(order)}
+              highlight={highlightedIds.has(order.id)}
             />
           ))}
         </section>

--- a/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
+++ b/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
@@ -23,15 +23,40 @@ vi.mock('../../../../api/useOrderUpdates', () => ({
 // jsdom — mock it so we can assert *what* would print without side effects.
 vi.mock('../../utils/printTicket', () => ({ printTicket: vi.fn() }));
 
+// Sound + push utils touch the Web Audio / Notification APIs (absent in jsdom).
+// Mock them so we can assert each channel fires without real side effects.
+vi.mock('../../utils/playNewOrderSound', () => ({
+  playNewOrderSound: vi.fn(),
+  primeAudioAlerts: vi.fn(),
+}));
+vi.mock('../../utils/notifyNewOrder', () => ({
+  showNewOrderNotification: vi.fn(),
+  requestNotificationPermission: vi.fn().mockResolvedValue('granted'),
+  notificationPermission: () => 'default',
+}));
+
 import { KitchenDisplay } from '../KitchenDisplay';
 import { printTicket } from '../../utils/printTicket';
+import { playNewOrderSound, primeAudioAlerts } from '../../utils/playNewOrderSound';
+import { showNewOrderNotification, requestNotificationPermission } from '../../utils/notifyNewOrder';
 
 const printTicketMock = vi.mocked(printTicket);
+const playSoundMock = vi.mocked(playNewOrderSound);
+const primeAudioMock = vi.mocked(primeAudioAlerts);
+const showNotificationMock = vi.mocked(showNewOrderNotification);
+const requestPermissionMock = vi.mocked(requestNotificationPermission);
 
 const brandSlug = 'frietjes';
 const shopId = '00000000-0000-0000-0000-000000000001';
 
-function shopResponse(ticketPrinterEnabled: boolean) {
+function shopResponse(
+  channels: Partial<{
+    kitchenDisplayEnabled: boolean;
+    ticketPrinterEnabled: boolean;
+    pushNotificationEnabled: boolean;
+    soundAlertEnabled: boolean;
+  }> = {},
+) {
   return {
     id: shopId,
     name: 'Frietjes Gent',
@@ -40,7 +65,10 @@ function shopResponse(ticketPrinterEnabled: boolean) {
     contactEmail: 'gent@frietjes.be',
     contactPhone: null,
     isActive: true,
-    ticketPrinterEnabled,
+    kitchenDisplayEnabled: channels.kitchenDisplayEnabled ?? false,
+    ticketPrinterEnabled: channels.ticketPrinterEnabled ?? false,
+    pushNotificationEnabled: channels.pushNotificationEnabled ?? false,
+    soundAlertEnabled: channels.soundAlertEnabled ?? false,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
   };
@@ -106,13 +134,17 @@ describe('KitchenDisplay', () => {
   beforeEach(() => {
     triggerStatusChange = undefined;
     printTicketMock.mockClear();
+    playSoundMock.mockClear();
+    primeAudioMock.mockClear();
+    showNotificationMock.mockClear();
+    requestPermissionMock.mockClear();
     server.use(
       http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
         HttpResponse.json({ orders: [] }),
       ),
-      // Ticket printing off by default so most tests never trigger auto-print.
+      // All notification channels off by default so most tests never trigger one.
       http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
-        HttpResponse.json(shopResponse(false)),
+        HttpResponse.json(shopResponse()),
       ),
     );
   });
@@ -264,7 +296,7 @@ describe('KitchenDisplay', () => {
   it('auto-prints a newly arrived order when ticket printing is enabled', async () => {
     server.use(
       http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
-        HttpResponse.json(shopResponse(true)),
+        HttpResponse.json(shopResponse({ ticketPrinterEnabled: true })),
       ),
     );
 
@@ -289,7 +321,7 @@ describe('KitchenDisplay', () => {
   it('does not auto-print the existing backlog on first load', async () => {
     server.use(
       http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
-        HttpResponse.json(shopResponse(true)),
+        HttpResponse.json(shopResponse({ ticketPrinterEnabled: true })),
       ),
       http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
         HttpResponse.json({ orders: [makeOrder({ id: 'a', orderNumber: '0001' })] }),
@@ -302,5 +334,102 @@ describe('KitchenDisplay', () => {
     // Give the auto-print effect a chance to (incorrectly) fire.
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(printTicketMock).not.toHaveBeenCalled();
+  });
+
+  it('plays a sound and highlights a newly arrived order when those channels are enabled', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
+        HttpResponse.json(shopResponse({ soundAlertEnabled: true, kitchenDisplayEnabled: true })),
+      ),
+    );
+
+    renderPage();
+
+    // First load is empty — seeds the "seen" set without reacting.
+    await screen.findByTestId('kitchen-empty');
+    expect(playSoundMock).not.toHaveBeenCalled();
+
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({ orders: [makeOrder({ id: 'new-1', orderNumber: '0042' })] }),
+      ),
+    );
+    triggerStatusChange?.();
+
+    await waitFor(() => expect(playSoundMock).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('kitchen-order-card')).toHaveAttribute('data-highlight', 'true'),
+    );
+    // The other channels stay silent — only the enabled ones fire (independent toggles).
+    expect(printTicketMock).not.toHaveBeenCalled();
+    expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('raises a push notification for a newly arrived order when enabled', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
+        HttpResponse.json(shopResponse({ pushNotificationEnabled: true })),
+      ),
+    );
+
+    renderPage();
+    await screen.findByTestId('kitchen-empty');
+
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({ orders: [makeOrder({ id: 'new-2', orderNumber: '0099' })] }),
+      ),
+    );
+    triggerStatusChange?.();
+
+    await waitFor(() => expect(showNotificationMock).toHaveBeenCalledTimes(1));
+    // Notification carries a title, a body and the order id as the dedupe tag.
+    expect(showNotificationMock.mock.calls[0]![2]).toBe('new-2');
+  });
+
+  it('does not fire sound, push or highlight for the existing backlog on first load', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
+        HttpResponse.json(
+          shopResponse({
+            soundAlertEnabled: true,
+            pushNotificationEnabled: true,
+            kitchenDisplayEnabled: true,
+          }),
+        ),
+      ),
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}/orders/active`, () =>
+        HttpResponse.json({ orders: [makeOrder({ id: 'a', orderNumber: '0001' })] }),
+      ),
+    );
+
+    renderPage();
+
+    const card = await screen.findByTestId('kitchen-order-card');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(playSoundMock).not.toHaveBeenCalled();
+    expect(showNotificationMock).not.toHaveBeenCalled();
+    expect(card).not.toHaveAttribute('data-highlight', 'true');
+  });
+
+  it('arms sound and push from the enable-alerts control', async () => {
+    server.use(
+      http.get(`/api/brands/${brandSlug}/shops/${shopId}`, () =>
+        HttpResponse.json(shopResponse({ soundAlertEnabled: true, pushNotificationEnabled: true })),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const enableButton = await screen.findByTestId('kitchen-enable-alerts');
+    await user.click(enableButton);
+
+    expect(primeAudioMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(requestPermissionMock).toHaveBeenCalledTimes(1));
+    // Once armed, the control disappears.
+    await waitFor(() =>
+      expect(screen.queryByTestId('kitchen-enable-alerts')).not.toBeInTheDocument(),
+    );
   });
 });

--- a/src/frontend/src/features/pos/utils/__tests__/notifyNewOrder.test.ts
+++ b/src/frontend/src/features/pos/utils/__tests__/notifyNewOrder.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import {
+  notificationsSupported,
+  notificationPermission,
+  requestNotificationPermission,
+  showNewOrderNotification,
+} from '../notifyNewOrder';
+
+const PERMISSIONS = ['granted', 'denied', 'default'];
+
+// jsdom provides no Notification API. The invariants under test: the helpers
+// never throw and always return a sane permission value regardless of support.
+describe('notifyNewOrder', () => {
+  it('never throws and reports a valid permission', async () => {
+    expect(typeof notificationsSupported()).toBe('boolean');
+    expect(PERMISSIONS).toContain(notificationPermission());
+    const requested = await requestNotificationPermission();
+    expect(PERMISSIONS).toContain(requested);
+    expect(() => showNewOrderNotification('New order', '#0042', 'order-1')).not.toThrow();
+  });
+});

--- a/src/frontend/src/features/pos/utils/__tests__/playNewOrderSound.test.ts
+++ b/src/frontend/src/features/pos/utils/__tests__/playNewOrderSound.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { playNewOrderSound, primeAudioAlerts } from '../playNewOrderSound';
+
+// jsdom provides no Web Audio API, so these exercise the guard / no-op path.
+// The invariant under test: a missing AudioContext must never throw.
+describe('playNewOrderSound (no Web Audio API)', () => {
+  it('never throws when AudioContext is unavailable', () => {
+    expect(() => primeAudioAlerts()).not.toThrow();
+    expect(() => playNewOrderSound()).not.toThrow();
+  });
+});

--- a/src/frontend/src/features/pos/utils/notifyNewOrder.ts
+++ b/src/frontend/src/features/pos/utils/notifyNewOrder.ts
@@ -1,0 +1,45 @@
+/**
+ * Browser push-notification helpers for new kitchen orders (US-FP-026).
+ *
+ * Uses the basic Notification API (no service worker), so it works in dev and
+ * surfaces a desktop notification while the kitchen page is open — even when the
+ * tab is in the background. No-ops when the API is unavailable (tests/SSR) or
+ * permission hasn't been granted, and never throws.
+ */
+
+export function notificationsSupported(): boolean {
+  return typeof Notification !== 'undefined';
+}
+
+/** Current permission, or 'denied' when notifications are unsupported. */
+export function notificationPermission(): NotificationPermission {
+  return notificationsSupported() ? Notification.permission : 'denied';
+}
+
+/**
+ * Requests notification permission. Must be called from a user gesture — browsers
+ * ignore it otherwise. Resolves to the resulting permission, or 'denied' when
+ * unsupported.
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (!notificationsSupported()) return 'denied';
+  try {
+    return await Notification.requestPermission();
+  } catch {
+    return notificationPermission();
+  }
+}
+
+/**
+ * Shows a desktop notification for a new order. No-ops unless notifications are
+ * supported and permission has been granted. `tag` (the order id) dedupes repeat
+ * notifications for the same order.
+ */
+export function showNewOrderNotification(title: string, body: string, tag: string): void {
+  if (!notificationsSupported() || Notification.permission !== 'granted') return;
+  try {
+    void new Notification(title, { body, tag });
+  } catch {
+    // Ignore — a failed notification must never break the order board.
+  }
+}

--- a/src/frontend/src/features/pos/utils/playNewOrderSound.ts
+++ b/src/frontend/src/features/pos/utils/playNewOrderSound.ts
@@ -1,0 +1,78 @@
+/**
+ * Sound-alert helper for new kitchen orders (US-FP-026).
+ *
+ * Synthesises a short chime with the Web Audio API rather than shipping an audio
+ * asset, so there is nothing to license or bundle. No-ops when the Web Audio API
+ * is unavailable (tests/SSR/old browsers) and never throws — a failed chime must
+ * never break the order board.
+ */
+
+type AudioContextCtor = typeof AudioContext;
+
+// Created lazily and reused: kept module-level so the kitchen page can prime it
+// from a user gesture (browsers start the context suspended until then) and so a
+// burst of new orders never allocates more than one context.
+let sharedContext: AudioContext | null = null;
+
+function getAudioContextCtor(): AudioContextCtor | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const w = window as typeof window & { webkitAudioContext?: AudioContextCtor };
+  return w.AudioContext ?? w.webkitAudioContext;
+}
+
+function ensureContext(): AudioContext | null {
+  const Ctor = getAudioContextCtor();
+  if (Ctor === undefined) return null;
+  if (sharedContext === null) {
+    try {
+      sharedContext = new Ctor();
+    } catch {
+      return null;
+    }
+  }
+  return sharedContext;
+}
+
+/**
+ * Resumes (or creates) the shared AudioContext from a user gesture. Browsers keep
+ * the context "suspended" until a gesture occurs, so the kitchen page calls this
+ * from its "enable alerts" control before any auto-played chime.
+ */
+export function primeAudioAlerts(): void {
+  const ctx = ensureContext();
+  if (ctx === null) return;
+  if (ctx.state === 'suspended') void ctx.resume();
+}
+
+function playBeep(ctx: AudioContext, frequency: number, startAt: number, durationSec: number): void {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'sine';
+  osc.frequency.value = frequency;
+  // Quick attack + exponential release so it reads as a chime, not a buzz.
+  gain.gain.setValueAtTime(0.0001, startAt);
+  gain.gain.exponentialRampToValueAtTime(0.3, startAt + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, startAt + durationSec);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(startAt);
+  osc.stop(startAt + durationSec + 0.02);
+}
+
+/**
+ * Plays a short two-tone chime to announce a new order (US-FP-026). No-ops when
+ * the Web Audio API is unavailable. Safe to call rapidly.
+ */
+export function playNewOrderSound(): void {
+  const ctx = ensureContext();
+  if (ctx === null) return;
+  if (ctx.state === 'suspended') void ctx.resume();
+  try {
+    const now = ctx.currentTime;
+    // Two ascending beeps — distinctive over kitchen noise without being harsh.
+    playBeep(ctx, 880, now, 0.18);
+    playBeep(ctx, 1320, now + 0.2, 0.22);
+  } catch {
+    // Ignore — a failed chime must never break the order board.
+  }
+}

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -117,6 +117,9 @@
       "advanceTo": "→ {{status}}",
       "advanceError": "Status konnte nicht aktualisiert werden. Bitte erneut versuchen.",
       "reprint": "Bon drucken",
+      "enableAlerts": "Benachrichtigungen aktivieren",
+      "newOrderTitle": "Neue Bestellung",
+      "newOrderBody": "Bestellung #{{number}}",
       "orderType": {
         "Pickup": "Abholung",
         "EatIn": "Vor Ort",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -117,6 +117,9 @@
       "advanceTo": "→ {{status}}",
       "advanceError": "Échec de la mise à jour du statut. Réessayez.",
       "reprint": "Imprimer le ticket",
+      "enableAlerts": "Activer les alertes",
+      "newOrderTitle": "Nouvelle commande",
+      "newOrderBody": "Commande #{{number}}",
       "orderType": {
         "Pickup": "À emporter",
         "EatIn": "Sur place",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -117,6 +117,9 @@
       "advanceTo": "→ {{status}}",
       "advanceError": "Status bijwerken mislukt. Probeer opnieuw.",
       "reprint": "Bon afdrukken",
+      "enableAlerts": "Meldingen inschakelen",
+      "newOrderTitle": "Nieuwe bestelling",
+      "newOrderBody": "Bestelling #{{number}}",
       "orderType": {
         "Pickup": "Afhalen",
         "EatIn": "Ter plaatse",

--- a/src/frontend/src/types/common.ts
+++ b/src/frontend/src/types/common.ts
@@ -76,8 +76,14 @@ export interface Shop {
   contactEmail: string;
   contactPhone: string | null;
   isActive: boolean;
+  /** When true, new orders are highlighted on the kitchen display (US-FP-026). */
+  kitchenDisplayEnabled: boolean;
   /** When true, new orders auto-print on the kitchen display (US-FP-028). */
   ticketPrinterEnabled: boolean;
+  /** When true, the kitchen display raises a browser push notification per new order (US-FP-026). */
+  pushNotificationEnabled: boolean;
+  /** When true, the kitchen display plays a sound alert per new order (US-FP-026). */
+  soundAlertEnabled: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## US-FP-026 — Configure order notifications

**As a Shop Manager, I want to choose how the shop is notified of new orders (kitchen display, ticket printer, push notification, sound alert), so that notifications match our workflow.**

Extends the per-shop `TicketPrinterEnabled` slice (US-FP-028) into four independent notification channels.

### Acceptance criteria
- [x] Each method enable/disable independently — `KitchenDisplayEnabled`, `TicketPrinterEnabled`, `PushNotificationEnabled`, `SoundAlertEnabled` (four flat bools; four checkboxes on ShopEdit)
- [x] Multiple methods active simultaneously — independent booleans (live-verified: `kitchenDisplay=true, push=true, ticketPrinter=false, sound=false` persists)
- [x] New orders trigger all enabled methods — kitchen display hooks every channel into one new-order detection loop (highlight + auto-print + Web-Audio chime + Notification-API push)
- [x] Both online and in-store orders trigger the same notifications — shared `OrderService.CreateOrderCoreAsync → OrderCreatedHandler → SignalR` (no per-channel divergence)

### Design notes
- **Flat bools, not a value object** — avoids a breaking rename/column-rebuild of `TicketPrinterEnabled` shipped one PR ago. All default `false` (opt-in), matching the existing flag.
- **Kitchen display** channel = transient highlight on newly-arrived cards (the board always lists orders — that's US-FP-027). **Push** = in-tab Notification API (no Web Push infra). **Sound** = Web Audio synthesized chime (no binary asset to ship/license).
- Sound + push need a user gesture (autoplay/permission policy), so staff arm them once via an "enable alerts" control in the kitchen header.
- Admin checkboxes use hardcoded English to match ShopEdit's existing convention (the page has no i18n); kitchen-page strings use `pos.kitchen.*` (NL/FR/DE).

### Verification
- Backend: Release build clean; **279 TUnit unit tests pass** (8 new Shop tests covering defaults, independent toggles, idempotent setters).
- Frontend: `tsc` clean; **89 Vitest tests pass** (13 KitchenDisplay incl. sound/push/highlight + no-backlog-on-first-load + enable-alerts; 7 ShopEdit; 2 new util suites); production build clean.
- **Live (running stack):** killed + restarted Aspire so the provisioner applied migration `20260604061358_AddShopNotificationSettings`; the brand-DB API returns all four flags; an independent toggle mix persists end-to-end (PUT/GET); the kitchen display renders as counter-staff with SignalR "Live" and surfaces the enable-alerts control because it read `pushNotificationEnabled=true` live.

Closes US-FP-026. Dependency tree updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)