### PR TITLE
feat(orders): print customer receipt at point of sale (US-FP-052)

### DIFF
--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -1,7 +1,7 @@
 # User Story Dependency Tree & Progress Tracker
 
 > Generated from [frietjes-platform.md](./extract-prd/user-stories/frietjes-platform.md)
-> Last updated: 2026-06-04 (US-FP-026 order notifications done; US-FP-023 + US-FP-071 verified done; online-channel cluster unblocked — see "Status Accuracy" below)
+> Last updated: 2026-06-04 (US-FP-052 print receipt done; US-FP-026 order notifications done; US-FP-023 + US-FP-071 verified done; online-channel cluster unblocked — see "Status Accuracy" below)
 
 ## Progress Legend
 
@@ -20,6 +20,7 @@
 **✅ Online-ordering entry point RESOLVED (2026-06-04).** US-FP-071 (shop selection + shop-slug-scoped storefront routes) merged via **PR #128** and was runtime-verified. The storefront now has a real customer journey: `/{brand}/{lang}/shops` chooser → `{shopSlug}/menu` → checkout → payment → order tracking, with the localStorage `shopId` hack removed. This unblocks the cluster that was previously "component-complete but NOT user-reachable" — **US-FP-016 / 017 / 038 / 058 / 063 restored to ✅.** (Historical note: this gap was found 2026-06-03 — `Home.tsx` was a stub and the menu only rendered at a GUID-based route nothing linked to.)
 
 **Changed 2026-06-04:**
+- **US-FP-052** → ✅ done. POS customer receipt: thermal-format `buildReceiptHtml` (seller legal block — shop name, address, VAT number — plus per-line prices, Belgian VAT breakdown net/VAT/gross, payment method, date) printed via the shared hidden-iframe `printDocument` helper (extracted from US-FP-028's `printTicket`). A "Print receipt" action on the POS confirmation screen triggers print and doubles as reprint (AC3). New nullable `Shop.VatNumber` (domain + EF + brand migration `AddShopVatNumber` + shop create/update DTOs/endpoints/validators + admin ShopEdit field). The seller legal block is denormalised onto `OrderResponse` (populated on the create + GET-order paths; null on the kitchen status-advance/list paths) — this also lays the groundwork for US-FP-051 (digital receipt). Note: the receipt button is fed the order via router state, so reprint is available on the confirmation screen but not after a hard refresh (acceptable for MVP). 284 unit + 45 integration + 84 frontend tests green.
 - **US-FP-071** → ✅ done. Shop chooser + shop-slug routes; FE/BE verified at runtime. PR #128 merged.
 - **US-FP-023** → ✅ done. Status-advance endpoint + kitchen-card button shipped (commit `adf18f2`); SignalR negotiate CSRF fix (`7fb5299`). The keystone is complete.
 - **US-FP-016 / 017 / 038 / 058 / 063** → ✅ — entry-point blocker resolved by 071; these were already component-complete.
@@ -196,7 +197,7 @@ Once ordering works, these streams are **all independent**.
 | Status | Story | Description | Depends On |
 |--------|-------|-------------|------------|
 | ⬜ | **US-FP-051** | Generate digital receipt | 016, 046 |
-| ⬜ | **US-FP-052** | Print receipt at point of sale | 016, 046 |
+| ✅ | **US-FP-052** | Print receipt at point of sale (POS thermal receipt + reprint) | 016, 046 |
 
 ### Stream K: Offline Mode
 

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderByNumberEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderByNumberEndpoint.cs
@@ -2,6 +2,7 @@ using FastEndpoints;
 using TheMillionthFoodOrderApp.Application.OrderLifecycle;
 using TheMillionthFoodOrderApp.Application.Orders.Dtos;
 using TheMillionthFoodOrderApp.Domain.Orders;
+using TheMillionthFoodOrderApp.Domain.Shops;
 
 namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
 
@@ -15,7 +16,10 @@ public sealed record GetOrderByNumberRequest(
 /// the shop's configured lifecycle. Supports guest lookup where only the order
 /// confirmation slip (with the order number) is available.
 /// </summary>
-public sealed class GetOrderByNumberEndpoint(IOrderRepository orderRepository, IOrderLifecycleService lifecycleService)
+public sealed class GetOrderByNumberEndpoint(
+    IOrderRepository orderRepository,
+    IOrderLifecycleService lifecycleService,
+    IShopRepository shopRepository)
     : Endpoint<GetOrderByNumberRequest, OrderTrackingResponse>
 {
     public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders/number/{orderNumber}";
@@ -51,8 +55,12 @@ public sealed class GetOrderByNumberEndpoint(IOrderRepository orderRepository, I
 
         var lifecycle = await lifecycleService.GetLifecycleAsync(req.ShopId, ct);
 
+        // Load the shop so the seller legal block (name, VAT number, address) is included
+        // for receipt reprints (US-FP-052).
+        var shop = await shopRepository.GetByIdAsync(req.ShopId, ct);
+
         var response = new OrderTrackingResponse(
-            OrderTrackingMapper.MapOrder(order),
+            OrderTrackingMapper.MapOrder(order, shop),
             lifecycle);
 
         await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetOrderEndpoint.cs
@@ -2,6 +2,7 @@ using FastEndpoints;
 using TheMillionthFoodOrderApp.Application.OrderLifecycle;
 using TheMillionthFoodOrderApp.Application.Orders.Dtos;
 using TheMillionthFoodOrderApp.Domain.Orders;
+using TheMillionthFoodOrderApp.Domain.Shops;
 
 namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
 
@@ -15,7 +16,10 @@ public sealed record GetOrderRequest(
 /// configured lifecycle so the customer can see their order's progression
 /// without a second round-trip.
 /// </summary>
-public sealed class GetOrderEndpoint(IOrderRepository orderRepository, IOrderLifecycleService lifecycleService)
+public sealed class GetOrderEndpoint(
+    IOrderRepository orderRepository,
+    IOrderLifecycleService lifecycleService,
+    IShopRepository shopRepository)
     : Endpoint<GetOrderRequest, OrderTrackingResponse>
 {
     public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}";
@@ -50,8 +54,12 @@ public sealed class GetOrderEndpoint(IOrderRepository orderRepository, IOrderLif
 
         var lifecycle = await lifecycleService.GetLifecycleAsync(req.ShopId, ct);
 
+        // Load the shop so the seller legal block (name, VAT number, address) is included
+        // for receipt rendering (US-FP-052).
+        var shop = await shopRepository.GetByIdAsync(req.ShopId, ct);
+
         var response = new OrderTrackingResponse(
-            OrderTrackingMapper.MapOrder(order),
+            OrderTrackingMapper.MapOrder(order, shop),
             lifecycle);
 
         await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/ListActiveOrdersEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/ListActiveOrdersEndpoint.cs
@@ -40,8 +40,10 @@ public sealed class ListActiveOrdersEndpoint(IOrderRepository orderRepository)
     {
         var orders = await orderRepository.GetActiveByShopAsync(req.ShopId, ct);
 
+        // Kitchen display renders order tickets (not customer receipts), so the seller
+        // legal block is left null — MapOrder is called with the order only.
         var response = new ListActiveOrdersResponse(
-            orders.Select(OrderTrackingMapper.MapOrder).ToList().AsReadOnly());
+            orders.Select(o => OrderTrackingMapper.MapOrder(o)).ToList().AsReadOnly());
 
         await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
     }

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
@@ -1,5 +1,6 @@
 using TheMillionthFoodOrderApp.Application.Orders.Dtos;
 using TheMillionthFoodOrderApp.Domain.Orders;
+using TheMillionthFoodOrderApp.Domain.Shops;
 
 namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
 
@@ -11,7 +12,12 @@ namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
 /// </summary>
 internal static class OrderTrackingMapper
 {
-    internal static OrderResponse MapOrder(Order order) =>
+    /// <summary>
+    /// Maps an order for tracking responses. When <paramref name="shop"/> is supplied, the
+    /// seller legal block (name, VAT number, address) is included so counter staff can
+    /// reprint a complete receipt (US-FP-052).
+    /// </summary>
+    internal static OrderResponse MapOrder(Order order, Shop? shop = null) =>
         new(
             order.Id,
             order.OrderNumber,
@@ -45,5 +51,8 @@ internal static class OrderTrackingMapper
             order.TableNumber,
             order.CreatedByStaffId,
             order.CustomerEmail,
-            order.CustomerPhone);
+            order.CustomerPhone,
+            shop?.Name,
+            shop?.VatNumber,
+            shop?.Address.ToSingleLine());
 }

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/CreateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/CreateShopEndpoint.cs
@@ -11,7 +11,8 @@ public sealed record CreateShopRequest(
     string Slug,
     AddressRequest Address,
     string ContactEmail,
-    string? ContactPhone);
+    string? ContactPhone,
+    string? VatNumber = null);
 
 public sealed record AddressRequest(
     string Street,
@@ -64,6 +65,10 @@ public sealed class CreateShopRequestValidator : Validator<CreateShopRequest>
         RuleFor(x => x.ContactPhone)
             .MaximumLength(30)
             .When(x => x.ContactPhone is not null);
+
+        RuleFor(x => x.VatNumber)
+            .MaximumLength(30)
+            .When(x => x.VatNumber is not null);
     }
 }
 
@@ -100,7 +105,8 @@ public sealed class CreateShopEndpoint(IShopService shopService)
                     req.Address.PostalCode,
                     req.Address.Country),
                 req.ContactEmail,
-                req.ContactPhone);
+                req.ContactPhone,
+                req.VatNumber);
 
             var response = await shopService.CreateShopAsync(appRequest, ct);
 

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Shops/UpdateShopEndpoint.cs
@@ -14,7 +14,8 @@ public sealed record UpdateShopRequest(
     bool KitchenDisplayEnabled,
     bool TicketPrinterEnabled,
     bool PushNotificationEnabled,
-    bool SoundAlertEnabled);
+    bool SoundAlertEnabled,
+    string? VatNumber = null);
 
 public sealed class UpdateShopRequestValidator : Validator<UpdateShopRequest>
 {
@@ -57,6 +58,10 @@ public sealed class UpdateShopRequestValidator : Validator<UpdateShopRequest>
         RuleFor(x => x.ContactPhone)
             .MaximumLength(30)
             .When(x => x.ContactPhone is not null);
+
+        RuleFor(x => x.VatNumber)
+            .MaximumLength(30)
+            .When(x => x.VatNumber is not null);
     }
 }
 
@@ -96,7 +101,8 @@ public sealed class UpdateShopEndpoint(IShopService shopService)
                 req.KitchenDisplayEnabled,
                 req.TicketPrinterEnabled,
                 req.PushNotificationEnabled,
-                req.SoundAlertEnabled);
+                req.SoundAlertEnabled,
+                req.VatNumber);
 
             var response = await shopService.UpdateShopAsync(req.Id, appRequest, ct);
 

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/Dtos/OrderResponse.cs
@@ -49,4 +49,13 @@ public sealed record OrderResponse(
     /// <summary>Optional customer email address for digital receipts (US-FP-017).</summary>
     string? CustomerEmail = null,
     /// <summary>Optional customer phone number (US-FP-017).</summary>
-    string? CustomerPhone = null);
+    string? CustomerPhone = null,
+    /// <summary>
+    /// Seller legal block for receipts (US-FP-052): the shop's name, VAT number, and a
+    /// single-line address. Populated on the order-create and order-tracking responses
+    /// (where the shop is loaded); null on the status-advance response which the kitchen
+    /// display consumes and which does not render a receipt.
+    /// </summary>
+    string? ShopName = null,
+    string? ShopVatNumber = null,
+    string? ShopAddressLine = null);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -140,7 +140,9 @@ public sealed class OrderService(
         order.AdvanceTo(targetStatus.Name);
         await orderRepository.SaveChangesAsync(cancellationToken);
 
-        return MapToResponse(order);
+        // The status-advance response feeds the kitchen display, which renders an order
+        // ticket (not a customer receipt), so the seller legal block is not needed here.
+        return MapToResponse(order, shop: null);
     }
 
     // ── Private helpers ──────────────────────────────────────────────────────
@@ -321,7 +323,7 @@ public sealed class OrderService(
             }
         }
 
-        return MapToResponse(order!);
+        return MapToResponse(order!, shop);
     }
 
     private static Domain.OrderLifecycle.OrderStatus GetOpeningStatus(OrderLifecycleConfig config)
@@ -349,7 +351,12 @@ public sealed class OrderService(
         return Guid.CreateVersion7().ToString("N")[..16].ToUpperInvariant();
     }
 
-    private static OrderResponse MapToResponse(Order order) =>
+    /// <summary>
+    /// Maps an order to its response DTO. When <paramref name="shop"/> is supplied, the
+    /// seller legal block (name, VAT number, address) is included for receipt rendering
+    /// (US-FP-052); pass null on paths that do not render a receipt.
+    /// </summary>
+    private static OrderResponse MapToResponse(Order order, Shop? shop) =>
         new(
             order.Id,
             order.OrderNumber,
@@ -383,5 +390,8 @@ public sealed class OrderService(
             order.TableNumber,
             order.CreatedByStaffId,
             order.CustomerEmail,
-            order.CustomerPhone);
+            order.CustomerPhone,
+            shop?.Name,
+            shop?.VatNumber,
+            shop?.Address.ToSingleLine());
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
@@ -5,7 +5,8 @@ public sealed record CreateShopRequest(
     string Slug,
     AddressRequest Address,
     string ContactEmail,
-    string? ContactPhone);
+    string? ContactPhone,
+    string? VatNumber = null);
 
 public sealed record UpdateShopRequest(
     string Name,
@@ -15,7 +16,8 @@ public sealed record UpdateShopRequest(
     bool KitchenDisplayEnabled,
     bool TicketPrinterEnabled,
     bool PushNotificationEnabled,
-    bool SoundAlertEnabled);
+    bool SoundAlertEnabled,
+    string? VatNumber = null);
 
 public sealed record AddressRequest(
     string Street,
@@ -44,7 +46,8 @@ public sealed record ShopResponse(
     bool PushNotificationEnabled,
     bool SoundAlertEnabled,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt,
+    string? VatNumber = null);
 
 /// <summary>
 /// Lightweight shop summary returned by the public storefront endpoint.

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
@@ -13,7 +13,7 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
             throw new InvalidOperationException($"A shop with slug '{request.Slug}' already exists in this brand.");
 
         var address = MapToAddress(request.Address);
-        var shop = Shop.Create(request.Name, request.Slug, address, request.ContactEmail, request.ContactPhone);
+        var shop = Shop.Create(request.Name, request.Slug, address, request.ContactEmail, request.ContactPhone, request.VatNumber);
 
         await shopRepository.AddAsync(shop, cancellationToken);
         await shopRepository.SaveChangesAsync(cancellationToken);
@@ -32,7 +32,7 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
             id,
             s =>
             {
-                s.UpdateMetadata(request.Name, address, request.ContactEmail, request.ContactPhone);
+                s.UpdateMetadata(request.Name, address, request.ContactEmail, request.ContactPhone, request.VatNumber);
                 s.SetKitchenDisplayEnabled(request.KitchenDisplayEnabled);
                 s.SetTicketPrinterEnabled(request.TicketPrinterEnabled);
                 s.SetPushNotificationEnabled(request.PushNotificationEnabled);
@@ -108,7 +108,8 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
             shop.PushNotificationEnabled,
             shop.SoundAlertEnabled,
             shop.CreatedAt,
-            shop.UpdatedAt);
+            shop.UpdatedAt,
+            shop.VatNumber);
 
     private static StorefrontShopResponse MapToStorefrontResponse(Shop shop, DateTimeOffset now) =>
         new(

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Address.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Address.cs
@@ -32,4 +32,15 @@ public sealed class Address : ValueObject
         yield return PostalCode;
         yield return Country;
     }
+
+    /// <summary>
+    /// Renders the address as a single human-readable line for receipts and tickets,
+    /// e.g. "Frietstraat 1, 1000 Brussel". The country is appended only when it is not
+    /// the Belgian default ("BE").
+    /// </summary>
+    public string ToSingleLine()
+    {
+        var line = $"{Street} {Number}, {PostalCode} {City}";
+        return Country == "BE" ? line : $"{line}, {Country}";
+    }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Shop.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Shops/Shop.cs
@@ -16,6 +16,14 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
     public Address Address { get; private set; } = null!;
     public string ContactEmail { get; private set; } = string.Empty;
     public string? ContactPhone { get; private set; }
+
+    /// <summary>
+    /// VAT / enterprise number of the legal entity operating this shop (e.g. "BE0123456789").
+    /// Optional — printed on customer receipts as a legal requirement (US-FP-052). Null when
+    /// not yet configured.
+    /// </summary>
+    public string? VatNumber { get; private set; }
+
     public bool IsActive { get; private set; } = true;
 
     /// <summary>
@@ -70,7 +78,8 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
         string slug,
         Address address,
         string contactEmail,
-        string? contactPhone)
+        string? contactPhone,
+        string? vatNumber = null)
     {
         var now = DateTimeOffset.UtcNow;
         var shop = new Shop
@@ -81,6 +90,7 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
             Address = address,
             ContactEmail = contactEmail,
             ContactPhone = contactPhone,
+            VatNumber = vatNumber,
             IsActive = true,
             CreatedAt = now,
             UpdatedAt = now,
@@ -96,12 +106,14 @@ public sealed class Shop : AggregateRoot<Guid>, IAuditable
         string name,
         Address address,
         string contactEmail,
-        string? contactPhone)
+        string? contactPhone,
+        string? vatNumber = null)
     {
         Name = name;
         Address = address;
         ContactEmail = contactEmail;
         ContactPhone = contactPhone;
+        VatNumber = vatNumber;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604074952_AddShopVatNumber.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604074952_AddShopVatNumber.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604074952_AddShopVatNumber")]
+    partial class AddShopVatNumber
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604074952_AddShopVatNumber.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260604074952_AddShopVatNumber.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddShopVatNumber : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "VatNumber",
+                table: "Shops",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VatNumber",
+                table: "Shops");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopConfiguration.cs
@@ -31,6 +31,10 @@ public sealed class ShopConfiguration : IEntityTypeConfiguration<Shop>
         builder.Property(s => s.ContactPhone)
             .HasMaxLength(30);
 
+        // Optional VAT / enterprise number printed on customer receipts (US-FP-052).
+        builder.Property(s => s.VatNumber)
+            .HasMaxLength(30);
+
         builder.Property(s => s.IsActive)
             .IsRequired();
 

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetOrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetOrderTests.cs
@@ -73,7 +73,8 @@ public sealed class GetOrderTests(IntegrationTestBase fixture)
                 Country = "BE"
             },
             ContactEmail = "track@frietjes.be",
-            ContactPhone = (string?)null
+            ContactPhone = (string?)null,
+            VatNumber = "BE0123456789"
         };
 
         var response = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
@@ -254,6 +255,37 @@ public sealed class GetOrderTests(IntegrationTestBase fixture)
         var response = await client.GetAsync(GetOrderByIdUrl(brand, wrongShopId, placed.Id));
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    // ── Test 7: Receipt seller legal block is present (US-FP-052) ────────────
+
+    [Test]
+    public async Task OrderResponses_IncludeShopLegalBlockForReceipt()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        await SeedTaxConfigAsync(client, brand);
+        var shopId = await CreateShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand, price: 4.00m, name: "Receipt Frietje");
+        var placed = await PlaceOrderAsync(client, brand, shopId, productId);
+
+        // The create-order response already carries the seller legal block so the POS can
+        // print a receipt immediately after placing the order.
+        await Assert.That(placed.ShopName).IsNotNull();
+        await Assert.That(placed.ShopName!).StartsWith("Tracking Shop");
+        await Assert.That(placed.ShopVatNumber).IsEqualTo("BE0123456789");
+        await Assert.That(placed.ShopAddressLine).IsEqualTo("Frietstraat 42, 9000 Gent");
+
+        // ...and so does the get-by-number response, which backs receipt reprints.
+        var response = await client.GetAsync(GetOrderByNumberUrl(brand, shopId, placed.OrderNumber));
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var tracking = await response.Content.ReadFromJsonAsync<OrderTrackingResponse>();
+        await Assert.That(tracking).IsNotNull();
+        await Assert.That(tracking!.Order.ShopName).IsEqualTo(placed.ShopName);
+        await Assert.That(tracking.Order.ShopVatNumber).IsEqualTo("BE0123456789");
+        await Assert.That(tracking.Order.ShopAddressLine).IsEqualTo("Frietstraat 42, 9000 Gent");
     }
 
     // ── Bonus Test 6: Lifecycle statuses are ordered by SortOrder ────────────

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Shops/ShopVatNumberTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Shops/ShopVatNumberTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using System.Net.Http.Json;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Shops;
+
+/// <summary>
+/// Integration tests for the shop VAT number (US-FP-052) — the legal identifier printed on
+/// customer receipts. Verifies it round-trips through create, get, and update.
+/// Runs against a real SQL Server via Testcontainers.
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class ShopVatNumberTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string ShopsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/shops";
+
+    private static string ShopUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}";
+
+    [Test]
+    public async Task CreateShop_WithVatNumber_PersistsAndReturnsIt()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var request = new
+        {
+            Name = "VAT Shop",
+            Slug = $"vat-shop-{Guid.NewGuid():N}",
+            Address = new
+            {
+                Street = "Btwstraat",
+                Number = "7",
+                City = "Gent",
+                PostalCode = "9000",
+                Country = "BE"
+            },
+            ContactEmail = "vat@frietjes.be",
+            ContactPhone = (string?)null,
+            VatNumber = "BE0123456789"
+        };
+
+        var createResponse = await client.PostAsJsonAsync(ShopsUrl(brand), request);
+        await Assert.That(createResponse.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(created).IsNotNull();
+        await Assert.That(created!.VatNumber).IsEqualTo("BE0123456789");
+
+        // Re-fetch to prove it persisted (not just echoed from the request).
+        var getResponse = await client.GetAsync(ShopUrl(brand, created.Id));
+        await Assert.That(getResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var fetched = await getResponse.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(fetched).IsNotNull();
+        await Assert.That(fetched!.VatNumber).IsEqualTo("BE0123456789");
+    }
+
+    [Test]
+    public async Task CreateShop_WithoutVatNumber_ReturnsNull()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        var request = new
+        {
+            Name = "No-VAT Shop",
+            Slug = $"novat-shop-{Guid.NewGuid():N}",
+            Address = new
+            {
+                Street = "Btwstraat",
+                Number = "8",
+                City = "Gent",
+                PostalCode = "9000",
+                Country = "BE"
+            },
+            ContactEmail = "novat@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var createResponse = await client.PostAsJsonAsync(ShopsUrl(brand), request);
+        await Assert.That(createResponse.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(created).IsNotNull();
+        await Assert.That(created!.VatNumber).IsNull();
+    }
+
+    [Test]
+    public async Task UpdateShop_SetsVatNumber()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        // Create without a VAT number.
+        var createRequest = new
+        {
+            Name = "Editable Shop",
+            Slug = $"edit-vat-{Guid.NewGuid():N}",
+            Address = new
+            {
+                Street = "Btwstraat",
+                Number = "9",
+                City = "Gent",
+                PostalCode = "9000",
+                Country = "BE"
+            },
+            ContactEmail = "edit@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var createResponse = await client.PostAsJsonAsync(ShopsUrl(brand), createRequest);
+        await Assert.That(createResponse.StatusCode).IsEqualTo(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(created).IsNotNull();
+        await Assert.That(created!.VatNumber).IsNull();
+
+        // Update it with a VAT number.
+        var updateRequest = new
+        {
+            Name = created.Name,
+            Address = new
+            {
+                Street = created.Address.Street,
+                Number = created.Address.Number,
+                City = created.Address.City,
+                PostalCode = created.Address.PostalCode,
+                Country = created.Address.Country
+            },
+            ContactEmail = created.ContactEmail,
+            ContactPhone = (string?)null,
+            KitchenDisplayEnabled = false,
+            TicketPrinterEnabled = false,
+            PushNotificationEnabled = false,
+            SoundAlertEnabled = false,
+            VatNumber = "BE0987654321"
+        };
+
+        var updateResponse = await client.PutAsJsonAsync(ShopUrl(brand, created.Id), updateRequest);
+        await Assert.That(updateResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(updated).IsNotNull();
+        await Assert.That(updated!.VatNumber).IsEqualTo("BE0987654321");
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/AddressTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/AddressTests.cs
@@ -112,4 +112,22 @@ public sealed class AddressTests
         await Assert.That(address.PostalCode).IsEqualTo("9000");
         await Assert.That(address.Country).IsEqualTo("BE");
     }
+
+    // ── ToSingleLine (receipt rendering, US-FP-052) ─────────────────────────────
+
+    [Test]
+    public async Task ToSingleLine_BelgianAddress_OmitsCountry()
+    {
+        var address = new Address("Vrijdagmarkt", "1", "Gent", "9000", "BE");
+
+        await Assert.That(address.ToSingleLine()).IsEqualTo("Vrijdagmarkt 1, 9000 Gent");
+    }
+
+    [Test]
+    public async Task ToSingleLine_NonBelgianAddress_AppendsCountry()
+    {
+        var address = new Address("Dam", "1", "Amsterdam", "1012", "NL");
+
+        await Assert.That(address.ToSingleLine()).IsEqualTo("Dam 1, 1012 Amsterdam, NL");
+    }
 }

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/ShopTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/ShopTests.cs
@@ -35,6 +35,23 @@ public sealed class ShopTests
     }
 
     [Test]
+    public async Task Create_WithoutVatNumber_DefaultsToNull()
+    {
+        var shop = CreateValidShop();
+
+        await Assert.That(shop.VatNumber).IsNull();
+    }
+
+    [Test]
+    public async Task Create_WithVatNumber_SetsVatNumber()
+    {
+        var shop = Shop.Create(
+            "Frietjes Gent", "frietjes-gent", ValidAddress, "gent@frietjes.be", null, "BE0123456789");
+
+        await Assert.That(shop.VatNumber).IsEqualTo("BE0123456789");
+    }
+
+    [Test]
     public async Task Create_OpeningHours_IsEmpty()
     {
         var shop = CreateValidShop();
@@ -109,6 +126,16 @@ public sealed class ShopTests
         shop.UpdateMetadata("Frietjes Gent", ValidAddress, "gent@frietjes.be", null);
 
         await Assert.That(shop.ContactPhone).IsNull();
+    }
+
+    [Test]
+    public async Task UpdateMetadata_SetsVatNumber()
+    {
+        var shop = CreateValidShop();
+
+        shop.UpdateMetadata("Frietjes Gent", ValidAddress, "gent@frietjes.be", null, "BE0987654321");
+
+        await Assert.That(shop.VatNumber).IsEqualTo("BE0987654321");
     }
 
     // ── SetTicketPrinterEnabled ─────────────────────────────────────────────────

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -70,6 +70,14 @@ export interface OrderResponse {
   tableNumber?: number;
   /** Staff member who created the order (set by the server from the auth token). */
   createdByStaffId?: string;
+  /**
+   * Seller legal block for receipts (US-FP-052) — the shop's name, VAT number, and a
+   * single-line address. Present on order-create and order-tracking responses; absent on
+   * the status-advance response consumed by the kitchen display.
+   */
+  shopName?: string | null;
+  shopVatNumber?: string | null;
+  shopAddressLine?: string | null;
 }
 
 export interface ListActiveOrdersResponse {

--- a/src/frontend/src/api/shops.ts
+++ b/src/frontend/src/api/shops.ts
@@ -29,6 +29,8 @@ export interface CreateShopRequest {
   };
   contactEmail: string;
   contactPhone?: string;
+  /** VAT / enterprise number printed on customer receipts (US-FP-052). */
+  vatNumber?: string;
 }
 
 export interface UpdateShopRequest {
@@ -42,6 +44,8 @@ export interface UpdateShopRequest {
   };
   contactEmail: string;
   contactPhone?: string;
+  /** VAT / enterprise number printed on customer receipts (US-FP-052). */
+  vatNumber?: string;
   /** Highlight new orders on the kitchen display (US-FP-026). */
   kitchenDisplayEnabled: boolean;
   /** Auto-print new orders on the kitchen display (US-FP-028). */

--- a/src/frontend/src/features/admin/pages/ShopEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ShopEdit.tsx
@@ -41,6 +41,7 @@ export function ShopEdit() {
       address: { street: '', number: '', city: '', postalCode: '', country: 'BE' },
       contactEmail: '',
       contactPhone: '',
+      vatNumber: '',
       kitchenDisplayEnabled: false,
       ticketPrinterEnabled: false,
       pushNotificationEnabled: false,
@@ -57,6 +58,7 @@ export function ShopEdit() {
       },
       contactEmail: shop.contactEmail,
       contactPhone: shop.contactPhone ?? '',
+      vatNumber: shop.vatNumber ?? '',
       kitchenDisplayEnabled: shop.kitchenDisplayEnabled,
       ticketPrinterEnabled: shop.ticketPrinterEnabled,
       pushNotificationEnabled: shop.pushNotificationEnabled,
@@ -78,6 +80,9 @@ export function ShopEdit() {
       soundAlertEnabled: values.soundAlertEnabled,
       ...(values.contactPhone.trim().length > 0
         ? { contactPhone: values.contactPhone.trim() }
+        : {}),
+      ...(values.vatNumber.trim().length > 0
+        ? { vatNumber: values.vatNumber.trim() }
         : {}),
     }),
     invalidate: [shopKeys.all(resolvedBrandSlug), shopKeys.detail(resolvedBrandSlug, resolvedShopId)],
@@ -270,6 +275,24 @@ export function ShopEdit() {
             {...register('contactPhone')}
             style={inputStyle(false)}
           />
+        </div>
+
+        {/* VAT number (optional) — printed on customer receipts (US-FP-052) */}
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label style={labelStyle} htmlFor="vatNumber">
+            VAT Number{' '}
+            <span style={{ color: '#9ca3af', fontWeight: 400 }}>(optional)</span>
+          </label>
+          <input
+            id="vatNumber"
+            type="text"
+            {...register('vatNumber')}
+            style={inputStyle(false)}
+            placeholder="BE0123456789"
+          />
+          <p style={{ fontSize: '0.75rem', color: '#6b7280', marginTop: '0.25rem' }}>
+            Shown on printed customer receipts as a legal requirement.
+          </p>
         </div>
 
         {/* Order notifications (US-FP-026) — independent per-shop channels */}

--- a/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
+++ b/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
@@ -11,6 +11,7 @@ export const shopEditSchema = z.object({
   }),
   contactEmail: z.string().email({ message: 'Enter a valid email address.' }),
   contactPhone: z.string(),
+  vatNumber: z.string(),
   kitchenDisplayEnabled: z.boolean(),
   ticketPrinterEnabled: z.boolean(),
   pushNotificationEnabled: z.boolean(),

--- a/src/frontend/src/features/pos/__tests__/PosOrderConfirmation.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosOrderConfirmation.test.tsx
@@ -14,6 +14,7 @@ import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { render } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { OrderResponse } from '@api/orders';
 import { PosOrderConfirmationInner, PosOrderConfirmation } from '../pages/PosOrderConfirmation';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -22,6 +23,29 @@ function createTestClient() {
   return new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+}
+
+function makeOrder(): OrderResponse {
+  return {
+    id: 'order-1',
+    orderNumber: 'ORD-042',
+    shopId: 'shop-1',
+    brandSlug: 'frietjes',
+    orderType: 'Pickup',
+    statusName: 'Placed',
+    customerName: null,
+    items: [],
+    vatRatePercent: 6,
+    subtotalGross: 0,
+    totalVatAmount: 0,
+    totalNet: 0,
+    totalGross: 0,
+    createdAt: '2026-06-04T10:15:00Z',
+    paymentMethod: 'CashAtPickup',
+    shopName: 'Frietjes Gent',
+    shopVatNumber: 'BE0123456789',
+    shopAddressLine: 'Korenmarkt 1, 9000 Gent',
+  };
 }
 
 /**
@@ -63,6 +87,32 @@ describe('PosOrderConfirmationInner (t-15)', () => {
     fireEvent.click(backBtn);
 
     expect(backCalled).toBe(true);
+  });
+
+  it('shows a print-receipt button and calls onPrintReceipt when an order is present', () => {
+    let printed = false;
+    render(
+      <QueryClientProvider client={createTestClient()}>
+        <MemoryRouter>
+          <PosOrderConfirmationInner
+            orderNumber="ORD-042"
+            onBackToMenu={() => { /* no-op */ }}
+            order={makeOrder()}
+            onPrintReceipt={() => { printed = true; }}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const printBtn = screen.getByTestId('pos-print-receipt');
+    fireEvent.click(printBtn);
+
+    expect(printed).toBe(true);
+  });
+
+  it('does not show a print-receipt button when no order is available', () => {
+    renderInner('ORD-001');
+    expect(screen.queryByTestId('pos-print-receipt')).not.toBeInTheDocument();
   });
 });
 

--- a/src/frontend/src/features/pos/pages/Dashboard.tsx
+++ b/src/frontend/src/features/pos/pages/Dashboard.tsx
@@ -35,7 +35,11 @@ function PosDashboardInner({ brandSlug, shopId }: PosDashboardInnerProps) {
     if (!canSubmit) return;
     try {
       const order = await mutation.mutateAsync({});
-      void navigate(`/${paramBrandSlug}/${lang}/pos/confirmation/${order.orderNumber}`);
+      // Carry the full order to the confirmation screen so counter staff can print/reprint
+      // the customer receipt (US-FP-052) without an extra round-trip.
+      void navigate(`/${paramBrandSlug}/${lang}/pos/confirmation/${order.orderNumber}`, {
+        state: { order },
+      });
     } catch {
       // error is exposed via mutation.isError
     }

--- a/src/frontend/src/features/pos/pages/PosOrderConfirmation.tsx
+++ b/src/frontend/src/features/pos/pages/PosOrderConfirmation.tsx
@@ -1,21 +1,58 @@
 import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import type { OrderResponse } from '@api/orders';
+import { printReceipt, type ReceiptLabels } from '../utils/printReceipt';
 
 interface PosOrderConfirmationProps {
   orderNumber: string;
   onBackToMenu: () => void;
+  /**
+   * The placed order, when available. Present immediately after placing an order (carried
+   * via router state); absent after a refresh or direct navigation. The receipt button is
+   * only shown when this is present.
+   */
+  order?: OrderResponse | null;
+  onPrintReceipt?: (() => void) | undefined;
+}
+
+/**
+ * Resolves the localised, pre-resolved receipt labels for an order.
+ */
+function buildReceiptLabels(order: OrderResponse, t: TFunction): ReceiptLabels {
+  return {
+    heading: t('pos.receipt.heading'),
+    vatNumber: t('pos.receipt.vatNumber'),
+    orderType: t(`pos.receipt.orderType.${order.orderType}`, { defaultValue: order.orderType }),
+    table: t('pos.receipt.table'),
+    timeSlot: t('pos.receipt.timeSlot'),
+    customer: t('pos.receipt.customer'),
+    placedAt: t('pos.receipt.placedAt'),
+    subtotalNet: t('pos.receipt.subtotalNet'),
+    vat: t('pos.receipt.vat', { rate: order.vatRatePercent }),
+    total: t('pos.receipt.total'),
+    paymentMethod: t('pos.receipt.paymentMethod'),
+    paymentMethodValue: t(`pos.receipt.payment.${order.paymentMethod}`, {
+      defaultValue: order.paymentMethod,
+    }),
+  };
 }
 
 /**
  * Minimal POS-specific order confirmation page.
- * Shows the order number, a success indicator, and a "Back to Menu" button.
+ * Shows the order number, a success indicator, a "Print receipt" action (US-FP-052),
+ * and a "Back to Menu" button.
  *
- * This is intentionally simple — no storefront OrderConfirmationPage complexity
- * (no SignalR tracking, no payment status) since the staff already knows the order
- * was placed successfully.
+ * The print action doubles as the reprint trigger — counter staff can click it as many
+ * times as needed to reprint the customer receipt.
  */
-export function PosOrderConfirmationInner({ orderNumber, onBackToMenu }: PosOrderConfirmationProps) {
+export function PosOrderConfirmationInner({
+  orderNumber,
+  onBackToMenu,
+  order,
+  onPrintReceipt,
+}: PosOrderConfirmationProps) {
   const { t } = useTranslation('common');
 
   return (
@@ -57,23 +94,46 @@ export function PosOrderConfirmationInner({ orderNumber, onBackToMenu }: PosOrde
         {t('pos.confirmation.orderNumber', { number: orderNumber })}
       </p>
 
-      <button
-        type="button"
-        onClick={onBackToMenu}
-        style={{
-          padding: '0.875rem 2.5rem',
-          borderRadius: '0.5rem',
-          border: 'none',
-          background: 'var(--brand-color-primary, #111827)',
-          color: '#fff',
-          fontWeight: 700,
-          fontSize: '1.0625rem',
-          cursor: 'pointer',
-          minHeight: '3rem',
-        }}
-      >
-        {t('pos.confirmation.back')}
-      </button>
+      <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+        {order != null && onPrintReceipt != null && (
+          <button
+            type="button"
+            onClick={onPrintReceipt}
+            data-testid="pos-print-receipt"
+            style={{
+              padding: '0.875rem 2rem',
+              borderRadius: '0.5rem',
+              border: '2px solid var(--brand-color-primary, #111827)',
+              background: '#fff',
+              color: 'var(--brand-color-primary, #111827)',
+              fontWeight: 700,
+              fontSize: '1.0625rem',
+              cursor: 'pointer',
+              minHeight: '3rem',
+            }}
+          >
+            {t('pos.receipt.print')}
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={onBackToMenu}
+          style={{
+            padding: '0.875rem 2.5rem',
+            borderRadius: '0.5rem',
+            border: 'none',
+            background: 'var(--brand-color-primary, #111827)',
+            color: '#fff',
+            fontWeight: 700,
+            fontSize: '1.0625rem',
+            cursor: 'pointer',
+            minHeight: '3rem',
+          }}
+        >
+          {t('pos.confirmation.back')}
+        </button>
+      </div>
     </main>
   );
 }
@@ -88,6 +148,13 @@ export function PosOrderConfirmation() {
     orderNumber: string;
   }>();
   const navigate = useNavigate();
+  const location = useLocation();
+  const { t } = useTranslation('common');
+
+  // The full order is carried via router state from the POS dashboard when an order is
+  // placed. It is intentionally not re-fetched on refresh: the receipt button simply
+  // hides when the order is unavailable.
+  const order = (location.state as { order?: OrderResponse } | null)?.order ?? null;
 
   // Redirect to /pos dashboard if the orderNumber param is missing (e.g. direct navigation)
   useEffect(() => {
@@ -100,6 +167,11 @@ export function PosOrderConfirmation() {
     void navigate(`/${brandSlug}/${lang}/pos`);
   }
 
+  function handlePrintReceipt() {
+    if (order == null) return;
+    printReceipt(order, buildReceiptLabels(order, t));
+  }
+
   if (!orderNumber) {
     return null;
   }
@@ -108,6 +180,8 @@ export function PosOrderConfirmation() {
     <PosOrderConfirmationInner
       orderNumber={orderNumber}
       onBackToMenu={handleBackToMenu}
+      order={order}
+      onPrintReceipt={order != null ? handlePrintReceipt : undefined}
     />
   );
 }

--- a/src/frontend/src/features/pos/utils/__tests__/printReceipt.test.ts
+++ b/src/frontend/src/features/pos/utils/__tests__/printReceipt.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { buildReceiptHtml, type ReceiptLabels } from '../printReceipt';
+import type { OrderResponse } from '@api/orders';
+
+const labels: ReceiptLabels = {
+  heading: 'Receipt',
+  vatNumber: 'VAT no.',
+  orderType: 'Eat-in',
+  table: 'Table',
+  timeSlot: 'Time slot',
+  customer: 'Customer',
+  placedAt: 'Date',
+  subtotalNet: 'Total excl. VAT',
+  vat: 'VAT 21%',
+  total: 'Total incl. VAT',
+  paymentMethod: 'Payment',
+  paymentMethodValue: 'Cash',
+};
+
+function makeOrder(overrides: Partial<OrderResponse> = {}): OrderResponse {
+  return {
+    id: 'order-1',
+    orderNumber: '0042',
+    shopId: 'shop-1',
+    brandSlug: 'frietjes',
+    orderType: 'EatIn',
+    statusName: 'Placed',
+    customerName: null,
+    items: [
+      {
+        productId: 'p1',
+        productName: 'Frietje Speciaal',
+        quantity: 2,
+        unitGrossPrice: 3.5,
+        unitNetPrice: 2.89,
+        unitVatAmount: 0.61,
+        lineTotal: 7,
+        selectedModifiers: [
+          { modifierId: 'm1', modifierName: 'Extra mayo', priceAdjustment: 0.5 },
+        ],
+      },
+    ],
+    vatRatePercent: 21,
+    subtotalGross: 7,
+    totalVatAmount: 1.21,
+    totalNet: 5.79,
+    totalGross: 7,
+    createdAt: '2026-06-04T10:15:00Z',
+    paymentMethod: 'CashAtPickup',
+    shopName: 'Frietjes Gent',
+    shopVatNumber: 'BE0123456789',
+    shopAddressLine: 'Korenmarkt 1, 9000 Gent',
+    ...overrides,
+  };
+}
+
+describe('buildReceiptHtml', () => {
+  it('renders the seller legal block: shop name, address, and VAT number', () => {
+    const html = buildReceiptHtml(makeOrder(), labels);
+    expect(html).toContain('Frietjes Gent');
+    expect(html).toContain('Korenmarkt 1, 9000 Gent');
+    expect(html).toContain('VAT no.: BE0123456789');
+  });
+
+  it('omits legal lines the server did not supply', () => {
+    const html = buildReceiptHtml(
+      makeOrder({ shopVatNumber: null, shopAddressLine: null }),
+      labels,
+    );
+    expect(html).toContain('Frietjes Gent');
+    expect(html).not.toContain('VAT no.:');
+    expect(html).not.toContain('Korenmarkt');
+  });
+
+  it('includes the order number, items, quantities, line totals, and modifiers', () => {
+    const html = buildReceiptHtml(makeOrder(), labels);
+    expect(html).toContain('#0042');
+    expect(html).toContain('Frietje Speciaal');
+    expect(html).toContain('2×');
+    expect(html).toContain('Extra mayo');
+  });
+
+  it('renders the Belgian VAT breakdown: net, VAT amount, and gross total', () => {
+    const html = buildReceiptHtml(makeOrder(), labels);
+    expect(html).toContain('Total excl. VAT');
+    expect(html).toContain('VAT 21%');
+    expect(html).toContain('Total incl. VAT');
+    // Amounts are formatted as EUR currency (nl-BE) — assert the numeric portions appear.
+    expect(html).toContain('5,79');
+    expect(html).toContain('1,21');
+    expect(html).toContain('7,00');
+  });
+
+  it('renders the payment method', () => {
+    const html = buildReceiptHtml(makeOrder(), labels);
+    expect(html).toContain('Payment');
+    expect(html).toContain('Cash');
+  });
+
+  it('renders the table number only for orders that have one', () => {
+    expect(buildReceiptHtml(makeOrder({ tableNumber: 5 }), labels)).toContain('Table: 5');
+    expect(buildReceiptHtml(makeOrder(), labels)).not.toContain('Table:');
+  });
+
+  it('includes the order type and a timestamp', () => {
+    const html = buildReceiptHtml(makeOrder(), labels);
+    expect(html).toContain('Eat-in');
+    expect(html).toContain('Date:');
+  });
+
+  it('escapes HTML in user-controlled fields to prevent markup injection', () => {
+    const html = buildReceiptHtml(
+      makeOrder({ customerName: '<script>alert(1)</script>', shopName: '<b>x</b>' }),
+      labels,
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).not.toContain('<b>x</b>');
+  });
+});

--- a/src/frontend/src/features/pos/utils/printDocument.ts
+++ b/src/frontend/src/features/pos/utils/printDocument.ts
@@ -1,0 +1,47 @@
+/**
+ * Prints a self-contained HTML document via a transient hidden iframe so the
+ * surrounding app UI is never affected by print styles. No-ops outside the
+ * browser (tests/SSR).
+ *
+ * Each call isolates one document, which lets callers (e.g. the kitchen display)
+ * queue several prints without them bleeding into one another. Shared by the
+ * kitchen order ticket (US-FP-028) and the customer receipt (US-FP-052).
+ */
+export function printHtmlDocument(html: string): void {
+  if (typeof document === 'undefined') return;
+
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('aria-hidden', 'true');
+  iframe.style.position = 'fixed';
+  iframe.style.right = '0';
+  iframe.style.bottom = '0';
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframe.style.border = '0';
+
+  iframe.addEventListener('load', () => {
+    const frameWindow = iframe.contentWindow;
+    if (frameWindow == null) {
+      iframe.remove();
+      return;
+    }
+    try {
+      frameWindow.focus();
+      frameWindow.print();
+    } finally {
+      // Give the print dialog time to grab the document before tearing it down.
+      window.setTimeout(() => iframe.remove(), 1000);
+    }
+  });
+
+  document.body.appendChild(iframe);
+
+  const doc = iframe.contentWindow?.document ?? iframe.contentDocument;
+  if (doc == null) {
+    iframe.remove();
+    return;
+  }
+  doc.open();
+  doc.write(html);
+  doc.close();
+}

--- a/src/frontend/src/features/pos/utils/printReceipt.ts
+++ b/src/frontend/src/features/pos/utils/printReceipt.ts
@@ -1,0 +1,177 @@
+import type { OrderResponse } from '@api/orders';
+import { printHtmlDocument } from './printDocument';
+
+/**
+ * Localised, pre-resolved labels for the printed customer receipt. Kept caller-supplied
+ * so the receipt utility stays i18n-agnostic and easy to unit test — the caller resolves
+ * translations (including the VAT-rate interpolation and the payment-method display name).
+ */
+export interface ReceiptLabels {
+  /** Heading printed at the top, e.g. "Receipt" / "Kasticket". */
+  heading: string;
+  /** Label preceding the shop's VAT number, e.g. "VAT no." / "Btw-nr.". */
+  vatNumber: string;
+  /** Resolved order-type text, e.g. "Eat-in" / "Afhalen". */
+  orderType: string;
+  /** Label preceding the table number, e.g. "Table". */
+  table: string;
+  /** Label preceding the time slot, e.g. "Time slot". */
+  timeSlot: string;
+  /** Label preceding the customer name, e.g. "Customer". */
+  customer: string;
+  /** Label preceding the timestamp, e.g. "Date". */
+  placedAt: string;
+  /** Label for the net (VAT-exclusive) total, e.g. "Total excl. VAT". */
+  subtotalNet: string;
+  /** Label for the VAT amount, with the rate already interpolated, e.g. "VAT 21%". */
+  vat: string;
+  /** Label for the gross (VAT-inclusive) total, e.g. "Total incl. VAT". */
+  total: string;
+  /** Label preceding the payment method, e.g. "Payment". */
+  paymentMethod: string;
+  /** Resolved payment-method display text, e.g. "Cash" / "Bancontact". */
+  paymentMethodValue: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('nl-BE', { style: 'currency', currency: 'EUR' }).format(amount);
+}
+
+/**
+ * Builds a self-contained HTML document for a customer receipt, styled for a narrow
+ * (~72mm) thermal receipt printer (US-FP-052). Pure function — the returned markup is
+ * what gets written to the print iframe.
+ *
+ * Unlike the kitchen order ticket (US-FP-028), a receipt is a financial/legal record:
+ * it carries the seller legal block (shop name, address, VAT number), per-line prices,
+ * a Belgian VAT breakdown (net / VAT / gross), the payment method, and the date.
+ */
+export function buildReceiptHtml(order: OrderResponse, labels: ReceiptLabels): string {
+  const placed = new Date(order.createdAt);
+  const placedText = Number.isNaN(placed.getTime())
+    ? order.createdAt
+    : placed.toLocaleString('nl-BE', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+
+  // Seller legal block — each line only renders when the server supplied it.
+  const sellerRows: string[] = [];
+  if (order.shopName != null && order.shopName.length > 0) {
+    sellerRows.push(`<div class="seller-name">${escapeHtml(order.shopName)}</div>`);
+  }
+  if (order.shopAddressLine != null && order.shopAddressLine.length > 0) {
+    sellerRows.push(`<div class="seller">${escapeHtml(order.shopAddressLine)}</div>`);
+  }
+  if (order.shopVatNumber != null && order.shopVatNumber.length > 0) {
+    sellerRows.push(
+      `<div class="seller">${escapeHtml(labels.vatNumber)}: ${escapeHtml(order.shopVatNumber)}</div>`,
+    );
+  }
+
+  const metaRows: string[] = [`<div class="meta">${escapeHtml(labels.orderType)}</div>`];
+  if (order.tableNumber != null) {
+    metaRows.push(
+      `<div class="meta">${escapeHtml(labels.table)}: ${escapeHtml(String(order.tableNumber))}</div>`,
+    );
+  }
+  if (order.timeSlot != null && order.timeSlot.length > 0) {
+    metaRows.push(
+      `<div class="meta">${escapeHtml(labels.timeSlot)}: ${escapeHtml(order.timeSlot)}</div>`,
+    );
+  }
+  if (order.customerName != null && order.customerName.length > 0) {
+    metaRows.push(
+      `<div class="meta">${escapeHtml(labels.customer)}: ${escapeHtml(order.customerName)}</div>`,
+    );
+  }
+  metaRows.push(`<div class="meta">${escapeHtml(labels.placedAt)}: ${escapeHtml(placedText)}</div>`);
+
+  const itemRows = order.items
+    .map((item) => {
+      const modifiers = item.selectedModifiers
+        .map((m) => {
+          const adj =
+            m.priceAdjustment !== 0 ? ` (${formatCurrency(m.priceAdjustment)})` : '';
+          return `<div class="mod">+ ${escapeHtml(m.modifierName)}${adj}</div>`;
+        })
+        .join('');
+      return `<li class="item">
+          <div class="item-line">
+            <span class="qty">${item.quantity}×</span>
+            <span class="name">${escapeHtml(item.productName)}</span>
+            <span class="line-total">${formatCurrency(item.lineTotal)}</span>
+          </div>
+          ${modifiers}
+        </li>`;
+    })
+    .join('');
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>${escapeHtml(labels.heading)} ${escapeHtml(order.orderNumber)}</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'Courier New', monospace; width: 72mm; padding: 4mm; color: #000; }
+  .seller-block { text-align: center; margin-bottom: 2mm; }
+  .seller-name { font-size: 13px; font-weight: 700; }
+  .seller { font-size: 11px; }
+  .heading { text-align: center; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; }
+  .number { text-align: center; font-size: 22px; font-weight: 700; margin: 2mm 0; }
+  .meta { font-size: 11px; }
+  hr { border: none; border-top: 1px dashed #000; margin: 3mm 0; }
+  ul { list-style: none; }
+  .item { margin-bottom: 2mm; }
+  .item-line { display: flex; gap: 2mm; font-size: 13px; font-weight: 700; }
+  .qty { min-width: 7mm; }
+  .name { flex: 1; }
+  .line-total { white-space: nowrap; }
+  .mod { font-size: 11px; padding-left: 9mm; font-weight: 400; }
+  .totals { font-size: 12px; }
+  .totals .row { display: flex; justify-content: space-between; }
+  .totals .grand { font-size: 14px; font-weight: 700; margin-top: 1mm; }
+  .payment { font-size: 12px; margin-top: 2mm; display: flex; justify-content: space-between; }
+  @page { margin: 0; }
+</style>
+</head>
+<body>
+  <div class="seller-block">${sellerRows.join('\n  ')}</div>
+  <hr />
+  <div class="heading">${escapeHtml(labels.heading)}</div>
+  <div class="number">#${escapeHtml(order.orderNumber)}</div>
+  ${metaRows.join('\n  ')}
+  <hr />
+  <ul>${itemRows}</ul>
+  <hr />
+  <div class="totals">
+    <div class="row"><span>${escapeHtml(labels.subtotalNet)}</span><span>${formatCurrency(order.totalNet)}</span></div>
+    <div class="row"><span>${escapeHtml(labels.vat)}</span><span>${formatCurrency(order.totalVatAmount)}</span></div>
+    <div class="row grand"><span>${escapeHtml(labels.total)}</span><span>${formatCurrency(order.totalGross)}</span></div>
+  </div>
+  <div class="payment"><span>${escapeHtml(labels.paymentMethod)}</span><span>${escapeHtml(labels.paymentMethodValue)}</span></div>
+</body>
+</html>`;
+}
+
+/**
+ * Prints a customer receipt via the shared hidden-iframe print mechanism. No-ops outside
+ * the browser. Counter staff trigger this from the POS order-confirmation screen, and may
+ * call it repeatedly to reprint (US-FP-052).
+ */
+export function printReceipt(order: OrderResponse, labels: ReceiptLabels): void {
+  printHtmlDocument(buildReceiptHtml(order, labels));
+}

--- a/src/frontend/src/features/pos/utils/printTicket.ts
+++ b/src/frontend/src/features/pos/utils/printTicket.ts
@@ -1,4 +1,5 @@
 import type { OrderResponse } from '@api/orders';
+import { printHtmlDocument } from './printDocument';
 
 /**
  * Localised, pre-resolved labels for the printed ticket. Kept caller-supplied so
@@ -117,40 +118,5 @@ export function buildTicketHtml(order: OrderResponse, labels: TicketLabels): str
  * auto-prints without them bleeding into one another.
  */
 export function printTicket(order: OrderResponse, labels: TicketLabels): void {
-  if (typeof document === 'undefined') return;
-
-  const iframe = document.createElement('iframe');
-  iframe.setAttribute('aria-hidden', 'true');
-  iframe.style.position = 'fixed';
-  iframe.style.right = '0';
-  iframe.style.bottom = '0';
-  iframe.style.width = '0';
-  iframe.style.height = '0';
-  iframe.style.border = '0';
-
-  iframe.addEventListener('load', () => {
-    const frameWindow = iframe.contentWindow;
-    if (frameWindow == null) {
-      iframe.remove();
-      return;
-    }
-    try {
-      frameWindow.focus();
-      frameWindow.print();
-    } finally {
-      // Give the print dialog time to grab the document before tearing it down.
-      window.setTimeout(() => iframe.remove(), 1000);
-    }
-  });
-
-  document.body.appendChild(iframe);
-
-  const doc = iframe.contentWindow?.document ?? iframe.contentDocument;
-  if (doc == null) {
-    iframe.remove();
-    return;
-  }
-  doc.open();
-  doc.write(buildTicketHtml(order, labels));
-  doc.close();
+  printHtmlDocument(buildTicketHtml(order, labels));
 }

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -162,6 +162,29 @@
       "title": "Bestellung aufgegeben!",
       "orderNumber": "Bestellnummer: {{number}}",
       "back": "Zurück zum Menü"
+    },
+    "receipt": {
+      "heading": "Kassenbon",
+      "print": "Bon drucken",
+      "vatNumber": "USt-IdNr.",
+      "table": "Tisch",
+      "timeSlot": "Zeitfenster",
+      "customer": "Kunde",
+      "placedAt": "Datum",
+      "subtotalNet": "Summe ohne MwSt.",
+      "vat": "MwSt. {{rate}}%",
+      "total": "Summe inkl. MwSt.",
+      "paymentMethod": "Zahlung",
+      "orderType": {
+        "Pickup": "Abholung",
+        "EatIn": "Vor Ort",
+        "Delivery": "Lieferung"
+      },
+      "payment": {
+        "CashAtPickup": "Bar",
+        "CreditCard": "Kreditkarte",
+        "Bancontact": "Bancontact"
+      }
     }
   },
   "allergens": {

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -162,6 +162,29 @@
       "title": "Commande passée !",
       "orderNumber": "Numéro de commande : {{number}}",
       "back": "Retour au menu"
+    },
+    "receipt": {
+      "heading": "Ticket de caisse",
+      "print": "Imprimer le ticket",
+      "vatNumber": "N° TVA",
+      "table": "Table",
+      "timeSlot": "Créneau",
+      "customer": "Client",
+      "placedAt": "Date",
+      "subtotalNet": "Total hors TVA",
+      "vat": "TVA {{rate}}%",
+      "total": "Total TTC",
+      "paymentMethod": "Paiement",
+      "orderType": {
+        "Pickup": "À emporter",
+        "EatIn": "Sur place",
+        "Delivery": "Livraison"
+      },
+      "payment": {
+        "CashAtPickup": "Espèces",
+        "CreditCard": "Carte de crédit",
+        "Bancontact": "Bancontact"
+      }
     }
   },
   "allergens": {

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -162,6 +162,29 @@
       "title": "Bestelling geplaatst!",
       "orderNumber": "Bestelnummer: {{number}}",
       "back": "Terug naar menu"
+    },
+    "receipt": {
+      "heading": "Kasticket",
+      "print": "Bon afdrukken",
+      "vatNumber": "Btw-nr.",
+      "table": "Tafel",
+      "timeSlot": "Tijdslot",
+      "customer": "Klant",
+      "placedAt": "Datum",
+      "subtotalNet": "Totaal excl. btw",
+      "vat": "Btw {{rate}}%",
+      "total": "Totaal incl. btw",
+      "paymentMethod": "Betaling",
+      "orderType": {
+        "Pickup": "Afhalen",
+        "EatIn": "Ter plaatse",
+        "Delivery": "Bezorging"
+      },
+      "payment": {
+        "CashAtPickup": "Contant",
+        "CreditCard": "Kredietkaart",
+        "Bancontact": "Bancontact"
+      }
     }
   },
   "allergens": {

--- a/src/frontend/src/types/common.ts
+++ b/src/frontend/src/types/common.ts
@@ -75,6 +75,8 @@ export interface Shop {
   address: ShopAddress;
   contactEmail: string;
   contactPhone: string | null;
+  /** VAT / enterprise number printed on customer receipts (US-FP-052). Null when not set. */
+  vatNumber: string | null;
   isActive: boolean;
   /** When true, new orders are highlighted on the kitchen display (US-FP-026). */
   kitchenDisplayEnabled: boolean;


### PR DESCRIPTION
## US-FP-052 — Print receipt at point of sale

Adds a thermal **customer receipt** to the POS, distinct from the US-FP-028 kitchen *order ticket*. A receipt is a financial/legal record, so it carries the seller legal block, prices, the Belgian VAT breakdown, payment method, and date.

### Acceptance criteria
- ✅ Receipt printed on the receipt printer (72mm thermal format, via a shared hidden-iframe helper).
- ✅ Includes legal requirements: shop **name**, **address**, **VAT number**, **date**, order number.
- ✅ Counter staff can **reprint** from the in-store interface (the "Print receipt" action on the POS confirmation screen triggers print and can be clicked repeatedly).
- ✅ Same information as the digital receipt — the seller block + totals are denormalised onto `OrderResponse`, which also lays the groundwork for US-FP-051.

### Backend
- New nullable **`Shop.VatNumber`** — domain + EF config + brand migration `AddShopVatNumber` (adds only that column) + shop create/update DTOs, endpoints, and validators + admin ShopEdit field.
- `Address.ToSingleLine()` for receipt rendering.
- `ShopName` / `ShopVatNumber` / `ShopAddressLine` appended to `OrderResponse`, populated on the order-create and GET-order paths; left null on the kitchen status-advance/list paths (which render a ticket, not a receipt).

### Frontend
- `buildReceiptHtml` (+ `printReceipt`) renders the receipt; the iframe print mechanism is extracted into a shared `printDocument` helper reused by `printTicket`.
- `pos.receipt.*` i18n in NL/FR/DE; VAT-number field on the admin ShopEdit form.

### Testing
- Backend: builds clean; **284 unit** + **45 integration** tests (real SQL via Testcontainers — incl. new seller-block + VAT round-trip assertions).
- Frontend: type-check/build passes; **84 tests** (new receipt-builder escaping/VAT/seller + print-button tests).
- Adversarial review across correctness / AC-completeness / security lenses → zero findings.

### Note
The receipt is fed the order via router state, so reprint is available on the confirmation screen (immediately after placing, clickable repeatedly) but **not after a hard browser refresh**. A refresh-proof reprint would need `shopId` in the confirmation route + a `getByNumber` fetch — straightforward to add later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)