### PR TITLE
chore(frontend): resolve remaining ESLint errors (576 -> 0)

### DIFF
--- a/src/frontend/src/api/__tests__/auth.test.ts
+++ b/src/frontend/src/api/__tests__/auth.test.ts
@@ -71,6 +71,7 @@ describe('auth API', () => {
       Object.defineProperty(window, 'location', {
         configurable: true,
         value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread -- intentional shallow copy of Location's own enumerable props for a test stub; prototype not needed
           ...window.location,
           set href(url: string) {
             capturedHref = url;
@@ -87,6 +88,7 @@ describe('auth API', () => {
       Object.defineProperty(window, 'location', {
         configurable: true,
         value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread -- intentional shallow copy of Location's own enumerable props for a test stub; prototype not needed
           ...window.location,
           set href(url: string) {
             capturedHref = url;
@@ -103,6 +105,7 @@ describe('auth API', () => {
       Object.defineProperty(window, 'location', {
         configurable: true,
         value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread -- intentional shallow copy of Location's own enumerable props for a test stub; prototype not needed
           ...window.location,
           set href(url: string) {
             capturedHref = url;
@@ -129,6 +132,7 @@ describe('auth API', () => {
       Object.defineProperty(window, 'location', {
         configurable: true,
         value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread -- intentional shallow copy of Location's own enumerable props for a test stub; prototype not needed
           ...window.location,
           reload: () => {
             reloadCalled = true;

--- a/src/frontend/src/api/__tests__/orders.test.ts
+++ b/src/frontend/src/api/__tests__/orders.test.ts
@@ -71,10 +71,14 @@ describe('ordersApi', () => {
 
       // Verify outgoing payload
       expect(capturedBody).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed non-null by the assertion above
       expect(capturedBody!.customerFirstName).toBe('Jane');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed non-null by the assertion above
       expect(capturedBody!.customerLastName).toBe('Doe');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed non-null by the assertion above
       expect(capturedBody!.languageCode).toBe('nl');
       // customerName must NOT be in the request body (backend derives it)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed non-null by the assertion above
       expect('customerName' in capturedBody!).toBe(false);
 
       // Verify that the response customerName is preserved (display compat)
@@ -140,9 +144,12 @@ describe('ordersApi', () => {
       await ordersApi.createInStore('frietjes', 'shop-1', payload);
 
       expect(capturedBody).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed non-null by the assertion above
       expect(capturedBody!.customerFirstName).toBe('Staff');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed non-null by the assertion above
       expect(capturedBody!.customerLastName).toBe('Member');
       // Old field must not be present in the request body
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed non-null by the assertion above
       expect('customerName' in capturedBody!).toBe(false);
     });
   });

--- a/src/frontend/src/api/brandStaff.ts
+++ b/src/frontend/src/api/brandStaff.ts
@@ -31,6 +31,6 @@ export const brandStaffApi = {
 
   deactivate: (brandSlug: string, roleId: string): Promise<void> =>
     apiClient
-      .post<void>(`/brands/${brandSlug}/staff/${roleId}/deactivate`)
+      .post(`/brands/${brandSlug}/staff/${roleId}/deactivate`)
       .then(() => undefined),
 };

--- a/src/frontend/src/api/brands.ts
+++ b/src/frontend/src/api/brands.ts
@@ -32,10 +32,10 @@ export const brandsApi = {
     apiClient.put<Brand>(`/brands/${id}`, data).then((r) => r.data),
 
   deactivate: (id: string): Promise<void> =>
-    apiClient.post<void>(`/brands/${id}/deactivate`).then(() => undefined),
+    apiClient.post(`/brands/${id}/deactivate`).then(() => undefined),
 
   activate: (id: string): Promise<void> =>
-    apiClient.post<void>(`/brands/${id}/activate`).then(() => undefined),
+    apiClient.post(`/brands/${id}/activate`).then(() => undefined),
 
   configureStaffAuth: (slug: string, method: StaffAuthMethod): Promise<Brand> => {
     const methodMap: Record<StaffAuthMethod, number> = {

--- a/src/frontend/src/api/client.ts
+++ b/src/frontend/src/api/client.ts
@@ -59,6 +59,7 @@ apiClient.interceptors.response.use(
         window.dispatchEvent(new CustomEvent('auth:access-denied'));
       }
     }
+    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- must re-reject the original axios error unchanged so downstream axios.isAxiosError checks and callers see the real rejection value
     return Promise.reject(error);
   },
 );

--- a/src/frontend/src/api/menuCategories.ts
+++ b/src/frontend/src/api/menuCategories.ts
@@ -76,7 +76,7 @@ export const menuCategoriesApi = {
     data: ReorderMenuCategoryRequest,
   ): Promise<void> =>
     apiClient
-      .patch<void>(`/brands/${brandSlug}/menu-categories/${id}/sort-order`, data)
+      .patch(`/brands/${brandSlug}/menu-categories/${id}/sort-order`, data)
       .then(toVoid),
 
   assignProduct: (
@@ -84,7 +84,7 @@ export const menuCategoriesApi = {
     data: AssignProductRequest,
   ): Promise<void> =>
     apiClient
-      .post<void>(`/brands/${brandSlug}/menu-categories/assign-product`, data)
+      .post(`/brands/${brandSlug}/menu-categories/assign-product`, data)
       .then(toVoid),
 
   listProducts: (brandSlug: string, categoryId: string): Promise<ProductListItem[]> =>
@@ -98,7 +98,7 @@ export const menuCategoriesApi = {
     data: ReorderProductsRequest,
   ): Promise<void> =>
     apiClient
-      .put<void>(
+      .put(
         `/brands/${brandSlug}/menu-categories/${categoryId}/products/order`,
         data,
       )

--- a/src/frontend/src/api/platformAdmins.ts
+++ b/src/frontend/src/api/platformAdmins.ts
@@ -18,5 +18,5 @@ export const platformAdminsApi = {
     apiClient.post<PlatformAdmin>('/platform-admins', data).then((r) => r.data),
 
   deactivate: (id: string): Promise<void> =>
-    apiClient.post<void>(`/platform-admins/${id}/deactivate`).then(() => undefined),
+    apiClient.post(`/platform-admins/${id}/deactivate`).then(() => undefined),
 };

--- a/src/frontend/src/api/shops.ts
+++ b/src/frontend/src/api/shops.ts
@@ -82,12 +82,12 @@ export const shopsApi = {
 
   deactivate: (brandSlug: string, id: string): Promise<void> =>
     apiClient
-      .post<void>(`/brands/${brandSlug}/shops/${id}/deactivate`)
+      .post(`/brands/${brandSlug}/shops/${id}/deactivate`)
       .then(() => undefined),
 
   activate: (brandSlug: string, id: string): Promise<void> =>
     apiClient
-      .post<void>(`/brands/${brandSlug}/shops/${id}/activate`)
+      .post(`/brands/${brandSlug}/shops/${id}/activate`)
       .then(() => undefined),
 
   /**

--- a/src/frontend/src/api/useSignalR.ts
+++ b/src/frontend/src/api/useSignalR.ts
@@ -94,7 +94,7 @@ export function useSignalR(options: UseSignalROptions = {}) {
           setStatus('connected');
           void joinGroups(conn);
         })
-        .catch((err) => {
+        .catch((err: unknown) => {
           console.error('[SignalR] Connection failed:', err);
           setStatus('disconnected');
         });
@@ -109,10 +109,14 @@ export function useSignalR(options: UseSignalROptions = {}) {
       const current = groupsRef.current;
       if (conn.state === HubConnectionState.Connected) {
         if (current.shopGroup && shopGroup) {
-          conn.invoke('LeaveShopGroup', shopGroup.brandSlug, shopGroup.shopId).catch(() => {});
+          conn.invoke('LeaveShopGroup', shopGroup.brandSlug, shopGroup.shopId).catch(() => {
+            // Intentionally ignored: connection may be closing during unmount.
+          });
         }
         if (current.orderGroup && orderId) {
-          conn.invoke('LeaveOrderGroup', orderId).catch(() => {});
+          conn.invoke('LeaveOrderGroup', orderId).catch(() => {
+            // Intentionally ignored: connection may be closing during unmount.
+          });
         }
       }
       groupsRef.current = {};

--- a/src/frontend/src/auth/MockAuthProvider.tsx
+++ b/src/frontend/src/auth/MockAuthProvider.tsx
@@ -58,6 +58,7 @@ interface MockAuthProviderProps {
  */
 export function MockAuthProvider({ children }: MockAuthProviderProps) {
   const initialRole = (import.meta.env.VITE_MOCK_ROLE as UserRole | undefined) ?? 'platform-admin';
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- env var is typed string but is undefined at runtime when unset; fallback is load-bearing
   const initialDisplayName = import.meta.env.VITE_MOCK_DISPLAY_NAME ?? 'Dev User';
 
   const [currentRole, setCurrentRole] = useState<UserRole>(initialRole);

--- a/src/frontend/src/auth/__tests__/BffAuthProvider.test.tsx
+++ b/src/frontend/src/auth/__tests__/BffAuthProvider.test.tsx
@@ -39,7 +39,7 @@ describe('BffAuthProvider', () => {
     vi.restoreAllMocks();
   });
 
-  it('shows loading state while /bff/user is being fetched', async () => {
+  it('shows loading state while /bff/user is being fetched', () => {
     // Make /bff/user hang for a moment
     server.use(
       http.get('/bff/user', async () => {

--- a/src/frontend/src/auth/__tests__/useSessionKeepalive.test.tsx
+++ b/src/frontend/src/auth/__tests__/useSessionKeepalive.test.tsx
@@ -74,6 +74,7 @@ describe('useSessionKeepalive', () => {
 
     renderHook(() => { useSessionKeepalive(true); });
     window.dispatchEvent(new MouseEvent('mousemove'));
+    // eslint-disable-next-line @typescript-eslint/require-await -- async act() flushes pending effects/microtasks after the timer advance; sync act() would not preserve that behavior
     await act(async () => {
       vi.advanceTimersByTime(600);
     });
@@ -91,6 +92,7 @@ describe('useSessionKeepalive', () => {
     await expectAuthSessionExpired(async () => {
       renderHook(() => { useSessionKeepalive(true); });
       window.dispatchEvent(new MouseEvent('mousemove'));
+      // eslint-disable-next-line @typescript-eslint/require-await -- async act() flushes pending effects/microtasks after the timer advance; sync act() would not preserve that behavior
       await act(async () => {
         vi.advanceTimersByTime(600);
       });

--- a/src/frontend/src/features/admin/forms/ComboTranslationFields.tsx
+++ b/src/frontend/src/features/admin/forms/ComboTranslationFields.tsx
@@ -19,7 +19,7 @@ export function ComboTranslationFields({
   activeTab,
   register,
   nlNameError,
-}: ComboTranslationFieldsProps): JSX.Element {
+}: ComboTranslationFieldsProps): React.JSX.Element {
   if (activeTab === 'nl') {
     return (
       <>

--- a/src/frontend/src/features/admin/forms/ComponentProductPicker.tsx
+++ b/src/frontend/src/features/admin/forms/ComponentProductPicker.tsx
@@ -19,7 +19,7 @@ export function ComponentProductPicker({
   simpleProducts,
   selectedIds,
   onAdd,
-}: ComponentProductPickerProps): JSX.Element | null {
+}: ComponentProductPickerProps): React.JSX.Element | null {
   const { t } = useTranslation();
 
   if (simpleProducts.length === 0) return null;

--- a/src/frontend/src/features/admin/forms/FormSection.tsx
+++ b/src/frontend/src/features/admin/forms/FormSection.tsx
@@ -16,7 +16,7 @@ export function FormSection({
   description,
   defaultOpen = true,
   children,
-}: FormSectionProps): JSX.Element {
+}: FormSectionProps): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (

--- a/src/frontend/src/features/admin/forms/NestedItemList.tsx
+++ b/src/frontend/src/features/admin/forms/NestedItemList.tsx
@@ -25,7 +25,7 @@ interface NestedItemListProps<TFormValues extends FieldValues, TItem> {
  */
 export function NestedItemList<TFormValues extends FieldValues, TItem>(
   props: NestedItemListProps<TFormValues, TItem>,
-): JSX.Element {
+): React.JSX.Element {
   const { form, name, renderRow, newItem, addLabel = 'Add' } = props;
   const { fields, append, remove } = useFieldArray<TFormValues>({
     control: form.control,

--- a/src/frontend/src/features/admin/forms/ResourceFormShell.tsx
+++ b/src/frontend/src/features/admin/forms/ResourceFormShell.tsx
@@ -21,7 +21,7 @@ export function ResourceFormShell({
   resourceName,
   onCancel,
   children,
-}: ResourceFormShellProps): JSX.Element {
+}: ResourceFormShellProps): React.JSX.Element {
   if (isFetching) {
     return (
       <main style={{ padding: '1.5rem' }}>

--- a/src/frontend/src/features/admin/forms/SelectedComponentsList.tsx
+++ b/src/frontend/src/features/admin/forms/SelectedComponentsList.tsx
@@ -29,7 +29,7 @@ export function SelectedComponentsList({
   onMoveUp,
   onMoveDown,
   onRemove,
-}: SelectedComponentsListProps): JSX.Element | null {
+}: SelectedComponentsListProps): React.JSX.Element | null {
   const { t } = useTranslation();
 
   if (selectedProducts.length === 0) return null;

--- a/src/frontend/src/features/admin/forms/adminFormStyles.ts
+++ b/src/frontend/src/features/admin/forms/adminFormStyles.ts
@@ -1,4 +1,0 @@
-// Barrel re-export — all admin form styles and micro-components are defined in
-// adminFormStyles.tsx (JSX). This .ts file forwards everything so that module
-// resolution finds a single entry point for import './adminFormStyles'.
-export * from './adminFormStyles.tsx';

--- a/src/frontend/src/features/admin/forms/adminFormStyles.tsx
+++ b/src/frontend/src/features/admin/forms/adminFormStyles.tsx
@@ -1,3 +1,7 @@
+/* eslint-disable react-refresh/only-export-components --
+   Intentional shared module: exports admin-form style constants alongside two tiny
+   presentational helpers (RequiredMark, FieldError). Splitting them would churn every
+   importer for a HMR-only hint with no correctness benefit. */
 import type React from 'react';
 
 // ---------------------------------------------------------------------------
@@ -31,11 +35,11 @@ export function inputStyle(hasError: boolean): React.CSSProperties {
   };
 }
 
-export function RequiredMark(): JSX.Element {
+export function RequiredMark(): React.JSX.Element {
   return <span style={{ color: '#dc2626' }}>*</span>;
 }
 
-export function FieldError({ message }: { message: string }): JSX.Element {
+export function FieldError({ message }: { message: string }): React.JSX.Element {
   return (
     <p style={{ color: '#dc2626', fontSize: '0.75rem', marginTop: '0.25rem' }}>
       {message}

--- a/src/frontend/src/features/admin/pages/BrandCreate.tsx
+++ b/src/frontend/src/features/admin/pages/BrandCreate.tsx
@@ -95,14 +95,14 @@ export function BrandCreate() {
       },
       {
         onSuccess: () => {
-          navigate(`/${brandSlug}/${lang}/admin/brands`);
+          navigate(`/${String(brandSlug)}/${String(lang)}/admin/brands`);
         },
       },
     );
   }
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/brands`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/brands`);
   }
 
   return (

--- a/src/frontend/src/features/admin/pages/BrandEdit.tsx
+++ b/src/frontend/src/features/admin/pages/BrandEdit.tsx
@@ -55,7 +55,7 @@ export function BrandEdit() {
         : {}),
     }),
     invalidate: [brandKeys.all, brandKeys.detail(resolvedBrandId)],
-    onSuccess: () => { navigate(`/${brandSlug}/${lang}/admin/brands`); },
+    onSuccess: () => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/brands`); },
   });
 
   const { register, formState: { errors } } = form;
@@ -111,7 +111,7 @@ export function BrandEdit() {
   // ---------------------------------------------------------------------------
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/brands`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/brands`);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/frontend/src/features/admin/pages/BrandList.tsx
+++ b/src/frontend/src/features/admin/pages/BrandList.tsx
@@ -86,11 +86,11 @@ export function BrandList() {
   const { data: brands, isLoading, isError, error } = useBrands();
 
   function handleCreateClick() {
-    navigate(`/${brandSlug}/${lang}/admin/brands/new`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/brands/new`);
   }
 
   function handleRowClick(id: string) {
-    navigate(`/${brandSlug}/${lang}/admin/brands/${id}`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/brands/${id}`);
   }
 
   return (

--- a/src/frontend/src/features/admin/pages/BrandTheming.tsx
+++ b/src/frontend/src/features/admin/pages/BrandTheming.tsx
@@ -31,7 +31,7 @@ export function BrandTheming() {
   // Clean up any pending blob URL on unmount
   useEffect(() => {
     return () => {
-      if (logoPreview && logoPreview.startsWith('blob:')) {
+      if (logoPreview?.startsWith('blob:')) {
         URL.revokeObjectURL(logoPreview);
       }
     };

--- a/src/frontend/src/features/admin/pages/ComboProductCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ComboProductCreate.tsx
@@ -110,6 +110,7 @@ export function ComboProductCreate() {
   function handleMoveUp(index: number) {
     if (index === 0) return;
     const next = [...currentComponentIds];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index is in-bounds (index > 0) and next is a copy of currentComponentIds
     [next[index - 1], next[index]] = [next[index]!, next[index - 1]!];
     setValue('componentProductIds', next);
   }
@@ -117,6 +118,7 @@ export function ComboProductCreate() {
   function handleMoveDown(index: number) {
     if (index >= currentComponentIds.length - 1) return;
     const next = [...currentComponentIds];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index and index+1 are in-bounds (index < length-1) and next is a copy of currentComponentIds
     [next[index], next[index + 1]] = [next[index + 1]!, next[index]!];
     setValue('componentProductIds', next);
   }

--- a/src/frontend/src/features/admin/pages/ComboProductEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ComboProductEdit.tsx
@@ -136,7 +136,7 @@ export function ComboProductEdit() {
       componentProductIds: values.componentProductIds,
     }),
     invalidate: [productKeys.all(resolvedBrandSlug)],
-    onSuccess: () => { navigate(`/${brandSlug}/${lang}/admin/products`); },
+    onSuccess: () => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/products`); },
   });
 
   // ---------------------------------------------------------------------------
@@ -161,6 +161,7 @@ export function ComboProductEdit() {
   function handleMoveUp(index: number, currentIds: string[], onChange: (ids: string[]) => void) {
     if (index === 0) return;
     const next = [...currentIds];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index is in-bounds (index > 0) and next is a copy of currentIds
     [next[index - 1], next[index]] = [next[index]!, next[index - 1]!];
     onChange(next);
   }
@@ -168,6 +169,7 @@ export function ComboProductEdit() {
   function handleMoveDown(index: number, currentIds: string[], onChange: (ids: string[]) => void) {
     if (index >= currentIds.length - 1) return;
     const next = [...currentIds];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index and index+1 are in-bounds (index < length-1) and next is a copy of currentIds
     [next[index], next[index + 1]] = [next[index + 1]!, next[index]!];
     onChange(next);
   }
@@ -181,14 +183,14 @@ export function ComboProductEdit() {
     if (window.confirm(t('admin.comboProducts.confirmDelete', { name: nlName }))) {
       deleteProduct.mutate(resolvedProductId, {
         onSuccess: () => {
-          navigate(`/${brandSlug}/${lang}/admin/products`);
+          navigate(`/${String(brandSlug)}/${String(lang)}/admin/products`);
         },
       });
     }
   }
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/products`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/products`);
   }
 
   // ---------------------------------------------------------------------------
@@ -225,6 +227,7 @@ export function ComboProductEdit() {
     if (index === 0) return;
     setAssignedGroups((prev) => {
       const next = [...prev];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index is in-bounds (index > 0) and next is a copy of prev
       [next[index - 1], next[index]] = [next[index]!, next[index - 1]!];
       return next.map((g, i) => ({ ...g, sortOrder: i }));
     });
@@ -234,6 +237,7 @@ export function ComboProductEdit() {
     setAssignedGroups((prev) => {
       if (index >= prev.length - 1) return prev;
       const next = [...prev];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index and index+1 are in-bounds (index < length-1) and next is a copy of prev
       [next[index], next[index + 1]] = [next[index + 1]!, next[index]!];
       return next.map((g, i) => ({ ...g, sortOrder: i }));
     });
@@ -295,7 +299,7 @@ export function ComboProductEdit() {
         {t('admin.comboProducts.edit')}
       </h1>
 
-      <form onSubmit={submit} noValidate>
+      <form onSubmit={(e) => { e.preventDefault(); void submit(); }} noValidate>
         {/* Base Price */}
         <div style={{ marginBottom: '1rem' }}>
           <label style={labelStyle} htmlFor="basePrice">
@@ -399,6 +403,7 @@ export function ComboProductEdit() {
             name="componentProductIds"
             control={form.control}
             render={({ field }) => {
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- RHF Controller field.value can be undefined at runtime before the form resets to fetched values, despite the non-nullable schema type
               const currentIds: string[] = field.value ?? [];
               const selectedProducts = currentIds
                 .map((id) => allProducts?.find((p) => p.id === id))

--- a/src/frontend/src/features/admin/pages/Dashboard.tsx
+++ b/src/frontend/src/features/admin/pages/Dashboard.tsx
@@ -17,12 +17,12 @@ export function AdminDashboard() {
         <NavCard
           title="Brands"
           description="Manage brands on the platform."
-          onClick={() => { navigate(`/${brandSlug}/${lang}/admin/brands`); }}
+          onClick={() => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/brands`); }}
         />
         <NavCard
           title="Manage Shops"
           description="Create and manage shops within this brand."
-          onClick={() => { navigate(`/${brandSlug}/${lang}/admin/shops`); }}
+          onClick={() => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops`); }}
         />
       </div>
     </main>

--- a/src/frontend/src/features/admin/pages/MenuCategoryCreate.tsx
+++ b/src/frontend/src/features/admin/pages/MenuCategoryCreate.tsx
@@ -105,14 +105,14 @@ export function MenuCategoryCreate() {
       },
       {
         onSuccess: () => {
-          navigate(`/${brandSlug}/${lang}/admin/menu-categories`);
+          navigate(`/${String(brandSlug)}/${String(lang)}/admin/menu-categories`);
         },
       },
     );
   }
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/menu-categories`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/menu-categories`);
   }
 
   return (

--- a/src/frontend/src/features/admin/pages/MenuCategoryEdit.tsx
+++ b/src/frontend/src/features/admin/pages/MenuCategoryEdit.tsx
@@ -129,7 +129,7 @@ export function MenuCategoryEdit() {
         })),
     }),
     invalidate: [menuCategoryKeys.all(resolvedBrandSlug)],
-    onSuccess: () => { navigate(`/${brandSlug}/${lang}/admin/menu-categories`); },
+    onSuccess: () => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/menu-categories`); },
   });
 
   // ---------------------------------------------------------------------------
@@ -145,14 +145,14 @@ export function MenuCategoryEdit() {
     ) {
       deleteCategory.mutate(resolvedCategoryId, {
         onSuccess: () => {
-          navigate(`/${brandSlug}/${lang}/admin/menu-categories`);
+          navigate(`/${String(brandSlug)}/${String(lang)}/admin/menu-categories`);
         },
       });
     }
   }
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/menu-categories`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/menu-categories`);
   }
 
   function moveProduct(index: number, direction: 'up' | 'down') {
@@ -208,7 +208,7 @@ export function MenuCategoryEdit() {
         Edit Menu Category
       </h1>
 
-      <form onSubmit={submit} noValidate>
+      <form onSubmit={(e) => { e.preventDefault(); void submit(); }} noValidate>
         {/* Sort Order */}
         <div style={{ marginBottom: '1rem' }}>
           <label style={labelStyle} htmlFor="sortOrder">

--- a/src/frontend/src/features/admin/pages/MenuCategoryList.tsx
+++ b/src/frontend/src/features/admin/pages/MenuCategoryList.tsx
@@ -148,11 +148,11 @@ export function MenuCategoryList() {
   const reorderCategory = useReorderMenuCategory(resolvedBrandSlug);
 
   function handleCreateClick() {
-    navigate(`/${brandSlug}/${lang}/admin/menu-categories/new`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/menu-categories/new`);
   }
 
   function handleRowClick(id: string) {
-    navigate(`/${brandSlug}/${lang}/admin/menu-categories/${id}`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/menu-categories/${id}`);
   }
 
   function handleDelete(id: string) {

--- a/src/frontend/src/features/admin/pages/ModifierGroupCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ModifierGroupCreate.tsx
@@ -150,14 +150,14 @@ export function ModifierGroupCreate() {
       },
       {
         onSuccess: () => {
-          navigate(`/${brandSlug}/${lang}/admin/modifier-groups`);
+          navigate(`/${String(brandSlug)}/${String(lang)}/admin/modifier-groups`);
         },
       },
     );
   }
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/modifier-groups`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/modifier-groups`);
   }
 
   return (
@@ -341,12 +341,12 @@ function ModifierFormRow({
       </div>
 
       <div style={{ marginBottom: '0.5rem' }}>
-        <label style={labelStyle} htmlFor={`modifier-${index}-name-${activeTab}`}>
+        <label style={labelStyle} htmlFor={`modifier-${String(index)}-name-${activeTab}`}>
           {t('admin.modifierGroups.modifierName')} ({activeTab.toUpperCase()})
           {activeTab === primaryLocale && ' *'}
         </label>
         <input
-          id={`modifier-${index}-name-${activeTab}`}
+          id={`modifier-${String(index)}-name-${activeTab}`}
           type="text"
           value={modifier.translations[activeTab].name}
           onChange={(e) => { onUpdateTranslation(index, activeTab, e.target.value); }}
@@ -362,11 +362,11 @@ function ModifierFormRow({
       </div>
 
       <div>
-        <label style={labelStyle} htmlFor={`modifier-${index}-price`}>
+        <label style={labelStyle} htmlFor={`modifier-${String(index)}-price`}>
           {t('admin.modifierGroups.priceAdjustment')}
         </label>
         <input
-          id={`modifier-${index}-price`}
+          id={`modifier-${String(index)}-price`}
           type="number"
           step="0.01"
           value={modifier.priceAdjustment}

--- a/src/frontend/src/features/admin/pages/ModifierGroupEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ModifierGroupEdit.tsx
@@ -107,7 +107,7 @@ export function ModifierGroupEdit() {
       modifierGroupKeys.all(resolvedBrandSlug),
       modifierGroupKeys.detail(resolvedBrandSlug, resolvedId),
     ],
-    onSuccess: () => { navigate(`/${brandSlug}/${lang}/admin/modifier-groups`); },
+    onSuccess: () => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/modifier-groups`); },
   });
 
   const {
@@ -137,14 +137,14 @@ export function ModifierGroupEdit() {
     if (window.confirm(message)) {
       deleteModifierGroup.mutate(resolvedId, {
         onSuccess: () => {
-          navigate(`/${brandSlug}/${lang}/admin/modifier-groups`);
+          navigate(`/${String(brandSlug)}/${String(lang)}/admin/modifier-groups`);
         },
       });
     }
   }
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/modifier-groups`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/modifier-groups`);
   }
 
   // ---------------------------------------------------------------------------
@@ -163,7 +163,7 @@ export function ModifierGroupEdit() {
         {t('admin.modifierGroups.edit')}
       </h1>
 
-      <form onSubmit={submit} noValidate>
+      <form onSubmit={(e) => { e.preventDefault(); void submit(); }} noValidate>
         {/* Group name — Translation Tabs */}
         <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.5rem' }}>
           {t('admin.modifierGroups.name')} <RequiredMark />
@@ -386,7 +386,7 @@ function ModifierRow({ index, register, activeTab, onRemove }: ModifierRowProps)
       </div>
 
       <div style={{ marginBottom: '0.5rem' }}>
-        <label style={labelStyle} htmlFor={`modifier-${index}-name-${activeTab}`}>
+        <label style={labelStyle} htmlFor={`modifier-${String(index)}-name-${activeTab}`}>
           {t('admin.modifierGroups.modifierName')} ({activeTab.toUpperCase()})
           {activeTab === 'nl' ? ' *' : null}
         </label>
@@ -394,15 +394,15 @@ function ModifierRow({ index, register, activeTab, onRemove }: ModifierRowProps)
       </div>
 
       <div>
-        <label style={labelStyle} htmlFor={`modifier-${index}-price`}>
+        <label style={labelStyle} htmlFor={`modifier-${String(index)}-price`}>
           {t('admin.modifierGroups.priceAdjustment')}
         </label>
         <input
-          id={`modifier-${index}-price`}
+          id={`modifier-${String(index)}-price`}
           type="number"
           step="0.01"
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          {...register(`modifiers.${index}.priceAdjustment` as any, { valueAsNumber: true })}
+          {...register(`modifiers.${String(index)}.priceAdjustment` as any, { valueAsNumber: true })}
           style={{ ...inputStyle(false), maxWidth: '12rem' }}
         />
       </div>
@@ -427,10 +427,10 @@ function ModifierTranslationFields({ index, register, activeTab }: ModifierTrans
   if (activeTab === 'nl') {
     return (
       <input
-        id={`modifier-${index}-name-nl`}
+        id={`modifier-${String(index)}-name-nl`}
         type="text"
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {...register(`modifiers.${index}.translations.nl.name` as any)}
+        {...register(`modifiers.${String(index)}.translations.nl.name` as any)}
         style={inputStyle(false)}
         placeholder="Modifier name in NL"
       />
@@ -439,10 +439,10 @@ function ModifierTranslationFields({ index, register, activeTab }: ModifierTrans
   if (activeTab === 'fr') {
     return (
       <input
-        id={`modifier-${index}-name-fr`}
+        id={`modifier-${String(index)}-name-fr`}
         type="text"
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {...register(`modifiers.${index}.translations.fr.name` as any)}
+        {...register(`modifiers.${String(index)}.translations.fr.name` as any)}
         style={inputStyle(false)}
         placeholder="Modifier name in FR"
       />
@@ -450,10 +450,10 @@ function ModifierTranslationFields({ index, register, activeTab }: ModifierTrans
   }
   return (
     <input
-      id={`modifier-${index}-name-de`}
+      id={`modifier-${String(index)}-name-de`}
       type="text"
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      {...register(`modifiers.${index}.translations.de.name` as any)}
+      {...register(`modifiers.${String(index)}.translations.de.name` as any)}
       style={inputStyle(false)}
       placeholder="Modifier name in DE"
     />

--- a/src/frontend/src/features/admin/pages/ModifierGroupList.tsx
+++ b/src/frontend/src/features/admin/pages/ModifierGroupList.tsx
@@ -72,11 +72,11 @@ export function ModifierGroupList() {
   const deleteModifierGroup = useDeleteModifierGroup(resolvedBrandSlug);
 
   function handleCreateClick() {
-    navigate(`/${brandSlug}/${lang}/admin/modifier-groups/new`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/modifier-groups/new`);
   }
 
   function handleRowClick(id: string) {
-    navigate(`/${brandSlug}/${lang}/admin/modifier-groups/${id}`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/modifier-groups/${id}`);
   }
 
   function handleDelete(id: string) {

--- a/src/frontend/src/features/admin/pages/ProductCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ProductCreate.tsx
@@ -170,6 +170,7 @@ export function ProductCreate() {
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                 {ALLERGEN_KEYS.map((key) => {
                   const val = Allergen[key];
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                   const checked = (field.value ?? []).includes(val);
                   return (
                     <label
@@ -187,8 +188,10 @@ export function ProductCreate() {
                         checked={checked}
                         onChange={() => {
                           if (checked) {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange((field.value ?? []).filter((v) => v !== val));
                           } else {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange([...(field.value ?? []), val]);
                           }
                         }}
@@ -214,6 +217,7 @@ export function ProductCreate() {
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                 {DIETARY_TAG_KEYS.map((key) => {
                   const val = DietaryTag[key];
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                   const checked = (field.value ?? []).includes(val);
                   return (
                     <label
@@ -231,8 +235,10 @@ export function ProductCreate() {
                         checked={checked}
                         onChange={() => {
                           if (checked) {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange((field.value ?? []).filter((v) => v !== val));
                           } else {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange([...(field.value ?? []), val]);
                           }
                         }}

--- a/src/frontend/src/features/admin/pages/ProductEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ProductEdit.tsx
@@ -123,7 +123,9 @@ export function ProductEdit() {
       imageUrl: product.imageUrl ?? '',
       translations: buildTranslationsMap(product.translations),
       // allergens/dietaryTags stored as number[] at form layer (was Set<number>)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- product is API/JSON data; arrays may be absent at runtime despite the type
       allergens: product.allergens ?? [],
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- product is API/JSON data; arrays may be absent at runtime despite the type
       dietaryTags: product.dietaryTags ?? [],
     }),
     toUpdatePayload: (values) => ({
@@ -140,7 +142,7 @@ export function ProductEdit() {
       dietaryTags: values.dietaryTags,
     }),
     invalidate: [productKeys.all(resolvedBrandSlug)],
-    onSuccess: () => { navigate(`/${brandSlug}/${lang}/admin/products`); },
+    onSuccess: () => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/products`); },
   });
 
   // ---------------------------------------------------------------------------
@@ -152,14 +154,14 @@ export function ProductEdit() {
     if (window.confirm(t('admin.products.confirmDelete', { name: nlName }))) {
       deleteProduct.mutate(resolvedProductId, {
         onSuccess: () => {
-          navigate(`/${brandSlug}/${lang}/admin/products`);
+          navigate(`/${String(brandSlug)}/${String(lang)}/admin/products`);
         },
       });
     }
   }
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/products`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/products`);
   }
 
   // ---------------------------------------------------------------------------
@@ -196,7 +198,11 @@ export function ProductEdit() {
     if (index === 0) return;
     setAssignedGroups((prev) => {
       const next = [...prev];
-      [next[index - 1], next[index]] = [next[index]!, next[index - 1]!];
+      const current = next[index];
+      const above = next[index - 1];
+      if (current === undefined || above === undefined) return prev;
+      next[index - 1] = current;
+      next[index] = above;
       return next.map((g, i) => ({ ...g, sortOrder: i }));
     });
   }
@@ -205,7 +211,11 @@ export function ProductEdit() {
     setAssignedGroups((prev) => {
       if (index >= prev.length - 1) return prev;
       const next = [...prev];
-      [next[index], next[index + 1]] = [next[index + 1]!, next[index]!];
+      const current = next[index];
+      const below = next[index + 1];
+      if (current === undefined || below === undefined) return prev;
+      next[index] = below;
+      next[index + 1] = current;
       return next.map((g, i) => ({ ...g, sortOrder: i }));
     });
   }
@@ -246,7 +256,7 @@ export function ProductEdit() {
         {t('admin.products.edit')}
       </h1>
 
-      <form onSubmit={submit} noValidate>
+      <form onSubmit={(e) => { e.preventDefault(); void submit(); }} noValidate>
         {/* Base Price */}
         <div style={{ marginBottom: '1rem' }}>
           <label style={labelStyle} htmlFor="basePrice">
@@ -307,6 +317,7 @@ export function ProductEdit() {
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                 {ALLERGEN_KEYS.map((key) => {
                   const val = Allergen[key];
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                   const checked = (field.value ?? []).includes(val);
                   return (
                     <label
@@ -324,8 +335,10 @@ export function ProductEdit() {
                         checked={checked}
                         onChange={() => {
                           if (checked) {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange((field.value ?? []).filter((v) => v !== val));
                           } else {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange([...(field.value ?? []), val]);
                           }
                         }}
@@ -351,6 +364,7 @@ export function ProductEdit() {
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                 {DIETARY_TAG_KEYS.map((key) => {
                   const val = DietaryTag[key];
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                   const checked = (field.value ?? []).includes(val);
                   return (
                     <label
@@ -368,8 +382,10 @@ export function ProductEdit() {
                         checked={checked}
                         onChange={() => {
                           if (checked) {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange((field.value ?? []).filter((v) => v !== val));
                           } else {
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
                             field.onChange([...(field.value ?? []), val]);
                           }
                         }}
@@ -496,7 +512,9 @@ export function ProductEdit() {
               // The assignment endpoint returns only { modifierGroupId, sortOrder };
               // resolve the display name + modifier count from the full group list.
               const info = allModifierGroups?.find((g) => g.id === group.modifierGroupId);
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- group is API/JSON data; name may be absent at runtime despite the type
               const groupName = info?.name ?? group.name ?? '';
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- group is API/JSON data; modifiers may be absent at runtime despite the type
               const modifierCount = info?.modifierCount ?? group.modifiers?.length ?? 0;
               return (
               <div

--- a/src/frontend/src/features/admin/pages/ProductList.tsx
+++ b/src/frontend/src/features/admin/pages/ProductList.tsx
@@ -96,19 +96,19 @@ export function ProductList() {
   const deleteProduct = useDeleteProduct(resolvedBrandSlug);
 
   function handleCreateClick() {
-    navigate(`/${brandSlug}/${lang}/admin/products/new`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/products/new`);
   }
 
   function handleCreateComboClick() {
-    navigate(`/${brandSlug}/${lang}/admin/combo-products/new`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/combo-products/new`);
   }
 
   function handleRowClick(id: string) {
     const product = products?.find((p) => p.id === id);
     if (product?.productType === 'Combo') {
-      navigate(`/${brandSlug}/${lang}/admin/combo-products/${id}`);
+      navigate(`/${String(brandSlug)}/${String(lang)}/admin/combo-products/${id}`);
     } else {
-      navigate(`/${brandSlug}/${lang}/admin/products/${id}`);
+      navigate(`/${String(brandSlug)}/${String(lang)}/admin/products/${id}`);
     }
   }
 

--- a/src/frontend/src/features/admin/pages/ShopEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ShopEdit.tsx
@@ -107,7 +107,7 @@ export function ShopEdit() {
         : {}),
     }),
     invalidate: [shopKeys.all(resolvedBrandSlug), shopKeys.detail(resolvedBrandSlug, resolvedShopId)],
-    onSuccess: () => { navigate(`/${brandSlug}/${lang}/admin/shops`); },
+    onSuccess: () => { navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops`); },
   });
 
   const { register, watch, formState: { errors } } = form;
@@ -119,7 +119,7 @@ export function ShopEdit() {
   // ---------------------------------------------------------------------------
 
   function handleCancel() {
-    navigate(`/${brandSlug}/${lang}/admin/shops`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops`);
   }
 
   // ---------------------------------------------------------------------------
@@ -518,7 +518,7 @@ export function ShopEdit() {
           <button
             type="button"
             onClick={() =>
-              { navigate(`/${brandSlug}/${lang}/admin/shops/${resolvedShopId}/opening-hours`); }
+              { navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops/${resolvedShopId}/opening-hours`); }
             }
             style={{
               padding: '0.5rem 1.25rem',
@@ -535,7 +535,7 @@ export function ShopEdit() {
           <button
             type="button"
             onClick={() =>
-              { navigate(`/${brandSlug}/${lang}/admin/shops/${resolvedShopId}/order-lifecycle`); }
+              { navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops/${resolvedShopId}/order-lifecycle`); }
             }
             style={{
               padding: '0.5rem 1.25rem',

--- a/src/frontend/src/features/admin/pages/ShopList.tsx
+++ b/src/frontend/src/features/admin/pages/ShopList.tsx
@@ -90,11 +90,11 @@ export function ShopList() {
   const { data: shops, isLoading, isError, error } = useShops(resolvedBrandSlug);
 
   function handleCreateClick() {
-    navigate(`/${brandSlug}/${lang}/admin/shops/new`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops/new`);
   }
 
   function handleRowClick(id: string) {
-    navigate(`/${brandSlug}/${lang}/admin/shops/${id}`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops/${id}`);
   }
 
   return (

--- a/src/frontend/src/features/admin/pages/ShopOpeningHours.tsx
+++ b/src/frontend/src/features/admin/pages/ShopOpeningHours.tsx
@@ -38,7 +38,7 @@ interface LocalTimeBlock {
 let _localIdCounter = 0;
 function nextLocalId(): string {
   _localIdCounter += 1;
-  return `local-${_localIdCounter}`;
+  return `local-${String(_localIdCounter)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,10 +81,10 @@ function validateBlocks(blocks: LocalTimeBlock[]): ValidationErrors {
     // Sort by openTime for overlap detection
     const sorted = [...dayBlocks].sort((a, b) => (a.openTime < b.openTime ? -1 : 1));
     for (let i = 1; i < sorted.length; i++) {
-      const prev = sorted[i - 1]!;
-      const curr = sorted[i]!;
+      const prev = sorted[i - 1];
+      const curr = sorted[i];
       // Overlap when current opens before previous closes
-      if (prev.closeTime > curr.openTime) {
+      if (prev && curr && prev.closeTime > curr.openTime) {
         errors[curr.localId] = 'Time blocks cannot overlap on the same day.';
       }
     }
@@ -147,11 +147,9 @@ export function ShopOpeningHours() {
 
   function removeBlock(localId: string) {
     setBlocks((prev) => prev.filter((b) => b.localId !== localId));
-    setValidationErrors((prev) => {
-      const next = { ...prev };
-      delete next[localId];
-      return next;
-    });
+    setValidationErrors((prev) =>
+      Object.fromEntries(Object.entries(prev).filter(([key]) => key !== localId)),
+    );
   }
 
   function updateBlock(localId: string, field: 'openTime' | 'closeTime', value: string) {
@@ -187,7 +185,7 @@ export function ShopOpeningHours() {
   }
 
   function handleBack() {
-    navigate(`/${brandSlug}/${lang}/admin/shops/${resolvedShopId}`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/admin/shops/${resolvedShopId}`);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/frontend/src/features/admin/pages/ShopOrderLifecycle.tsx
+++ b/src/frontend/src/features/admin/pages/ShopOrderLifecycle.tsx
@@ -33,7 +33,7 @@ interface LocalTransition {
 let _localIdCounter = 0;
 function nextLocalId(): string {
   _localIdCounter += 1;
-  return `local-${_localIdCounter}`;
+  return `local-${String(_localIdCounter)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -284,7 +284,7 @@ export function ShopOrderLifecycle() {
       >
         <button
           type="button"
-          onClick={() => { navigate(`/${brandSlug}/${lang}/admin/shops/${shopId}`); }}
+          onClick={() => { navigate(`/${brandSlug}/${String(lang)}/admin/shops/${shopId}`); }}
           style={{
             background: 'none',
             border: 'none',
@@ -354,7 +354,7 @@ export function ShopOrderLifecycle() {
                 border: `1px solid ${s.isTerminal ? '#bbf7d0' : '#bfdbfe'}`,
               }}
             >
-              {s.name || `Status ${s.sortOrder}`}
+              {s.name || `Status ${String(s.sortOrder)}`}
               {s.isTerminal ? ' *' : ''}
             </span>
             {i < statuses.length - 1 && (
@@ -577,7 +577,7 @@ export function ShopOrderLifecycle() {
           >
             {statuses.map((s) => (
               <option key={s.sortOrder} value={s.sortOrder}>
-                {s.name || `Status ${s.sortOrder}`}
+                {s.name || `Status ${String(s.sortOrder)}`}
               </option>
             ))}
           </select>
@@ -602,7 +602,7 @@ export function ShopOrderLifecycle() {
           >
             {statuses.map((s) => (
               <option key={s.sortOrder} value={s.sortOrder}>
-                {s.name || `Status ${s.sortOrder}`}
+                {s.name || `Status ${String(s.sortOrder)}`}
               </option>
             ))}
           </select>

--- a/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
+++ b/src/frontend/src/features/admin/pages/TaxConfiguration.tsx
@@ -267,7 +267,7 @@ export function TaxConfiguration() {
               amount={breakdown.netAmount}
             />
             <BreakdownRow
-              label={`${t('admin.taxConfiguration.vatAmount')} (${rates[calcMode]}%)`}
+              label={`${t('admin.taxConfiguration.vatAmount')} (${String(rates[calcMode])}%)`}
               amount={breakdown.vatAmount}
             />
             <BreakdownRow

--- a/src/frontend/src/features/admin/pages/__tests__/BrandTheming.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/BrandTheming.test.tsx
@@ -100,7 +100,7 @@ describe('BrandTheming', () => {
 
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
     expect(capturedBody).toMatchObject({
-      colors: expect.objectContaining({ primary: '#111827' }),
+      colors: expect.objectContaining({ primary: '#111827' }) as unknown,
     });
   });
 

--- a/src/frontend/src/features/admin/pages/__tests__/ComboProductCreate.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ComboProductCreate.test.tsx
@@ -150,6 +150,7 @@ describe('ComboProductCreate', () => {
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
     // Assert the POST body contains the name and the component product id
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;
@@ -157,6 +158,7 @@ describe('ComboProductCreate', () => {
     expect(translations.some((t) => t.languageCode === 'nl' && t.name === 'Friet + Drank')).toBe(
       true,
     );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const componentIds = capturedBody!.componentProductIds as string[];
     expect(componentIds).toContain('prod-simple-1');
     expect(componentIds).toContain('prod-simple-2');

--- a/src/frontend/src/features/admin/pages/__tests__/ComboProductEdit.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ComboProductEdit.test.tsx
@@ -138,7 +138,7 @@ describe('ComboProductEdit', () => {
           dietaryTags: [],
           comboItems: (capturedBody.componentProductIds as string[]).map((id, i) => ({
             componentProductId: id,
-            name: `Product ${i + 1}`,
+            name: `Product ${String(i + 1)}`,
             sortOrder: i,
           })),
           createdAt: '2024-01-01T00:00:00Z',
@@ -170,6 +170,7 @@ describe('ComboProductEdit', () => {
     });
 
     // Translations array must contain the NL entry with the original name
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;

--- a/src/frontend/src/features/admin/pages/__tests__/MenuCategoryCreate.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/MenuCategoryCreate.test.tsx
@@ -93,6 +93,7 @@ describe('MenuCategoryCreate', () => {
 
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;

--- a/src/frontend/src/features/admin/pages/__tests__/MenuCategoryEdit.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/MenuCategoryEdit.test.tsx
@@ -133,6 +133,7 @@ describe('MenuCategoryEdit', () => {
     expect(capturedBody).toMatchObject({ sortOrder: 7 });
 
     // Translations array must contain the NL entry with the original name
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;

--- a/src/frontend/src/features/admin/pages/__tests__/ModifierGroupCreate.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ModifierGroupCreate.test.tsx
@@ -91,6 +91,7 @@ describe('ModifierGroupCreate', () => {
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
     // Assert the POST body contains the NL group name
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;
@@ -98,12 +99,14 @@ describe('ModifierGroupCreate', () => {
     expect(translations.some((t) => t.languageCode === 'nl' && t.name === 'Sauzen')).toBe(true);
 
     // Assert the POST body contains at least one modifier with NL name
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const modifiers = capturedBody!.modifiers as {
       translations: { languageCode: string; name: string }[];
       priceAdjustment: number;
       sortOrder: number;
     }[];
     expect(modifiers.length).toBeGreaterThanOrEqual(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length asserted >= 1 above, so index 0 exists
     const firstModifier = modifiers[0]!;
     expect(
       firstModifier.translations.some((t) => t.languageCode === 'nl' && t.name === 'Mayonaise'),

--- a/src/frontend/src/features/admin/pages/__tests__/ModifierGroupEdit.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ModifierGroupEdit.test.tsx
@@ -118,6 +118,7 @@ describe('ModifierGroupEdit', () => {
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
     // The PUT body should contain the updated NL translation
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody is non-null per the waitFor assertion above
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;
@@ -148,6 +149,7 @@ describe('ModifierGroupEdit', () => {
     // The page renders multiple "Verwijderen" buttons (one per modifier row plus
     // the group-level delete). The group delete button is the last one in the DOM.
     const verwijderenButtons = screen.getAllByRole('button', { name: /verwijderen/i });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByRole guarantees a non-empty array, so the last index exists
     const deleteButton = verwijderenButtons[verwijderenButtons.length - 1]!;
     await user.click(deleteButton);
 

--- a/src/frontend/src/features/admin/pages/__tests__/ModifierGroupList.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ModifierGroupList.test.tsx
@@ -84,6 +84,7 @@ describe('ModifierGroupList', () => {
     await screen.findByText('Sauzen');
 
     // Click the row — the <tr> element containing "Sauzen"
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the clickable row is rendered once "Sauzen" is found above
     const row = container.querySelector('tr[style*="cursor: pointer"]')!;
     await user.click(row);
 

--- a/src/frontend/src/features/admin/pages/__tests__/PlatformAdminList.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/PlatformAdminList.test.tsx
@@ -81,6 +81,7 @@ describe('PlatformAdminList', () => {
     // A confirmation dialog appears — click the confirm (second "Deactiveren") button
     const confirmBtns = await screen.findAllByRole('button', { name: /deactiveren/i });
     // The confirm button inside the dialog is the last one
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- findAllByRole guarantees a non-empty array, so the last element exists
     await user.click(confirmBtns[confirmBtns.length - 1]!);
 
     await waitFor(() => { expect(deactivateCalled).toBe(true); });
@@ -121,7 +122,9 @@ describe('PlatformAdminList', () => {
     // The form has two inputs: email (index 0) and displayName (index 1).
     // Labels are not associated via htmlFor so we query by role index.
     const textboxes = screen.getAllByRole('textbox');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the invite form renders exactly two textboxes (email, displayName)
     const emailInput = textboxes[0]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the invite form renders exactly two textboxes (email, displayName)
     const displayNameInput = textboxes[1]!;
 
     await user.type(emailInput, 'new@platform.dev');
@@ -130,10 +133,13 @@ describe('PlatformAdminList', () => {
     // Submit — button text is "Beheerder uitnodigen" inside the form
     const submitBtns = screen.getAllByRole('button', { name: /beheerder uitnodigen/i });
     // The submit button inside the form is the last rendered one
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByRole guarantees a non-empty array, so the last element exists
     await user.click(submitBtns[submitBtns.length - 1]!);
 
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.email).toBe('new@platform.dev');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.displayName).toBe('New Admin');
   });
 
@@ -152,11 +158,13 @@ describe('PlatformAdminList', () => {
     // Fill in displayName but leave email empty.
     // Labels are not associated via htmlFor; query by role index (displayName is index 1).
     const textboxes = screen.getAllByRole('textbox');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the invite form renders exactly two textboxes (email, displayName)
     const displayNameInput = textboxes[1]!;
     await user.type(displayNameInput, 'New Admin');
 
     // Submit without filling in email
     const submitBtns = screen.getAllByRole('button', { name: /beheerder uitnodigen/i });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByRole guarantees a non-empty array, so the last element exists
     await user.click(submitBtns[submitBtns.length - 1]!);
 
     // Validation error: source builds "E-mailadres is required."

--- a/src/frontend/src/features/admin/pages/__tests__/ProductCreate.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ProductCreate.test.tsx
@@ -99,9 +99,11 @@ describe('ProductCreate', () => {
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
     // Assert basePrice
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.basePrice).toBe(3.5);
 
     // Assert NL translation is present
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;

--- a/src/frontend/src/features/admin/pages/__tests__/ProductEdit.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ProductEdit.test.tsx
@@ -131,6 +131,7 @@ describe('ProductEdit', () => {
     expect(capturedBody).toMatchObject({ basePrice: 5.99 });
 
     // Translations array must contain the NL entry with the original name
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     const translations = capturedBody!.translations as {
       languageCode: string;
       name: string;

--- a/src/frontend/src/features/admin/pages/__tests__/ProductList.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ProductList.test.tsx
@@ -78,6 +78,7 @@ describe('ProductList', () => {
     const productName = await screen.findByText('Kleine friet');
 
     // Click the table row that contains the product name
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the product name cell is rendered inside a table row, so closest('tr') always resolves
     const row = productName.closest('tr')!;
     await user.click(row);
 

--- a/src/frontend/src/features/admin/pages/__tests__/ShopCreate.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ShopCreate.test.tsx
@@ -106,10 +106,14 @@ describe('ShopCreate', () => {
 
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.name).toBe('Gent Centrum');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.slug).toBe('gent-centrum');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.contactEmail).toBe('gent@frietjes.be');
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     const address = capturedBody!.address as Record<string, string>;
     expect(address.street).toBe('Veldstraat');
     expect(address.number).toBe('12');

--- a/src/frontend/src/features/admin/pages/__tests__/ShopEdit.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ShopEdit.test.tsx
@@ -115,6 +115,7 @@ describe('ShopEdit', () => {
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
     expect(capturedBody).toMatchObject({
       name: 'Frietjes Gent Updated',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.objectContaining is typed as any by vitest; the asymmetric matcher is used as-is
       address: expect.objectContaining({ city: 'Gent' }),
     });
   });

--- a/src/frontend/src/features/admin/pages/__tests__/ShopOpeningHours.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ShopOpeningHours.test.tsx
@@ -57,6 +57,7 @@ describe('ShopOpeningHours', () => {
 
     // Click the first "Tijdblok toevoegen" button (Monday's add button)
     const addButtons = screen.getAllByRole('button', { name: /tijdblok toevoegen/i });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByRole guarantees a non-empty array, so the first element exists
     await user.click(addButtons[0]!);
 
     // A new row should have been added — one more remove button
@@ -89,7 +90,9 @@ describe('ShopOpeningHours', () => {
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
     // The PUT body should contain the Monday block
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.timeBlocks).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     const block = capturedBody!.timeBlocks[0] as {
       dayOfWeek: number;
       openTime: string;
@@ -111,7 +114,9 @@ describe('ShopOpeningHours', () => {
     // The existing block has openTime=09:00, closeTime=18:00 (valid).
     // Change closeTime to a value before openTime to trigger validation.
     const closeTimeInputs = screen.getAllByDisplayValue('18:00');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByDisplayValue guarantees a non-empty array, so the first element exists
     await user.clear(closeTimeInputs[0]!);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByDisplayValue guarantees a non-empty array, so the first element exists
     await user.type(closeTimeInputs[0]!, '08:00');
 
     // Click Save — should not call PUT, should show validation error instead

--- a/src/frontend/src/features/admin/pages/__tests__/ShopOrderLifecycle.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/ShopOrderLifecycle.test.tsx
@@ -100,6 +100,7 @@ describe('ShopOrderLifecycle', () => {
     // The terminal checkboxes are associated with rows; find the one in the new row
     const terminalCheckboxes = screen.getAllByRole('checkbox');
     // The last checkbox corresponds to the newly added row
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByRole guarantees a non-empty array, so the last element exists
     const lastCheckbox = terminalCheckboxes[terminalCheckboxes.length - 1]!;
     await user.click(lastCheckbox);
 
@@ -110,6 +111,7 @@ describe('ShopOrderLifecycle', () => {
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
     // The PUT body should contain statuses
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     const statuses = capturedBody!.statuses as { name: string }[];
     expect(statuses.some((s) => s.name === 'New')).toBe(true);
     expect(statuses.some((s) => s.name === 'Delivered')).toBe(true);

--- a/src/frontend/src/features/admin/pages/__tests__/StaffList.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/StaffList.test.tsx
@@ -61,6 +61,7 @@ describe('StaffList', () => {
     // A confirmation dialog appears — click the confirm button (also "Deactiveren")
     const confirmButtons = screen.getAllByRole('button', { name: /deactiveren/i });
     // The last "Deactiveren" button is inside the dialog
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getAllByRole guarantees a non-empty array, so the last element exists
     const confirmBtn = confirmButtons[confirmButtons.length - 1]!;
     await user.click(confirmBtn);
 
@@ -103,7 +104,9 @@ describe('StaffList', () => {
 
     // The form has two textboxes: first is email (type="email"), second is displayName (type="text")
     const textboxes = screen.getAllByRole('textbox');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the invite form renders exactly two textboxes (email, displayName)
     const emailInput = textboxes[0]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the invite form renders exactly two textboxes (email, displayName)
     const displayNameInput = textboxes[1]!;
 
     await user.type(emailInput, 'new@frietjes.be');
@@ -119,10 +122,14 @@ describe('StaffList', () => {
 
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.email).toBe('new@frietjes.be');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.displayName).toBe('New Staff');
     // BrandAdmin = 0
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.role).toBe(0);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     expect(capturedBody!.shopId).toBeNull();
   });
 

--- a/src/frontend/src/features/admin/pages/__tests__/TaxConfiguration.test.tsx
+++ b/src/frontend/src/features/admin/pages/__tests__/TaxConfiguration.test.tsx
@@ -36,11 +36,13 @@ describe('TaxConfiguration', () => {
     // Takeaway rate input has id="rate-Takeaway"
     const takeawayInput = container.querySelector<HTMLInputElement>('#rate-Takeaway');
     expect(takeawayInput).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- expect.not.toBeNull above asserts takeawayInput is non-null
     expect(Number(takeawayInput!.value)).toBe(6);
 
     // EatIn rate input has id="rate-EatIn"
     const eatInInput = container.querySelector<HTMLInputElement>('#rate-EatIn');
     expect(eatInInput).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- expect.not.toBeNull above asserts eatInInput is non-null
     expect(Number(eatInInput!.value)).toBe(21);
   });
 
@@ -51,6 +53,7 @@ describe('TaxConfiguration', () => {
     // Wait for the form to be ready
     await screen.findByRole('heading', { name: /btw-configuratie/i });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the rate input renders once the page has loaded (awaited above)
     const takeawayInput = container.querySelector<HTMLInputElement>('#rate-Takeaway')!;
 
     // Clear and type a new value
@@ -82,6 +85,7 @@ describe('TaxConfiguration', () => {
     await screen.findByRole('heading', { name: /btw-configuratie/i });
 
     // Change the Takeaway rate to 9
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the rate input renders once the page has loaded (awaited above)
     const takeawayInput = container.querySelector<HTMLInputElement>('#rate-Takeaway')!;
     await user.clear(takeawayInput);
     await user.type(takeawayInput, '9');
@@ -93,6 +97,7 @@ describe('TaxConfiguration', () => {
     // Wait for the PUT to be captured
     await waitFor(() => { expect(capturedBody).not.toBeNull(); });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above asserts capturedBody is non-null
     const vatRates = capturedBody!.vatRates as {
       consumptionMode: string;
       ratePercentage: number;
@@ -119,6 +124,7 @@ describe('TaxConfiguration', () => {
 
     // Change the gross amount to a different value to confirm reactivity
     // id="calc-gross" is the input for the gross amount in the example calculation section
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the gross input renders once the page has loaded (awaited above)
     const grossInput = container.querySelector<HTMLInputElement>('#calc-gross')!;
     await user.clear(grossInput);
     await user.type(grossInput, '21');

--- a/src/frontend/src/features/admin/pages/schemas/brandEditSchema.ts
+++ b/src/frontend/src/features/admin/pages/schemas/brandEditSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const brandEditSchema = z.object({
   name: z.string().min(1, { message: 'Name is required.' }),
-  contactEmail: z.string().email({ message: 'Enter a valid email address.' }),
+  contactEmail: z.email({ message: 'Enter a valid email address.' }),
   contactPhone: z.string(),
 });
 

--- a/src/frontend/src/features/admin/pages/schemas/shopCreateSchema.ts
+++ b/src/frontend/src/features/admin/pages/schemas/shopCreateSchema.ts
@@ -15,7 +15,7 @@ export const shopCreateSchema = z.object({
     postalCode: z.string().min(1, { message: 'Postal code is required.' }),
     country: z.string().min(1),
   }),
-  contactEmail: z.string().email({ message: 'Enter a valid email address.' }),
+  contactEmail: z.email({ message: 'Enter a valid email address.' }),
   contactPhone: z.string(),
 });
 

--- a/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
+++ b/src/frontend/src/features/admin/pages/schemas/shopEditSchema.ts
@@ -9,7 +9,7 @@ export const shopEditSchema = z.object({
     postalCode: z.string().min(1, { message: 'Postal code is required.' }),
     country: z.string().min(1),
   }),
-  contactEmail: z.string().email({ message: 'Enter a valid email address.' }),
+  contactEmail: z.email({ message: 'Enter a valid email address.' }),
   contactPhone: z.string(),
   vatNumber: z.string(),
   kitchenDisplayEnabled: z.boolean(),

--- a/src/frontend/src/features/pos/__tests__/PosDashboardGuard.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosDashboardGuard.test.tsx
@@ -153,6 +153,7 @@ describe('PosDashboard — EatIn submit guard (t-17, AC4)', () => {
       const alerts = screen.getAllByRole('alert');
       // At least one alert contains the table-number error text
       const tableAlert = alerts.find((el) =>
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Node.textContent is null for some node kinds at runtime despite the narrowed type; keep the guard.
         el.textContent?.toLowerCase().includes('tafelnummer'),
       );
       expect(tableAlert).toBeDefined();
@@ -217,6 +218,7 @@ describe('PosDashboard — EatIn submit guard (t-17, AC4)', () => {
     await waitFor(() => {
       const alerts = screen.queryAllByRole('alert');
       const tableAlert = alerts.find((el) =>
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Node.textContent is null for some node kinds at runtime despite the narrowed type; keep the guard.
         el.textContent?.toLowerCase().includes('tafelnummer'),
       );
       expect(tableAlert).toBeUndefined();

--- a/src/frontend/src/features/pos/__tests__/PosModifierFlow.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/PosModifierFlow.test.tsx
@@ -254,8 +254,10 @@ describe('POS modifier flow — end-to-end UI (t-16, AC5)', () => {
 
     // Step 9: Assert the POST body contains the correct selectedModifierIds
     expect(capturedBody).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- asserted non-null above
     expect(capturedBody!.items).toHaveLength(1);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- body captured and asserted non-null; items[0] guaranteed by toHaveLength(1) above
     const item = capturedBody!.items![0]!;
     expect(item.productId).toBe('prod-friet');
     // The modifier selected via the UI checkbox must appear here — NOT from a fixture
@@ -342,6 +344,7 @@ describe('POS modifier flow — end-to-end UI (t-16, AC5)', () => {
     });
 
     expect(capturedBody).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- body captured and asserted non-null; the single posted item is guaranteed by the preceding item-count assertion
     expect(capturedBody!.items![0]!.selectedModifierIds).toEqual([]);
   });
 
@@ -427,6 +430,7 @@ describe('POS modifier flow — end-to-end UI (t-16, AC5)', () => {
     });
 
     expect(capturedBody).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- body captured and asserted non-null; the single posted item is guaranteed by the preceding submit/success flow
     const ids = capturedBody!.items![0]!.selectedModifierIds;
     expect(ids).toHaveLength(2);
     expect(ids).toContain('mod-mayo');

--- a/src/frontend/src/features/pos/__tests__/useCreateInStoreOrder.test.tsx
+++ b/src/frontend/src/features/pos/__tests__/useCreateInStoreOrder.test.tsx
@@ -61,7 +61,7 @@ function TestOrderForm({ brandSlug, shopId }: TestOrderFormProps) {
       </button>
 
       {mutation.isSuccess && (
-        <p data-testid="success">Order placed: {mutation.data?.orderNumber}</p>
+        <p data-testid="success">Order placed: {mutation.data.orderNumber}</p>
       )}
       {mutation.isError && <p data-testid="error">Error</p>}
 
@@ -128,6 +128,7 @@ describe('useCreateInStoreOrder (t-13)', () => {
     // Verify payload shape
     expect(capturedUrl).toContain('/api/brands/frietjes/shops/shop-1/orders/in-store');
     expect(capturedBody).not.toBeNull();
+    /* eslint-disable @typescript-eslint/no-non-null-assertion -- capturedBody asserted non-null on the line above */
     expect(capturedBody!.orderType).toBe('Pickup');
     expect(capturedBody!.paymentMethod).toBe('CashAtPickup');
     expect(Array.isArray(capturedBody!.items)).toBe(true);
@@ -137,6 +138,7 @@ describe('useCreateInStoreOrder (t-13)', () => {
       quantity: number;
       selectedModifierIds: string[];
     }[];
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
     expect(items).toHaveLength(1);
     expect(items[0]?.productId).toBe('prod-1');
     expect(items[0]?.quantity).toBe(2);
@@ -188,8 +190,10 @@ describe('useCreateInStoreOrder (t-13)', () => {
     });
 
     expect(capturedBody).not.toBeNull();
+    /* eslint-disable @typescript-eslint/no-non-null-assertion -- capturedBody asserted non-null on the line above */
     expect(capturedBody!.orderType).toBe('EatIn');
     expect(capturedBody!.tableNumber).toBe(7);
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
   });
 
   it('clears the order items after successful submission', async () => {
@@ -252,8 +256,10 @@ describe('useCreateInStoreOrder (t-13)', () => {
 
     expect(capturedBody).not.toBeNull();
     // tableNumber must be absent for Pickup orders
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody asserted non-null on the line above
     expect('tableNumber' in capturedBody!).toBe(false);
     // Only the expected top-level keys should be present (no accidental extras)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- capturedBody asserted non-null above
     const topLevelKeys = Object.keys(capturedBody!).sort();
     expect(topLevelKeys).toEqual(['items', 'orderType', 'paymentMethod'].sort());
   });

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -32,9 +32,9 @@ function formatRelative(iso: string, now: number): string {
   const elapsedMs = now - new Date(iso).getTime();
   const minutes = Math.max(0, Math.floor(elapsedMs / 60_000));
   if (minutes < 1) return '<1m';
-  if (minutes < 60) return `${minutes}m`;
+  if (minutes < 60) return `${String(minutes)}m`;
   const hours = Math.floor(minutes / 60);
-  return `${hours}h ${minutes % 60}m`;
+  return `${String(hours)}h ${String(minutes % 60)}m`;
 }
 
 export function KitchenOrderCard({
@@ -177,7 +177,7 @@ export function KitchenOrderCard({
 
       <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: '0.375rem' }}>
         {order.items.map((item, idx) => (
-          <li key={`${order.id}-${item.productId}-${idx}`}>
+          <li key={`${order.id}-${item.productId}-${String(idx)}`}>
             <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5rem' }}>
               <span style={{ fontWeight: 700, fontSize: '1rem', minWidth: '2rem' }}>
                 {item.quantity}×

--- a/src/frontend/src/features/pos/components/PosModifierModal.tsx
+++ b/src/frontend/src/features/pos/components/PosModifierModal.tsx
@@ -50,6 +50,7 @@ export function PosModifierModal({
 
     const selected: CartModifier[] = [];
     for (const group of modifierGroups) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- modifiers comes from a network response; the field can be absent at runtime despite the non-nullable type
       for (const modifier of group.modifiers ?? []) {
         if (selectedModifierIds.has(modifier.id)) {
           const modifierName = modifier.translations[0]?.name ?? '';
@@ -175,6 +176,7 @@ export function PosModifierModal({
                 >
                   {group.name}
                 </h3>
+                {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- modifiers comes from a network response; the field can be absent at runtime despite the non-nullable type */}
                 {(group.modifiers ?? []).map((modifier) => {
                   const modifierName = modifier.translations[0]?.name ?? '';
                   const isChecked = selectedModifierIds.has(modifier.id);

--- a/src/frontend/src/features/pos/components/PosOrderPanel.tsx
+++ b/src/frontend/src/features/pos/components/PosOrderPanel.tsx
@@ -156,11 +156,13 @@ export function PosOrderPanel({ eatIn }: PosOrderPanelProps) {
             onIncrease={() =>
               { updateQuantity(item.productId, item.selectedModifiers, item.quantity + 1); }
             }
-            onDecrease={() =>
-              { item.quantity <= 1
-                ? removeItem(item.productId, item.selectedModifiers)
-                : updateQuantity(item.productId, item.selectedModifiers, item.quantity - 1); }
-            }
+            onDecrease={() => {
+              if (item.quantity <= 1) {
+                removeItem(item.productId, item.selectedModifiers);
+              } else {
+                updateQuantity(item.productId, item.selectedModifiers, item.quantity - 1);
+              }
+            }}
             formatCurrency={formatCurrency}
           />
         ))}

--- a/src/frontend/src/features/pos/context/PosOrderContext.tsx
+++ b/src/frontend/src/features/pos/context/PosOrderContext.tsx
@@ -51,6 +51,7 @@ interface PosOrderContextValue {
  * Creates a stable deduplication key from selected modifiers.
  * Same product + same modifiers = same line item.
  */
+// eslint-disable-next-line react-refresh/only-export-components -- HMR boundary rule; helper co-located with the context it serves
 export function modifierKey(selectedModifiers: CartModifier[]): string {
   return selectedModifiers
     .map((m) => m.modifierId)
@@ -273,6 +274,7 @@ export function PosOrderProvider({
  * Returns the current POS order context.
  * Throws if called outside a PosOrderProvider.
  */
+// eslint-disable-next-line react-refresh/only-export-components -- HMR boundary rule; hook co-located with the context it consumes
 export function useOrderState(): PosOrderContextValue {
   const ctx = useContext(PosOrderContext);
   if (ctx === null) {

--- a/src/frontend/src/features/pos/hooks/__tests__/useActiveOrders.test.ts
+++ b/src/frontend/src/features/pos/hooks/__tests__/useActiveOrders.test.ts
@@ -52,7 +52,9 @@ describe('useActiveOrders', () => {
     expect(callCount).toBe(1);
     expect(capturedOnStatusChange).toBeDefined();
 
+    // eslint-disable-next-line @typescript-eslint/require-await -- async act() flushes pending effects/microtasks after firing the callback; the sync overload would not
     await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- asserted defined via expect(capturedOnStatusChange).toBeDefined() above
       capturedOnStatusChange!({ orderId: 'x', newStatus: 'Preparing' });
     });
 

--- a/src/frontend/src/features/pos/pages/Dashboard.tsx
+++ b/src/frontend/src/features/pos/pages/Dashboard.tsx
@@ -41,7 +41,7 @@ function PosDashboardInner({ brandSlug, shopId, eatIn }: PosDashboardInnerProps)
       const order = await mutation.mutateAsync({});
       // Carry the full order to the confirmation screen so counter staff can print/reprint
       // the customer receipt (US-FP-052) without an extra round-trip.
-      navigate(`/${paramBrandSlug}/${lang}/pos/confirmation/${order.orderNumber}`, {
+      navigate(`/${String(paramBrandSlug)}/${String(lang)}/pos/confirmation/${order.orderNumber}`, {
         state: { order },
       });
     } catch {

--- a/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
+++ b/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
@@ -315,7 +315,7 @@ export function KitchenDisplay() {
               }
               isAdvancing={
                 advanceMutation.isPending &&
-                advanceMutation.variables?.orderId === order.id
+                advanceMutation.variables.orderId === order.id
               }
               advanceError={failedOrderId === order.id}
               onReprint={() => { printOrder(order); }}

--- a/src/frontend/src/features/pos/pages/PosOrderConfirmation.tsx
+++ b/src/frontend/src/features/pos/pages/PosOrderConfirmation.tsx
@@ -159,12 +159,12 @@ export function PosOrderConfirmation() {
   // Redirect to /pos dashboard if the orderNumber param is missing (e.g. direct navigation)
   useEffect(() => {
     if (!orderNumber) {
-      navigate(`/${brandSlug}/${lang}/pos`, { replace: true });
+      navigate(`/${String(brandSlug)}/${String(lang)}/pos`, { replace: true });
     }
   }, [orderNumber, navigate, brandSlug, lang]);
 
   function handleBackToMenu() {
-    navigate(`/${brandSlug}/${lang}/pos`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/pos`);
   }
 
   function handlePrintReceipt() {

--- a/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
+++ b/src/frontend/src/features/pos/pages/__tests__/KitchenDisplay.test.tsx
@@ -94,7 +94,7 @@ function makeOrder(overrides: Partial<{
     statusName: 'Placed',
     customerName: overrides.customerName ?? null,
     items: items.map((it, idx) => ({
-      productId: `prod-${idx}`,
+      productId: `prod-${String(idx)}`,
       productName: it.productName,
       quantity: it.quantity,
       unitGrossPrice: 3.5,
@@ -102,7 +102,7 @@ function makeOrder(overrides: Partial<{
       unitVatAmount: 0.2,
       lineTotal: 3.5 * it.quantity,
       selectedModifiers: it.modifiers.map((m, mIdx) => ({
-        modifierId: `mod-${idx}-${mIdx}`,
+        modifierId: `mod-${String(idx)}-${String(mIdx)}`,
         modifierName: m.name,
         priceAdjustment: 0,
       })),
@@ -171,9 +171,11 @@ describe('KitchenDisplay', () => {
 
     const cards = await screen.findAllByTestId('kitchen-order-card');
     expect(cards).toHaveLength(3);
+    /* eslint-disable @typescript-eslint/no-non-null-assertion -- exactly three cards guaranteed by toHaveLength(3) above */
     expect(within(cards[0]!).getByText('#0001')).toBeInTheDocument();
     expect(within(cards[1]!).getByText('#0002')).toBeInTheDocument();
     expect(within(cards[2]!).getByText('#0003')).toBeInTheDocument();
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
   });
 
   it('renders each item with its modifiers', async () => {
@@ -290,6 +292,7 @@ describe('KitchenDisplay', () => {
     await user.click(reprintBtn);
 
     expect(printTicketMock).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- first call exists per toHaveBeenCalledTimes(1) above
     expect(printTicketMock.mock.calls[0]![0]).toMatchObject({ id: 'a', orderNumber: '0001' });
   });
 
@@ -315,6 +318,7 @@ describe('KitchenDisplay', () => {
     triggerStatusChange?.();
 
     await waitFor(() => { expect(printTicketMock).toHaveBeenCalledTimes(1); });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- first call exists per the toHaveBeenCalledTimes(1) assertion above
     expect(printTicketMock.mock.calls[0]![0]).toMatchObject({ id: 'new-1', orderNumber: '0042' });
   });
 
@@ -384,6 +388,7 @@ describe('KitchenDisplay', () => {
 
     await waitFor(() => { expect(showNotificationMock).toHaveBeenCalledTimes(1); });
     // Notification carries a title, a body and the order id as the dedupe tag.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- first call exists per the toHaveBeenCalledTimes(1) assertion above
     expect(showNotificationMock.mock.calls[0]![2]).toBe('new-2');
   });
 

--- a/src/frontend/src/features/pos/utils/playNewOrderSound.ts
+++ b/src/frontend/src/features/pos/utils/playNewOrderSound.ts
@@ -17,6 +17,7 @@ let sharedContext: AudioContext | null = null;
 function getAudioContextCtor(): AudioContextCtor | undefined {
   if (typeof window === 'undefined') return undefined;
   const w = window as typeof window & { webkitAudioContext?: AudioContextCtor };
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- window.AudioContext is typed as always-present but is genuinely absent in older browsers/SSR; the ?? falls back to the prefixed ctor.
   return w.AudioContext ?? w.webkitAudioContext;
 }
 

--- a/src/frontend/src/features/pos/utils/printDocument.ts
+++ b/src/frontend/src/features/pos/utils/printDocument.ts
@@ -42,6 +42,7 @@ export function printHtmlDocument(html: string): void {
     return;
   }
   doc.open();
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- document.write is the intended mechanism for streaming a self-contained doc into a print iframe; srcdoc would change load timing/behaviour.
   doc.write(html);
   doc.close();
 }

--- a/src/frontend/src/features/pos/utils/printReceipt.ts
+++ b/src/frontend/src/features/pos/utils/printReceipt.ts
@@ -110,7 +110,7 @@ export function buildReceiptHtml(order: OrderResponse, labels: ReceiptLabels): s
         .join('');
       return `<li class="item">
           <div class="item-line">
-            <span class="qty">${item.quantity}×</span>
+            <span class="qty">${String(item.quantity)}×</span>
             <span class="name">${escapeHtml(item.productName)}</span>
             <span class="line-total">${formatCurrency(item.lineTotal)}</span>
           </div>

--- a/src/frontend/src/features/pos/utils/printTicket.ts
+++ b/src/frontend/src/features/pos/utils/printTicket.ts
@@ -74,7 +74,7 @@ export function buildTicketHtml(order: OrderResponse, labels: TicketLabels): str
         .map((m) => `<div class="mod">+ ${escapeHtml(m.modifierName)}</div>`)
         .join('');
       return `<li class="item">
-          <div class="item-line"><span class="qty">${item.quantity}×</span><span class="name">${escapeHtml(item.productName)}</span></div>
+          <div class="item-line"><span class="qty">${String(item.quantity)}×</span><span class="name">${escapeHtml(item.productName)}</span></div>
           ${modifiers}
         </li>`;
     })

--- a/src/frontend/src/features/storefront/__tests__/ShopChooserPage.test.tsx
+++ b/src/frontend/src/features/storefront/__tests__/ShopChooserPage.test.tsx
@@ -21,9 +21,7 @@ vi.mock('../hooks/useActiveShops', () => ({
 }));
 
 // Import after mock registration
-// eslint-disable-next-line import/first
 import { useActiveShops } from '../hooks/useActiveShops';
-// eslint-disable-next-line import/first
 import { ShopChooserPage } from '../pages/ShopChooserPage';
 
 // ---------------------------------------------------------------------------

--- a/src/frontend/src/features/storefront/__tests__/ShopResolver.test.tsx
+++ b/src/frontend/src/features/storefront/__tests__/ShopResolver.test.tsx
@@ -21,11 +21,8 @@ vi.mock('../hooks/useActiveShops', () => ({
 }));
 
 // We need to import AFTER the mock is registered
-// eslint-disable-next-line import/first
 import { useActiveShops } from '../hooks/useActiveShops';
-// eslint-disable-next-line import/first
 import { ShopResolver } from '../context/ShopContext';
-// eslint-disable-next-line import/first
 import { useResolvedShop } from '../hooks/useResolvedShop';
 
 // ---------------------------------------------------------------------------

--- a/src/frontend/src/features/storefront/components/CartDrawer.tsx
+++ b/src/frontend/src/features/storefront/components/CartDrawer.tsx
@@ -22,7 +22,7 @@ export function CartDrawer({ isOpen, onClose }: CartDrawerProps) {
 
   function handleGoToCheckout() {
     onClose();
-    navigate(`/${brandSlug}/${lang}/${shop.slug}/checkout`);
+    navigate(`/${String(brandSlug)}/${String(lang)}/${shop.slug}/checkout`);
   }
 
   function formatCurrency(amount: number): string {

--- a/src/frontend/src/features/storefront/components/MockPaymentScreen.tsx
+++ b/src/frontend/src/features/storefront/components/MockPaymentScreen.tsx
@@ -25,7 +25,7 @@ interface MockPaymentScreenProps {
 // No API calls, no side effects beyond the timer.
 // ---------------------------------------------------------------------------
 
-export function MockPaymentScreen({ orderId: _orderId, onComplete }: MockPaymentScreenProps) {
+export function MockPaymentScreen({ onComplete }: MockPaymentScreenProps) {
   const { t } = useTranslation('common');
 
   useEffect(() => {

--- a/src/frontend/src/features/storefront/components/ModifierModal.tsx
+++ b/src/frontend/src/features/storefront/components/ModifierModal.tsx
@@ -42,6 +42,7 @@ export function ModifierModal({ brandSlug, product, onConfirm, onClose }: Modifi
 
     const selected: CartModifier[] = [];
     for (const group of modifierGroups) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- modifiers comes from a JSON API response and may be absent at runtime despite the non-nullable type
       for (const modifier of group.modifiers ?? []) {
         if (selectedModifierIds.has(modifier.id)) {
           const modifierName = modifier.translations[0]?.name ?? '';
@@ -158,6 +159,7 @@ export function ModifierModal({ brandSlug, product, onConfirm, onClose }: Modifi
                   >
                     {group.name}
                   </h3>
+                  {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- modifiers comes from a JSON API response and may be absent at runtime despite the non-nullable type */}
                   {(group.modifiers ?? []).map((modifier) => {
                     const modifierName = modifier.translations[0]?.name ?? '';
                     const isChecked = selectedModifierIds.has(modifier.id);

--- a/src/frontend/src/features/storefront/components/ThemeProvider.tsx
+++ b/src/frontend/src/features/storefront/components/ThemeProvider.tsx
@@ -39,6 +39,9 @@ export function ThemeProvider({ children }: { children?: ReactNode }) {
 
   useEffect(() => {
     loadGoogleFonts(effectiveTheme, fontLinksRef.current);
+    // Intentionally re-run only when the font families change; loadGoogleFonts reads
+    // only those two fields from effectiveTheme, so the full object is not a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [effectiveTheme.headingFontFamily, effectiveTheme.bodyFontFamily]);
 
   // Cleanup font link elements on unmount

--- a/src/frontend/src/features/storefront/context/CartContext.tsx
+++ b/src/frontend/src/features/storefront/context/CartContext.tsx
@@ -275,6 +275,7 @@ export function CartProvider({ brandSlug, shopId, children }: CartProviderProps)
 // Hook
 // ---------------------------------------------------------------------------
 
+// eslint-disable-next-line react-refresh/only-export-components -- hook co-located with its provider; HMR boundary only, not a correctness concern
 export function useCart(): CartContextValue {
   const ctx = useContext(CartContext);
   if (ctx === null) {

--- a/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
+++ b/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
@@ -52,7 +52,7 @@ function makeCheckoutSchema(
         customerEmail: z
           .string()
           .trim()
-          .refine((v) => !v || z.string().email().safeParse(v).success, {
+          .refine((v) => !v || z.email().safeParse(v).success, {
             message: t('storefront.checkout.customerEmailInvalid'),
           }),
         customerPhone: z.string().trim().min(1, t('storefront.checkout.customerPhoneRequired')),
@@ -64,7 +64,7 @@ function makeCheckoutSchema(
           .string()
           .trim()
           .min(1, t('storefront.checkout.customerEmailRequired'))
-          .refine((v) => z.string().email().safeParse(v).success, {
+          .refine((v) => z.email().safeParse(v).success, {
             message: t('storefront.checkout.customerEmailInvalid'),
           }),
         customerPhone: z.string().trim().min(1, t('storefront.checkout.customerPhoneRequired')),
@@ -134,7 +134,7 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
   // Redirect to menu if cart is empty
   useEffect(() => {
     if (state.items.length === 0) {
-      navigate(`/${paramSlug}/${lang}/${shopSlug}/menu`, { replace: true });
+      navigate(`/${String(paramSlug)}/${String(lang)}/${shopSlug}/menu`, { replace: true });
     }
   }, [state.items.length, navigate, paramSlug, lang, shopSlug]);
 
@@ -174,9 +174,7 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
   const vatNotice =
     orderType === 'EatIn'
       ? t('storefront.checkout.vatEatIn')
-      : orderType
-        ? t('storefront.checkout.vatTakeaway')
-        : null;
+      : t('storefront.checkout.vatTakeaway');
 
   function formatCurrency(amount: number): string {
     return new Intl.NumberFormat('nl-BE', { style: 'currency', currency: 'EUR' }).format(amount);
@@ -215,7 +213,7 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
     clearCart();
 
     if (values.paymentMethod === 'CashAtPickup') {
-      navigate(`/${paramSlug}/${lang}/${shopSlug}/order/${result.id}`);
+      navigate(`/${String(paramSlug)}/${String(lang)}/${shopSlug}/order/${result.id}`);
     } else {
       // Online payment methods: show mock processing screen first
       setPendingOrderId(result.id);
@@ -225,7 +223,7 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
 
   function handleMockPaymentComplete() {
     setShowMockPayment(false);
-    navigate(`/${paramSlug}/${lang}/${shopSlug}/order/${pendingOrderId}`);
+    navigate(`/${String(paramSlug)}/${String(lang)}/${shopSlug}/order/${String(pendingOrderId)}`);
   }
 
   if (state.items.length === 0) {

--- a/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
@@ -73,7 +73,7 @@ export function OrderConfirmationPage() {
       <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
         <p style={{ color: '#ef4444' }}>{t('error')}</p>
         <Link
-          to={`/${resolvedBrandSlug}/${lang}`}
+          to={`/${resolvedBrandSlug}/${String(lang)}`}
           style={{ color: 'var(--brand-color-primary, #111827)', fontWeight: 600 }}
         >
           {t('storefront.order.backToHome')}
@@ -177,7 +177,7 @@ export function OrderConfirmationPage() {
         <div style={{ padding: '0.75rem 1rem' }}>
           {order.items.map((item, idx) => (
             <div
-              key={`${item.productId}-${idx}`}
+              key={`${item.productId}-${String(idx)}`}
               style={{
                 display: 'flex',
                 justifyContent: 'space-between',
@@ -238,7 +238,7 @@ export function OrderConfirmationPage() {
       {/* Back to home */}
       <div style={{ textAlign: 'center' }}>
         <Link
-          to={`/${resolvedBrandSlug}/${lang}`}
+          to={`/${resolvedBrandSlug}/${String(lang)}`}
           style={{
             color: 'var(--brand-color-primary, #111827)',
             fontWeight: 700,

--- a/src/frontend/src/features/storefront/pages/OrderTrackingPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderTrackingPage.tsx
@@ -83,7 +83,7 @@ export function OrderTrackingPage() {
       <main style={{ maxWidth: '40rem', margin: '0 auto', padding: '1.5rem 1rem' }}>
         <p style={{ color: '#ef4444' }}>{t('error')}</p>
         <Link
-          to={`/${resolvedBrandSlug}/${lang}`}
+          to={`/${resolvedBrandSlug}/${String(lang)}`}
           style={{ color: 'var(--brand-color-primary, #111827)', fontWeight: 600 }}
         >
           {t('storefront.order.backToHome')}

--- a/src/frontend/src/features/storefront/pages/__tests__/CheckoutPage.test.tsx
+++ b/src/frontend/src/features/storefront/pages/__tests__/CheckoutPage.test.tsx
@@ -26,9 +26,7 @@ vi.mock('../../hooks/useResolvedShop', () => ({
 }));
 
 // Import after mock registration
-// eslint-disable-next-line import/first
 import { useResolvedShop } from '../../hooks/useResolvedShop';
-// eslint-disable-next-line import/first
 import { CheckoutPage } from '../CheckoutPage';
 
 // ---------------------------------------------------------------------------
@@ -167,7 +165,7 @@ describe('CheckoutPage (US-FP-051)', () => {
     it('does not submit when first name is missing', async () => {
       let submitted = false;
       server.use(
-        http.post('/api/brands/:slug/shops/:shopId/orders', async () => {
+        http.post('/api/brands/:slug/shops/:shopId/orders', () => {
           submitted = true;
           return HttpResponse.json({}, { status: 201 });
         }),
@@ -184,7 +182,9 @@ describe('CheckoutPage (US-FP-051)', () => {
       fireEvent.change(screen.getByLabelText(/telefoonnummer/i), { target: { value: '+32470000001' } });
 
       // Select order type and payment method
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[0]!); // Pickup
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[3]!); // CashAtPickup
 
       fireEvent.click(screen.getByRole('button', { name: /bestelling plaatsen/i }));
@@ -198,7 +198,7 @@ describe('CheckoutPage (US-FP-051)', () => {
     it('does not submit when last name is missing', async () => {
       let submitted = false;
       server.use(
-        http.post('/api/brands/:slug/shops/:shopId/orders', async () => {
+        http.post('/api/brands/:slug/shops/:shopId/orders', () => {
           submitted = true;
           return HttpResponse.json({}, { status: 201 });
         }),
@@ -213,7 +213,9 @@ describe('CheckoutPage (US-FP-051)', () => {
       fireEvent.change(screen.getByLabelText(/e-mailadres/i), { target: { value: 'jane@example.com' } });
       fireEvent.change(screen.getByLabelText(/telefoonnummer/i), { target: { value: '+32470000001' } });
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[0]!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[3]!);
       fireEvent.click(screen.getByRole('button', { name: /bestelling plaatsen/i }));
 
@@ -225,7 +227,7 @@ describe('CheckoutPage (US-FP-051)', () => {
     it('does not submit when email is missing', async () => {
       let submitted = false;
       server.use(
-        http.post('/api/brands/:slug/shops/:shopId/orders', async () => {
+        http.post('/api/brands/:slug/shops/:shopId/orders', () => {
           submitted = true;
           return HttpResponse.json({}, { status: 201 });
         }),
@@ -240,7 +242,9 @@ describe('CheckoutPage (US-FP-051)', () => {
       // leave email empty
       fireEvent.change(screen.getByLabelText(/telefoonnummer/i), { target: { value: '+32470000001' } });
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[0]!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[3]!);
       fireEvent.click(screen.getByRole('button', { name: /bestelling plaatsen/i }));
 
@@ -252,7 +256,7 @@ describe('CheckoutPage (US-FP-051)', () => {
     it('does not submit when phone is missing', async () => {
       let submitted = false;
       server.use(
-        http.post('/api/brands/:slug/shops/:shopId/orders', async () => {
+        http.post('/api/brands/:slug/shops/:shopId/orders', () => {
           submitted = true;
           return HttpResponse.json({}, { status: 201 });
         }),
@@ -267,7 +271,9 @@ describe('CheckoutPage (US-FP-051)', () => {
       fireEvent.change(screen.getByLabelText(/e-mailadres/i), { target: { value: 'jane@example.com' } });
       // leave phone empty
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[0]!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[3]!);
       fireEvent.click(screen.getByRole('button', { name: /bestelling plaatsen/i }));
 
@@ -348,7 +354,9 @@ describe('CheckoutPage (US-FP-051)', () => {
       fireEvent.change(screen.getByLabelText(/telefoonnummer/i), { target: { value: '+32470000001' } });
 
       // Select Pickup and CashAtPickup
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[0]!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[3]!);
 
       fireEvent.click(screen.getByRole('button', { name: /bestelling plaatsen/i }));
@@ -357,11 +365,13 @@ describe('CheckoutPage (US-FP-051)', () => {
         expect(capturedBody).not.toBeNull();
       });
 
-      expect(capturedBody!.customerFirstName).toBe('Jane');
-      expect(capturedBody!.customerLastName).toBe('Doe');
-      expect(capturedBody!.languageCode).toBe('nl');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above guarantees capturedBody is non-null here
+      const body = capturedBody!;
+      expect(body.customerFirstName).toBe('Jane');
+      expect(body.customerLastName).toBe('Doe');
+      expect(body.languageCode).toBe('nl');
       // Old field must not be present in request
-      expect('customerName' in capturedBody!).toBe(false);
+      expect('customerName' in body).toBe(false);
     });
 
     it('normalises unsupported lang to nl in languageCode', async () => {
@@ -403,7 +413,9 @@ describe('CheckoutPage (US-FP-051)', () => {
       fireEvent.change(screen.getByLabelText(/e-mailadres/i), { target: { value: 'jane@example.com' } });
       fireEvent.change(screen.getByLabelText(/telefoonnummer/i), { target: { value: '+32470000001' } });
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[0]!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- fixed set of radios always rendered by the form
       fireEvent.click(screen.getAllByRole('radio')[3]!);
       fireEvent.click(screen.getByRole('button', { name: /bestelling plaatsen/i }));
 
@@ -411,6 +423,7 @@ describe('CheckoutPage (US-FP-051)', () => {
         expect(capturedBody).not.toBeNull();
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- waitFor above guarantees capturedBody is non-null here
       expect(capturedBody!.languageCode).toBe('nl');
     });
   });

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -33,6 +33,7 @@ function resolveInitialLocale(): string {
  * Root redirect component — re-evaluates on every render so that changes to
  * the stored language preference are picked up when the user returns to "/".
  */
+// eslint-disable-next-line react-refresh/only-export-components -- router module intentionally exports the router config alongside this internal redirect component; HMR boundary, not a correctness concern
 function RootRedirect() {
   return <Navigate to={`/frietjes/${resolveInitialLocale()}`} replace />;
 }

--- a/src/frontend/src/test/eventListenerHarness.ts
+++ b/src/frontend/src/test/eventListenerHarness.ts
@@ -21,7 +21,7 @@ interface RunWithEventListenerResult {
  */
 export async function runWithEventListener(
   eventName: string,
-  action: () => Promise<unknown> | unknown,
+  action: () => unknown,
 ): Promise<RunWithEventListenerResult> {
   const listener = vi.fn();
   window.addEventListener(eventName, listener);

--- a/src/frontend/src/test/msw/handlers.ts
+++ b/src/frontend/src/test/msw/handlers.ts
@@ -327,7 +327,7 @@ export const handlers = [
   http.put('/api/brands/:slug/shops/:shopId/opening-hours', async ({ request }) => {
     const body = await request.json() as { timeBlocks: unknown[] };
     return HttpResponse.json({
-      timeBlocks: body.timeBlocks.map((tb, i) => ({ id: `tb-${i}`, ...tb as object })),
+      timeBlocks: body.timeBlocks.map((tb, i) => ({ id: `tb-${String(i)}`, ...tb as object })),
     });
   }),
 
@@ -631,7 +631,7 @@ export const handlers = [
         dietaryTags: [],
         comboItems: (body.componentProductIds as string[]).map((id, i) => ({
           componentProductId: id,
-          name: `Product ${i + 1}`,
+          name: `Product ${String(i + 1)}`,
           sortOrder: i,
         })),
         createdAt: '2024-06-01T00:00:00Z',
@@ -655,7 +655,7 @@ export const handlers = [
       dietaryTags: [],
       comboItems: (body.componentProductIds as string[]).map((id, i) => ({
         componentProductId: id,
-        name: `Product ${i + 1}`,
+        name: `Product ${String(i + 1)}`,
         sortOrder: i,
       })),
       createdAt: '2024-01-01T00:00:00Z',
@@ -736,7 +736,7 @@ export const handlers = [
         languageCode: body.languageCode ?? null,
         customerEmail: body.customerEmail ?? null,
         customerPhone: body.customerPhone ?? null,
-        items: (body.items ?? []).map((item) => ({
+        items: body.items.map((item) => ({
           productId: item.productId,
           productName: 'Kleine friet',
           quantity: item.quantity,
@@ -751,13 +751,13 @@ export const handlers = [
           })),
         })),
         vatRatePercent: body.orderType === 'EatIn' ? 21 : 6,
-        subtotalGross: (body.items ?? []).reduce(
+        subtotalGross: body.items.reduce(
           (sum: number, item) => sum + item.quantity * 3.5,
           0,
         ),
         totalVatAmount: 0.2,
         totalNet: 3.3,
-        totalGross: (body.items ?? []).reduce(
+        totalGross: body.items.reduce(
           (sum: number, item) => sum + item.quantity * 3.5,
           0,
         ),
@@ -806,7 +806,7 @@ export const handlers = [
         customerName: [body.customerFirstName, body.customerLastName].filter(Boolean).join(' ') || null,
         customerFirstName: body.customerFirstName ?? null,
         customerLastName: body.customerLastName ?? null,
-        items: (body.items ?? []).map((item) => ({
+        items: body.items.map((item) => ({
           productId: item.productId,
           productName: 'Kleine friet',
           quantity: item.quantity,
@@ -821,13 +821,13 @@ export const handlers = [
           })),
         })),
         vatRatePercent: body.orderType === 'EatIn' ? 21 : 6,
-        subtotalGross: (body.items ?? []).reduce(
+        subtotalGross: body.items.reduce(
           (sum: number, item) => sum + item.quantity * 3.5,
           0,
         ),
         totalVatAmount: 0.2,
         totalNet: 3.3,
-        totalGross: (body.items ?? []).reduce(
+        totalGross: body.items.reduce(
           (sum: number, item) => sum + item.quantity * 3.5,
           0,
         ),

--- a/src/frontend/src/test/mswHelpers.ts
+++ b/src/frontend/src/test/mswHelpers.ts
@@ -9,11 +9,11 @@ type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
  * Use this to replace inline `server.use(http.get(path, () => new HttpResponse(null, { status })))`
  * blocks in tests.
  */
-export function mockEndpoint<TBody = unknown>(
+export function mockEndpoint(
   method: Method,
   path: string,
   status: number,
-  body?: TBody,
+  body?: unknown,
 ): HttpHandler {
   const responder = () => {
     if (body === undefined) {


### PR DESCRIPTION
Stacked on #134 (base = `feat/us-fp-066-eat-in-time-slots`) so this PR's diff is purely the lint cleanup. Merge #134 first; GitHub auto-retargets this to `main` when it lands.

## Summary
Clears the **pre-existing repo-wide ESLint debt: 576 → 0**. ~240 were auto-fixed in #134; the remaining ~337 are fixed here, manually and behaviour-preservingly, parallelised across disjoint file batches.

## How
- `restrict-template-expressions` (131): wrap interpolations with `String(...)` — byte-identical output.
- `no-non-null-assertion` (114): real guards / optional chaining where clean; justified `eslint-disable` for assertion-backed invariants in tests (e.g. `x!` after `expect(x).toBeDefined()`).
- `no-unnecessary-condition` (35): removed TS-proven-dead checks; **kept** runtime-load-bearing guards (env vars typed-but-undefined, JSON/DOM data) with justified disables + reasons.
- `no-deprecated` (zod): `z.string().email()` → `z.email()`.
- Long tail: `no-invalid-void-type`, `require-await`, `import/first`, `no-misused-promises`, etc.
- Removed the redundant `adminFormStyles.ts` barrel that re-exported the same-named `.tsx` (which left the `.tsx` outside the typed-lint project service → parsing error); imports now resolve straight to the `.tsx`. One justified file-level `react-refresh` disable remains on that shared styles+helpers module.
- Fixed a bad `eslint --fix` carry-over in `ComboProductEdit` (`onSubmit` had dropped `preventDefault` and passed the event to a 0-arg `submit`).

## Verification
- `pnpm lint` → **0 problems** (was 576 errors)
- `pnpm build` (type-check) clean
- **343/343** vitest pass — no behaviour regressions

No `eslint`/`tsconfig` config changes. Every `eslint-disable` carries a `-- <reason>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)