### PR TITLE
refactor(frontend): remove dead code and consolidate duplicated types

### DIFF
--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -1,4 +1,5 @@
 import { apiClient } from './client';
+import type { OrderLifecycleResponse } from '../types/common';
 
 // ---------------------------------------------------------------------------
 // Request types
@@ -94,7 +95,7 @@ export interface OrderResponse {
   shopAddressLine?: string | null;
 }
 
-export interface ListActiveOrdersResponse {
+interface ListActiveOrdersResponse {
   orders: OrderResponse[];
 }
 
@@ -117,28 +118,6 @@ export interface CreateInStoreOrderRequest {
 // ---------------------------------------------------------------------------
 // Order tracking response types (US-FP-063)
 // ---------------------------------------------------------------------------
-
-export interface OrderStatusResponse {
-  id: string;
-  name: string;
-  systemKey: string | null;
-  sortOrder: number;
-  isEnabled: boolean;
-  isTerminal: boolean;
-  colorHex: string | null;
-}
-
-export interface OrderStatusTransitionResponse {
-  id: string;
-  fromStatusId: string;
-  toStatusId: string;
-}
-
-export interface OrderLifecycleResponse {
-  shopId: string;
-  statuses: OrderStatusResponse[];
-  transitions: OrderStatusTransitionResponse[];
-}
 
 export interface OrderTrackingResponse {
   order: OrderResponse;

--- a/src/frontend/src/api/signalr.ts
+++ b/src/frontend/src/api/signalr.ts
@@ -1,6 +1,3 @@
-// fallow-ignore-file unused-export
-// fallow-ignore-file unused-file
-//
 // Real-time SignalR client + hooks. Wired up by US-FP-068
 // (Real-time order updates infrastructure).
 
@@ -44,7 +41,8 @@ export function getOrderHubConnection(): HubConnection {
 }
 
 /**
- * Resets the singleton connection. Used by tests and HMR cleanup.
+ * Resets the singleton connection. Intended for tests and HMR cleanup.
+ * @expected-unused — retained as a test/HMR reset utility; not yet imported
  */
 export function resetOrderHubConnection(): void {
   connection = null;

--- a/src/frontend/src/api/useOrderUpdates.ts
+++ b/src/frontend/src/api/useOrderUpdates.ts
@@ -1,11 +1,9 @@
-// fallow-ignore-file unused-file
-//
 // Hook subscribing to OrderHub events. Consumed by US-FP-068.
 
 import { useEffect, useRef } from 'react';
 import { useSignalR, type ConnectionStatus } from './useSignalR';
 
-export interface OrderStatusUpdate {
+interface OrderStatusUpdate {
   orderId: string;
   shopId: string;
   brandSlug: string;

--- a/src/frontend/src/api/useSignalR.ts
+++ b/src/frontend/src/api/useSignalR.ts
@@ -1,7 +1,3 @@
-// fallow-ignore-file unused-export
-// fallow-ignore-file unused-type
-// fallow-ignore-file unused-file
-//
 // Real-time SignalR React hook. Consumed by US-FP-068.
 
 import { useEffect, useRef, useState, useCallback } from 'react';

--- a/src/frontend/src/features/admin/forms/ProductTranslationFields.tsx
+++ b/src/frontend/src/features/admin/forms/ProductTranslationFields.tsx
@@ -1,0 +1,119 @@
+import type { UseFormRegister } from 'react-hook-form';
+import type { TFunction } from 'i18next';
+import type { SupportedLocale } from '../../../types/common';
+import type { ProductEditFormValues } from '../pages/schemas/productEditSchema';
+import { labelStyle, inputStyle, RequiredMark, FieldError } from './adminFormStyles';
+
+// ---------------------------------------------------------------------------
+// ProductTranslationFields — shared by ProductCreate and ProductEdit (both use
+// the same ProductEditFormValues schema). Kept as a component with literal
+// `register` path strings, which TypeScript resolves correctly (dynamic
+// template-literal paths produce unknown spreads in strict TSX).
+// ---------------------------------------------------------------------------
+
+export interface ProductTranslationFieldsProps {
+  activeTab: SupportedLocale;
+  register: UseFormRegister<ProductEditFormValues>;
+  nlNameError: string | undefined;
+  t: TFunction;
+}
+
+export function ProductTranslationFields({
+  activeTab,
+  register,
+  nlNameError,
+  t,
+}: ProductTranslationFieldsProps): React.JSX.Element {
+  if (activeTab === 'nl') {
+    return (
+      <>
+        <div style={{ marginBottom: '1rem' }}>
+          <label style={labelStyle} htmlFor="name-nl">
+            Name <RequiredMark />
+          </label>
+          <input
+            id="name-nl"
+            type="text"
+            {...register('translations.nl.name')}
+            style={inputStyle(!!nlNameError)}
+            placeholder={t('admin.products.namePlaceholder', { lang: 'NL' })}
+          />
+          {nlNameError && <FieldError message={nlNameError} />}
+        </div>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <label style={labelStyle} htmlFor="desc-nl">
+            {t('admin.products.description')}{' '}
+            <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
+          </label>
+          <textarea
+            id="desc-nl"
+            {...register('translations.nl.description')}
+            rows={3}
+            style={{ ...inputStyle(false), resize: 'vertical' }}
+            placeholder={t('admin.products.descriptionPlaceholder', { lang: 'NL' })}
+          />
+        </div>
+      </>
+    );
+  }
+  if (activeTab === 'fr') {
+    return (
+      <>
+        <div style={{ marginBottom: '1rem' }}>
+          <label style={labelStyle} htmlFor="name-fr">
+            Name
+          </label>
+          <input
+            id="name-fr"
+            type="text"
+            {...register('translations.fr.name')}
+            style={inputStyle(false)}
+            placeholder={t('admin.products.namePlaceholder', { lang: 'FR' })}
+          />
+        </div>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <label style={labelStyle} htmlFor="desc-fr">
+            {t('admin.products.description')}{' '}
+            <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
+          </label>
+          <textarea
+            id="desc-fr"
+            {...register('translations.fr.description')}
+            rows={3}
+            style={{ ...inputStyle(false), resize: 'vertical' }}
+            placeholder={t('admin.products.descriptionPlaceholder', { lang: 'FR' })}
+          />
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <div style={{ marginBottom: '1rem' }}>
+        <label style={labelStyle} htmlFor="name-de">
+          Name
+        </label>
+        <input
+          id="name-de"
+          type="text"
+          {...register('translations.de.name')}
+          style={inputStyle(false)}
+          placeholder={t('admin.products.namePlaceholder', { lang: 'DE' })}
+        />
+      </div>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <label style={labelStyle} htmlFor="desc-de">
+          {t('admin.products.description')}{' '}
+          <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
+        </label>
+        <textarea
+          id="desc-de"
+          {...register('translations.de.description')}
+          rows={3}
+          style={{ ...inputStyle(false), resize: 'vertical' }}
+          placeholder={t('admin.products.descriptionPlaceholder', { lang: 'DE' })}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/frontend/src/features/admin/pages/ProductCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ProductCreate.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useForm, Controller, type UseFormRegister } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { TFunction } from 'i18next';
 import { productsApi } from '@api/products';
 import type { CreateProductRequest } from '@api/products';
 import { productEditSchema, type ProductEditFormValues } from './schemas/productEditSchema';
@@ -17,6 +16,7 @@ import {
 } from '../../../types/common';
 import type { SupportedLocale } from '../../../types/common';
 import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
+import { ProductTranslationFields } from '../forms/ProductTranslationFields';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -286,7 +286,7 @@ export function ProductCreate() {
         </div>
 
         {/* Translation fields — rendered for all tabs, only the active one is visible */}
-        <TranslationFields
+        <ProductTranslationFields
           activeTab={activeTab}
           register={register}
           nlNameError={nlNameError}
@@ -325,114 +325,6 @@ export function ProductCreate() {
         </div>
       </form>
     </main>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// TranslationFields — extracted so `register` call uses literal path strings,
-// which TypeScript resolves correctly (dynamic template-literal paths produce
-// unknown spreads in strict TSX).
-// ---------------------------------------------------------------------------
-
-interface TranslationFieldsProps {
-  activeTab: SupportedLocale;
-  register: UseFormRegister<ProductEditFormValues>;
-  nlNameError: string | undefined;
-  t: TFunction;
-}
-
-function TranslationFields({ activeTab, register, nlNameError, t }: TranslationFieldsProps) {
-  if (activeTab === 'nl') {
-    return (
-      <>
-        <div style={{ marginBottom: '1rem' }}>
-          <label style={labelStyle} htmlFor="name-nl">
-            Name <RequiredMark />
-          </label>
-          <input
-            id="name-nl"
-            type="text"
-            {...register('translations.nl.name')}
-            style={inputStyle(!!nlNameError)}
-            placeholder={t('admin.products.namePlaceholder', { lang: 'NL' })}
-          />
-          {nlNameError && <FieldError message={nlNameError} />}
-        </div>
-        <div style={{ marginBottom: '1.5rem' }}>
-          <label style={labelStyle} htmlFor="desc-nl">
-            {t('admin.products.description')}{' '}
-            <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
-          </label>
-          <textarea
-            id="desc-nl"
-            {...register('translations.nl.description')}
-            rows={3}
-            style={{ ...inputStyle(false), resize: 'vertical' }}
-            placeholder={t('admin.products.descriptionPlaceholder', { lang: 'NL' })}
-          />
-        </div>
-      </>
-    );
-  }
-  if (activeTab === 'fr') {
-    return (
-      <>
-        <div style={{ marginBottom: '1rem' }}>
-          <label style={labelStyle} htmlFor="name-fr">
-            Name
-          </label>
-          <input
-            id="name-fr"
-            type="text"
-            {...register('translations.fr.name')}
-            style={inputStyle(false)}
-            placeholder={t('admin.products.namePlaceholder', { lang: 'FR' })}
-          />
-        </div>
-        <div style={{ marginBottom: '1.5rem' }}>
-          <label style={labelStyle} htmlFor="desc-fr">
-            {t('admin.products.description')}{' '}
-            <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
-          </label>
-          <textarea
-            id="desc-fr"
-            {...register('translations.fr.description')}
-            rows={3}
-            style={{ ...inputStyle(false), resize: 'vertical' }}
-            placeholder={t('admin.products.descriptionPlaceholder', { lang: 'FR' })}
-          />
-        </div>
-      </>
-    );
-  }
-  return (
-    <>
-      <div style={{ marginBottom: '1rem' }}>
-        <label style={labelStyle} htmlFor="name-de">
-          Name
-        </label>
-        <input
-          id="name-de"
-          type="text"
-          {...register('translations.de.name')}
-          style={inputStyle(false)}
-          placeholder={t('admin.products.namePlaceholder', { lang: 'DE' })}
-        />
-      </div>
-      <div style={{ marginBottom: '1.5rem' }}>
-        <label style={labelStyle} htmlFor="desc-de">
-          {t('admin.products.description')}{' '}
-          <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
-        </label>
-        <textarea
-          id="desc-de"
-          {...register('translations.de.description')}
-          rows={3}
-          style={{ ...inputStyle(false), resize: 'vertical' }}
-          placeholder={t('admin.products.descriptionPlaceholder', { lang: 'DE' })}
-        />
-      </div>
-    </>
   );
 }
 

--- a/src/frontend/src/features/admin/pages/ProductEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ProductEdit.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Controller, type UseFormRegister } from 'react-hook-form';
-import type { TFunction } from 'i18next';
+import { Controller } from 'react-hook-form';
 import { useDeleteProduct, productKeys } from '../hooks/useProducts';
 import {
   useProductModifierGroups,
@@ -22,6 +21,7 @@ import {
 import type { SupportedLocale, ProductModifierGroupResponse, Product } from '../../../types/common';
 import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
 import { ResourceFormShell } from '../forms/ResourceFormShell';
+import { ProductTranslationFields } from '../forms/ProductTranslationFields';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -433,7 +433,7 @@ export function ProductEdit() {
         </div>
 
         {/* Translation fields — rendered for all tabs, only the active one is visible */}
-        <TranslationFields
+        <ProductTranslationFields
           activeTab={activeTab}
           register={register}
           nlNameError={nlNameError}
@@ -661,114 +661,6 @@ export function ProductEdit() {
       </section>
     </main>
     </ResourceFormShell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// TranslationFields — extracted so `register` call uses literal path strings,
-// which TypeScript resolves correctly (dynamic template-literal paths produce
-// unknown spreads in strict TSX).
-// ---------------------------------------------------------------------------
-
-interface TranslationFieldsProps {
-  activeTab: SupportedLocale;
-  register: UseFormRegister<ProductEditFormValues>;
-  nlNameError: string | undefined;
-  t: TFunction;
-}
-
-function TranslationFields({ activeTab, register, nlNameError, t }: TranslationFieldsProps) {
-  if (activeTab === 'nl') {
-    return (
-      <>
-        <div style={{ marginBottom: '1rem' }}>
-          <label style={labelStyle} htmlFor="name-nl">
-            Name <RequiredMark />
-          </label>
-          <input
-            id="name-nl"
-            type="text"
-            {...register('translations.nl.name')}
-            style={inputStyle(!!nlNameError)}
-            placeholder={t('admin.products.namePlaceholder', { lang: 'NL' })}
-          />
-          {nlNameError && <FieldError message={nlNameError} />}
-        </div>
-        <div style={{ marginBottom: '1.5rem' }}>
-          <label style={labelStyle} htmlFor="desc-nl">
-            {t('admin.products.description')}{' '}
-            <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
-          </label>
-          <textarea
-            id="desc-nl"
-            {...register('translations.nl.description')}
-            rows={3}
-            style={{ ...inputStyle(false), resize: 'vertical' }}
-            placeholder={t('admin.products.descriptionPlaceholder', { lang: 'NL' })}
-          />
-        </div>
-      </>
-    );
-  }
-  if (activeTab === 'fr') {
-    return (
-      <>
-        <div style={{ marginBottom: '1rem' }}>
-          <label style={labelStyle} htmlFor="name-fr">
-            Name
-          </label>
-          <input
-            id="name-fr"
-            type="text"
-            {...register('translations.fr.name')}
-            style={inputStyle(false)}
-            placeholder={t('admin.products.namePlaceholder', { lang: 'FR' })}
-          />
-        </div>
-        <div style={{ marginBottom: '1.5rem' }}>
-          <label style={labelStyle} htmlFor="desc-fr">
-            {t('admin.products.description')}{' '}
-            <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
-          </label>
-          <textarea
-            id="desc-fr"
-            {...register('translations.fr.description')}
-            rows={3}
-            style={{ ...inputStyle(false), resize: 'vertical' }}
-            placeholder={t('admin.products.descriptionPlaceholder', { lang: 'FR' })}
-          />
-        </div>
-      </>
-    );
-  }
-  return (
-    <>
-      <div style={{ marginBottom: '1rem' }}>
-        <label style={labelStyle} htmlFor="name-de">
-          Name
-        </label>
-        <input
-          id="name-de"
-          type="text"
-          {...register('translations.de.name')}
-          style={inputStyle(false)}
-          placeholder={t('admin.products.namePlaceholder', { lang: 'DE' })}
-        />
-      </div>
-      <div style={{ marginBottom: '1.5rem' }}>
-        <label style={labelStyle} htmlFor="desc-de">
-          {t('admin.products.description')}{' '}
-          <span style={{ color: '#9ca3af', fontWeight: 400 }}>{t('admin.products.optional')}</span>
-        </label>
-        <textarea
-          id="desc-de"
-          {...register('translations.de.description')}
-          rows={3}
-          style={{ ...inputStyle(false), resize: 'vertical' }}
-          placeholder={t('admin.products.descriptionPlaceholder', { lang: 'DE' })}
-        />
-      </div>
-    </>
   );
 }
 

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import type { OrderResponse, OrderStatusResponse, OrderType } from '@api/orders';
+import type { OrderResponse, OrderType } from '@api/orders';
+import type { OrderStatusResponse } from '@/types/common';
 
 interface KitchenOrderCardProps {
   order: OrderResponse;

--- a/src/frontend/src/features/pos/context/PosOrderContext.tsx
+++ b/src/frontend/src/features/pos/context/PosOrderContext.tsx
@@ -16,14 +16,14 @@ export type { CartItem, CartModifier };
 // Types
 // ---------------------------------------------------------------------------
 
-export interface PosOrderState {
+interface PosOrderState {
   items: CartItem[];
   orderType: OrderType;
   tableNumber: number | undefined;
   paymentMethod: PaymentMethod;
 }
 
-export interface PosOrderTotals {
+interface PosOrderTotals {
   subtotalGross: number;
   vatPercent: number;
   vatAmount: number;
@@ -51,8 +51,7 @@ interface PosOrderContextValue {
  * Creates a stable deduplication key from selected modifiers.
  * Same product + same modifiers = same line item.
  */
-// eslint-disable-next-line react-refresh/only-export-components -- HMR boundary rule; helper co-located with the context it serves
-export function modifierKey(selectedModifiers: CartModifier[]): string {
+function modifierKey(selectedModifiers: CartModifier[]): string {
   return selectedModifiers
     .map((m) => m.modifierId)
     .sort()

--- a/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
+++ b/src/frontend/src/features/pos/pages/KitchenDisplay.tsx
@@ -12,7 +12,8 @@ import {
   showNewOrderNotification,
 } from '../utils/notifyNewOrder';
 import { orderLifecycleApi } from '@api/orderLifecycle';
-import { ordersApi, type OrderResponse, type OrderStatusResponse } from '@api/orders';
+import { ordersApi, type OrderResponse } from '@api/orders';
+import type { OrderStatusResponse } from '@/types/common';
 import { shopsApi } from '@api/shops';
 import type { ConnectionStatus } from '@api/useSignalR';
 

--- a/src/frontend/src/features/storefront/components/OrderStatusStepper.tsx
+++ b/src/frontend/src/features/storefront/components/OrderStatusStepper.tsx
@@ -1,7 +1,7 @@
 // Presentational stepper component — renders the shop's configured order
 // lifecycle as a horizontal step progression for customer-facing tracking.
 
-import type { OrderStatusResponse } from '@api/orders';
+import type { OrderStatusResponse } from '@/types/common';
 
 interface Props {
   /** Statuses from the lifecycle, ordered by sortOrder. */

--- a/src/frontend/src/features/storefront/context/CartContext.tsx
+++ b/src/frontend/src/features/storefront/context/CartContext.tsx
@@ -25,7 +25,7 @@ export interface CartItem {
   selectedModifiers: CartModifier[];
 }
 
-export interface CartState {
+interface CartState {
   brandSlug: string;
   shopId: string;
   items: CartItem[];

--- a/src/frontend/src/features/storefront/context/ShopContext.tsx
+++ b/src/frontend/src/features/storefront/context/ShopContext.tsx
@@ -4,10 +4,6 @@ import { useActiveShops } from '../hooks/useActiveShops';
 import { ShopContext } from './shopContextValue';
 import type { ResolvedShop } from './shopContextValue';
 
-// Re-export the type so callers can import from a single place
-export type { ResolvedShop };
-export { ShopContext };
-
 // ---------------------------------------------------------------------------
 // ShopResolver — layout route component
 // ---------------------------------------------------------------------------

--- a/src/frontend/src/features/storefront/hooks/useStorefrontMenu.ts
+++ b/src/frontend/src/features/storefront/hooks/useStorefrontMenu.ts
@@ -7,7 +7,7 @@ import type { MenuCategoryListItem, ProductListItem, ProductModifierGroupRespons
 // Query key factories — storefront-scoped, separate from admin keys
 // ---------------------------------------------------------------------------
 
-export const storefrontMenuKeys = {
+const storefrontMenuKeys = {
   categories: (brandSlug: string) => ['storefront', 'menuCategories', brandSlug] as const,
   categoryProducts: (brandSlug: string, categoryId: string) =>
     ['storefront', 'menuCategories', brandSlug, categoryId, 'products'] as const,

--- a/src/frontend/src/types/common.ts
+++ b/src/frontend/src/types/common.ts
@@ -143,7 +143,6 @@ export const Allergen = {
   Lupin: 12,
   Molluscs: 13,
 } as const;
-/** @expected-unused — DTO/response shape used once US-FP-005 (Product CRUD) allergen display ships */
 export type Allergen = (typeof Allergen)[keyof typeof Allergen];
 
 /** Label keys for allergens, used for i18n lookup. */
@@ -158,7 +157,6 @@ export const DietaryTag = {
   GlutenFree: 2,
   Halal: 3,
 } as const;
-/** @expected-unused — DTO/response shape used once US-FP-005 (Product CRUD) dietary tag display ships */
 export type DietaryTag = (typeof DietaryTag)[keyof typeof DietaryTag];
 
 /** Label keys for dietary tags, used for i18n lookup. */


### PR DESCRIPTION
Resolves all 19 fallow dead-code findings and the two largest production clones, with no behavior change.

- Drop unused exports/types (keeping internally-used symbols), remove the dead ShopContext re-exports, and delete 7 stale fallow suppressions
- Consolidate OrderStatus/OrderStatusTransition/OrderLifecycle response types into types/common.ts as the single source of truth; api/orders.ts and the three consumers (OrderStatusStepper, KitchenOrderCard, KitchenDisplay) import from there. Clears 3 duplicate-exports plus the orders<->common clone
- Extract shared ProductTranslationFields used by ProductCreate and ProductEdit (~94 LOC each); ComboTranslationFields left separate (different form schema + placeholder strategy)
- Tag the now-unmasked resetOrderHubConnection @expected-unused (retained as a test/HMR reset utility)

fallow: dead-code 19 -> 0; health A 88.4 -> 88.8; duplication 20.1% -> 19.4%.
Verified: type-check, lint, and 343 unit tests all green.