### PR TITLE
feat: select time slot at checkout (US-FP-019)

### DIFF
--- a/.agents/benchmarks/us-fp-019-baseline.md
+++ b/.agents/benchmarks/us-fp-019-baseline.md
@@ -1,0 +1,111 @@
+# US-FP-019 baseline session — cost & outcome record (2026-06-10)
+
+Baseline run of US-FP-019 "Select time slot at checkout" for comparison against a
+planned ultracode (full multi-agent orchestration) re-run of the same story.
+Result: PR #138, commit `3df4a0e`, branched from `chore/frontend-create-page-dedup` (d1cd886).
+
+## Approach used (baseline)
+
+Single main conversation orchestrating individual subagents:
+1. **Plan** agent (1×) — codebase exploration + full implementation plan
+2. **general-implementer** agent (1×) — entire backend + frontend implementation
+3. Main loop — verification, debugging 3 test failures, review fixes, commit, PR
+4. **Review fan-out** (7× parallel finder agents) — high-effort /code-review; verification done inline by main loop instead of separate verifier agents
+
+So the baseline was NOT purely single-agent: the review phase already fanned out.
+The ultracode run differs mainly in orchestrating understand/design/implement/verify
+phases through workflows too.
+
+## Token usage (as reported by the harness, subagents only)
+
+| Agent | Tokens | Tool uses | Duration |
+|---|---:|---:|---:|
+| Plan (us-fp-019 plan) | not reported | — | — |
+| general-implementer (full story) | 141,407 | 181 | 24m 57s |
+| Review finder: line-by-line | 94,154 | 21 | 5m 35s |
+| Review finder: removed-behavior | 98,921 | 24 | 5m 54s |
+| Review finder: cross-file tracer | 109,986 | 32 | 6m 46s |
+| Review finder: reuse | 67,753 | 16 | 3m 05s |
+| Review finder: simplification | 62,214 | 13 | 3m 16s |
+| Review finder: efficiency | 68,122 | 13 | 3m 35s |
+| Review finder: altitude | 74,710 | 17 | 3m 12s |
+| **Subagent total (excl. Plan agent)** | **717,267** | **317** | finders ran in parallel (~7m wall) |
+
+Main-conversation tokens (planning prompts, debugging, review verification, fixes,
+commit/PR) are NOT included above — not visible from inside the session.
+
+## Authoritative session totals (from /usage, recorded 2026-06-10)
+
+- **Total cost: $51.32**
+- Total duration (API): 1h 21m 17s
+- Total duration (wall): 1h 36m 27s
+- Code changes (as counted by the session): 2,689 lines added, 203 removed
+
+Usage by model:
+
+| Model | Input | Output | Cache read | Cache write | Cost |
+|---|---:|---:|---:|---:|---:|
+| claude-fable-5 | 134.0k | 218.5k | 21.3m | 837.7k | $44.07 |
+| claude-sonnet-4-6 | 3.4k | 75.3k | 16.7m | 296.6k | $7.25 |
+| claude-haiku-4-5 | 443 | 16 | 0 | 0 | $0.0005 |
+
+Session-attributed characteristics (from /usage, last-24h heuristics):
+- 95% of usage came from subagent-heavy sessions
+- 33% of usage was at >150k context
+- Subagent share: code-review 27%, general-implementer 14%, git-story 8%
+- Skill share: /code-review 5%, /git-story 3%, /commit 1%
+
+Note: the session ran ~15 min past the PR (baseline doc writing + this recording),
+but virtually all cost is from the story itself.
+
+## Scope delivered
+
+- 47 files changed, 3,658 insertions, 62 deletions (single feature commit)
+- Backend: 2 domain changes + 1 new domain service, 1 EF migration, 1 new endpoint,
+  1 new app service, 1 typed exception, server-side enforcement in OrderService
+- Frontend: 3 new modules (picker, hook, time utils), checkout integration with 409
+  recovery, kitchen/ticket/confirmation display, i18n NL/FR/DE, MSW handlers
+- Tests added: ~9 unit (TimeSlotGenerator) + Order invariants, 11 integration
+  (2 new classes), ~15 vitest (picker/utils + updated fixtures)
+- Final state: 347 unit / 11 integration / 357 vitest green; build + type-check clean
+
+## Quality events (for comparing defect-catch rates)
+
+Defects that escaped the implementer agent and were caught later:
+1. **Infinite loop / DateTime overflow** in TimeSlotGenerator when slot grid touched
+   midnight (TimeOnly wraparound) — caught by integration tests the implementer never
+   ran (Docker was down during its session)
+2. **In-store test used HTTP endpoint without CounterStaff auth** → 401 — caught by
+   integration test run, fixed via service-layer DI pattern
+3. **DST ambiguous-time offset inverted** (picked DST offset, comment claimed standard)
+   — caught by review fan-out
+4. **Stale-slot rejection = unrecoverable 400** (frontend only handled 409) — caught by
+   review fan-out; fixed with typed TimeSlotUnavailableException → 409
+5. **Silent ASAP downgrade** when selected slot aged out — caught by review fan-out
+6. **InvalidTimeZoneException uncaught** → 500 on public endpoint — caught by review
+7. Minor: weakened test assertion, per-call Intl.DateTimeFormat, duplicated formatter,
+   query-key literal duplication, polling behind payment screen — caught by review
+
+Known accepted gaps (same for both runs, by design): capacity check-then-insert race,
+cancelled orders consume capacity, today-only horizon, POS ASAP-only.
+
+## Wall-clock phase estimates (from tool durations)
+
+- Planning (Plan agent): ~5–10 min
+- Implementation (implementer agent): ~25 min
+- Verification + debugging (integration runs at 3m29s/22s/25s/21s/17s/14s, unit runs,
+  frontend test+build ×2): ~25 min
+- Review fan-out: ~7 min parallel + fixes ~20 min
+- Commit + PR: ~5 min
+
+## Comparison checklist for the ultracode re-run
+
+Record the same for the re-run:
+- [ ] Total subagent tokens + agent count
+- [ ] `/usage` session total (baseline: **$51.32**, 1h 21m API / 1h 36m wall)
+- [ ] Wall-clock time to PR
+- [ ] Defects remaining after implementation phase (run the same integration/unit/vitest suites)
+- [ ] Defects found by review phase(s)
+- [ ] Scope drift vs the approved plan (.agents/plans/us-fp-019-time-slot-checkout.md)
+- [ ] Re-run setup: branch fresh from d1cd886, revert/ignore this baseline's branch,
+      keep issue #19 open (or compare against PR #138 diff instead of merging twice)

--- a/.agents/plans/us-fp-019-time-slot-checkout.md
+++ b/.agents/plans/us-fp-019-time-slot-checkout.md
@@ -1,0 +1,333 @@
+# US-FP-019 — Select time slot at checkout
+
+GitHub issue: [#19](https://github.com/OoyeM/TheMillionthFoodOrderApp/issues/19)
+Branch: `feat/us-fp-019-time-slot-checkout`
+Prereqs: US-FP-016 ✅ (checkout), US-FP-020 ✅ (time-slot settings on Shop)
+
+## Acceptance criteria
+
+1. When time-slot ordering is enabled, checkout shows available slots based on the shop's configured interval and max orders per interval.
+2. Full slots are greyed out and not selectable.
+3. "As soon as possible" is always available as an option.
+4. Selected time slot is stored with the order and visible to kitchen staff.
+5. When time-slot ordering is disabled, customer sees estimated wait time (or place in line) instead.
+
+## Verified state of the codebase
+
+- `Shop.TimeSlotOrdering` (owned `TimeSlotOrderingSettings` VO: `IsEnabled`, `TimeSlotInterval?` enum 5/10/15, `MaxOrdersPerInterval?`) exists with columns `TimeSlotOrdering_IsEnabled/_Interval/_MaxOrdersPerInterval` — `src/backend/TheMillionthFoodOrderApp.Domain/Shops/TimeSlotOrderingSettings.cs`, `src/backend/TheMillionthFoodOrderApp.Infrastructure/Shops/ShopConfiguration.cs`.
+- **`Order` has NO time-slot field** — US-FP-028's "time slot" was speculative. The frontend `OrderResponse` type already declares `timeSlot?: string | null` (`src/frontend/src/api/orders.ts:83`), and `KitchenOrderCard.tsx` (line 143) + `printTicket.ts` (line 59) already render it when present, but the backend never sends it. Domain + migration + DTO work is required.
+- Order creation funnels through the private `CreateOrderCoreAsync` in `src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs` (~line 210), with per-path flags (`enforceOpeningHours: true` only for the online path) — the exact pattern to follow for slot enforcement.
+- `Shop` has `TimeZoneId` ("Europe/Brussels"), `OpeningHours` (local-time `OpeningHoursTimeBlock`s), `IsOpenAt()`, `GetNextOpeningTime()` with established UTC-conversion patterns. `ShopRepository.GetByIdAsync` already `Include`s `OpeningHours`.
+- Storefront checkout resolves the shop via `ShopResolver` → `ResolvedShop` context (`id`, `name`, `slug`, `isOpen`, `eatIn`) backed by `GET /api/brands/{brandSlug}/shops/active` (`StorefrontShopResponse`) — **which currently does NOT include `TimeSlotOrdering`**; it must be extended.
+- US-FP-021 (estimated wait times) is not started — AC5 needs an MVP fallback.
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where slots are computed | **New server endpoint** `GET /api/brands/{brandSlug}/shops/{shopId}/time-slots` | Capacity counting needs DB order counts; client can't know them. Server is also the enforcement point, so one shared generator avoids drift. |
+| Slot anchor & grid | Slots anchored at each opening block's `OpenTime`, stepping by `interval`; a slot `[start, start+interval)` is offered only if it fits fully inside the block | Cleaner than clock-hour anchoring with odd opening times (e.g. 11:30 open + 15 min → 11:30, 11:45 …). |
+| Horizon | **Remainder of today only** (shop-local day) — no artificial slot cap; the day itself bounds generation (worst case 24h open ÷ 5 min = 288 slots) | Same-day food pickup; no pre-order story exists. An arbitrary cap (e.g. 48) would silently truncate the day for long-open shops. Stated as scope decision. |
+| Lead time | First offered slot starts ≥ `now + interval` (rounded up to grid) | Kitchen needs at least one interval of prep runway. |
+| ASAP representation | `TimeSlotStart == null` on the Order (and absent from the request) | AC3: ASAP is always valid, including when slots are enabled. No sentinel values. |
+| Persisted shape | `TimeSlotStart` + `TimeSlotEnd` (`DateTimeOffset?`, UTC) on `Order` | Capacity counting groups by exact `TimeSlotStart`; storing `End` denormalises the interval so later admin config changes don't corrupt history (same denormalisation philosophy as `ProductName` on order items). |
+| Capacity counting | Count **all** orders with the same `TimeSlotStart`, regardless of status | No cancellation concept exists yet; slots are in the future so completed-before-slot is not a real case. Stated as scope decision. |
+| Concurrency on capacity | Accept the small check-then-insert race for MVP (two simultaneous orders could overbook a slot by 1) | Fixing it needs a serializable transaction or slot-counter table; low traffic at MVP. Documented below. |
+| Validation on create | Online path only: recompute valid slots via the shared generator and require the requested `TimeSlotStart` to be a member, then check capacity | One check enforces alignment + opening hours + future-ness + enabled-flag. In-store/POS path never passes a slot. |
+| Full-slot error | `InvalidOperationException("TIME_SLOT_FULL")` → endpoint maps to **409**; frontend refreshes slot list on 409 | Distinguishable from generic 400s so the picker can self-heal. |
+| Timezone | Generate in shop-local time from `OpeningHours`, convert boundaries to UTC via `TimeZoneInfo.ConvertTimeToUtc` (same pattern as `Shop.GetNextOpeningTime`); API returns ISO-8601 with offset; frontend formats with `Intl` (devices/customers are in the shop's timezone — consistent with how `createdAt` is already rendered) | Matches existing conventions; `DateTimeOffset` everywhere per backend CLAUDE.md. |
+| AC5 fallback (US-FP-021 not done) | When `isEnabled == false`, checkout shows a static notice: "Your order will be prepared as soon as possible." No backend work. When US-FP-021 lands, that notice is replaced with the configured wait time. | Explicit scope decision — no wait-time config exists to read. |
+| POS | **Stays ASAP-only.** No slot picker in POS; `CreateInStoreOrderRequest` unchanged | AC only covers customer checkout; staff at the counter take orders for "now". |
+| Order type scope | Slot picker shown for all online order types (Pickup/EatIn/Delivery) | US-FP-020's stated intent is matching kitchen capacity for all online orders. |
+
+## Backend
+
+### 1. Domain — Order gets a time slot
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs`
+- Add `public DateTimeOffset? TimeSlotStart { get; private set; }` and `public DateTimeOffset? TimeSlotEnd { get; private set; }` (null = ASAP).
+- Extend `Order.Create(...)` with optional params `DateTimeOffset? timeSlotStart = null, DateTimeOffset? timeSlotEnd = null` (appended after `languageCode`). Invariants guarded in the factory: both-or-neither set; `timeSlotEnd > timeSlotStart`; throw `ArgumentException` otherwise.
+
+**File (new):** `src/backend/TheMillionthFoodOrderApp.Domain/Shops/TimeSlotGenerator.cs`
+- Pure, static domain service:
+```csharp
+public static IReadOnlyList<(DateTimeOffset Start, DateTimeOffset End)> GenerateSlotsForToday(
+    Shop shop, DateTimeOffset now)
+```
+- No artificial slot cap — the today-only horizon bounds output naturally (≤ 288 slots for a 24h shop at 5-min intervals).
+- Returns `[]` when `!shop.TimeSlotOrdering.IsEnabled`, no opening hours, or unknown `TimeZoneId` (mirror `IsOpenAt`'s defensive try/catch).
+- Algorithm: convert `now` to shop-local; for each of today's blocks (ordered by `OpenTime`): anchor at `OpenTime`, step `interval` minutes; include slot if `slotEnd <= CloseTime` and `slotStart >= localNow + interval`; convert boundaries to UTC `DateTimeOffset`.
+
+### 2. EF configuration + migration
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs`
+- `builder.Property(o => o.TimeSlotStart).IsRequired(false);` and same for `TimeSlotEnd` (DateTimeOffsetConvention gives `datetimeoffset(7)`).
+- Filtered index for capacity counting:
+```csharp
+builder.HasIndex(o => new { o.ShopId, o.TimeSlotStart })
+    .HasDatabaseName("IX_Orders_ShopId_TimeSlotStart")
+    .HasFilter("[TimeSlotStart] IS NOT NULL");
+```
+
+**Migration (Brand context):**
+```
+dotnet ef migrations add AddOrderTimeSlot --project TheMillionthFoodOrderApp.Infrastructure --startup-project TheMillionthFoodOrderApp.Api --context BrandDbContext --output-dir Persistence/Migrations/Brand
+```
+
+### 3. Repository — slot occupancy counts
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs`
+```csharp
+Task<IReadOnlyDictionary<DateTimeOffset, int>> GetTimeSlotOrderCountsAsync(
+    Guid shopId, DateTimeOffset fromInclusive, DateTimeOffset toExclusive,
+    CancellationToken cancellationToken = default);
+```
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs`
+- `GroupBy(o => o.TimeSlotStart!.Value)` over `Orders.Where(o => o.ShopId == shopId && o.TimeSlotStart >= from && o.TimeSlotStart < to)` → `ToDictionaryAsync`.
+
+### 4. Application — availability service + DTOs
+
+**Files (new):** `src/backend/TheMillionthFoodOrderApp.Application/Orders/ITimeSlotAvailabilityService.cs`, `TimeSlotAvailabilityService.cs`
+- `Task<AvailableTimeSlotsResponse> GetAvailableSlotsAsync(Guid shopId, CancellationToken ct)`:
+  1. Load shop (404 if missing). If disabled → `new AvailableTimeSlotsResponse(false, null, null, [])`.
+  2. `TimeSlotGenerator.GenerateSlotsForToday(shop, DateTimeOffset.UtcNow)`.
+  3. One `GetTimeSlotOrderCountsAsync` call spanning first slot start → last slot end.
+  4. Map each slot to `remainingCapacity = max - count`, `isAvailable = remaining > 0`.
+- Register in `src/backend/TheMillionthFoodOrderApp.Application/DependencyInjection.cs`: `services.AddScoped<ITimeSlotAvailabilityService, TimeSlotAvailabilityService>();`
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderDtos.cs` — add:
+```csharp
+public sealed record TimeSlotDto(
+    DateTimeOffset Start, DateTimeOffset End, bool IsAvailable, int RemainingCapacity);
+
+public sealed record AvailableTimeSlotsResponse(
+    bool IsEnabled, int? IntervalMinutes, int? MaxOrdersPerInterval,
+    IReadOnlyList<TimeSlotDto> Slots);
+```
+- `CreateOrderRequest`: append `DateTimeOffset? TimeSlotStart = null`.
+- `OrderResponse`: append `DateTimeOffset? TimeSlotStart = null, DateTimeOffset? TimeSlotEnd = null` (optional positional params at the end — existing call sites unaffected).
+- `CreateInStoreOrderRequest`: **unchanged** (POS = ASAP-only).
+
+### 5. New endpoint — available slots
+
+**File (new):** `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetAvailableTimeSlotsEndpoint.cs`
+- `GET /api/brands/{brandSlug}/shops/{shopId}/time-slots`
+- Request record `(string BrandSlug, Guid ShopId)` route params; `AllowAnonymous()`; `PreProcessor<BrandScopedPreProcessor<…>>` (mirror `ListActiveShopsEndpoint`).
+- Response shape (200):
+```json
+{
+  "isEnabled": true,
+  "intervalMinutes": 10,
+  "maxOrdersPerInterval": 4,
+  "slots": [
+    { "start": "2026-06-10T15:10:00+00:00", "end": "2026-06-10T15:20:00+00:00",
+      "isAvailable": true, "remainingCapacity": 3 }
+  ]
+}
+```
+- 404 when shop unknown. Swagger summary documenting the disabled shape `{ "isEnabled": false, "slots": [] }`.
+
+### 6. OrderService — server-side enforcement (follows the eat-in gating pattern)
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs`
+- `CreateOrderCoreAsync`: new param `DateTimeOffset? timeSlotStart = null`. After the opening-hours check (step 3b), add step 3c:
+  - If `timeSlotStart is null` → nothing (ASAP, always allowed — AC3).
+  - Else:
+    - `!shop.TimeSlotOrdering.IsEnabled` → `ArgumentException("This shop does not accept time-slot orders.")` (400).
+    - Recompute `TimeSlotGenerator.GenerateSlotsForToday(shop, DateTimeOffset.UtcNow)`; requested start must match a generated slot's `Start` (compare UTC instants) → else `ArgumentException("The requested time slot is not available...")`.
+    - Capacity: `GetTimeSlotOrderCountsAsync(shopId, slot.Start, slot.End)`; if `count >= MaxOrdersPerInterval` → `throw new InvalidOperationException("TIME_SLOT_FULL")`.
+    - Pass `slot.Start`/`slot.End` to `Order.Create`.
+- `CreateOrderAsync` forwards `request.TimeSlotStart`; `CreateInStoreOrderAsync` passes `null`.
+- `MapToResponse`: append `order.TimeSlotStart, order.TimeSlotEnd`.
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs` — same two fields appended (feeds tracking, by-number, list-active → kitchen display).
+
+### 7. CreateOrderEndpoint — request field + 409 mapping
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs`
+- `CreateOrderApiRequest`: append `DateTimeOffset? TimeSlotStart = null`; forward to the app request.
+- Validator: light shape check only — `TimeSlotStart` must be in the future when supplied (`.GreaterThan(DateTimeOffset.UtcNow)` evaluated lazily via `.Must(...)`); authoritative validation stays in `OrderService` (comment referencing US-FP-019, same style as the table-number comment).
+- Add a specific catch **before** the generic `InvalidOperationException` catch:
+```csharp
+catch (InvalidOperationException ex) when (ex.Message == "TIME_SLOT_FULL")
+{
+    var failures = new List<ValidationFailure>
+        { new("timeSlotStart", "The selected time slot is full. Please pick another slot.") };
+    await HttpContext.Response.SendErrorsAsync(failures, statusCode: 409, cancellation: ct);
+}
+```
+- Swagger: document 409.
+
+### 8. Storefront shop DTO carries the settings
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs`
+- `StorefrontShopResponse`: append `TimeSlotOrderingSettingsDto TimeSlotOrdering`.
+
+**File:** `src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs`
+- `MapToStorefrontResponse`: map `shop.TimeSlotOrdering` exactly like `MapToResponse` does.
+
+## Frontend
+
+### 9. Types + API clients
+
+**File:** `src/frontend/src/api/shops.ts`
+- `StorefrontShop`: add `timeSlotOrdering: TimeSlotOrderingSettings;` (type already exists in `src/frontend/src/types/common.ts:76`).
+
+**File:** `src/frontend/src/api/orders.ts`
+- `CreateOrderRequest`: add `timeSlotStart?: string | null;`
+- `OrderResponse`: **replace** the speculative `timeSlot?: string | null` with `timeSlotStart?: string | null; timeSlotEnd?: string | null;`
+- New types + function:
+```ts
+export interface TimeSlotResponse {
+  start: string; end: string; isAvailable: boolean; remainingCapacity: number;
+}
+export interface AvailableTimeSlotsResponse {
+  isEnabled: boolean; intervalMinutes: number | null;
+  maxOrdersPerInterval: number | null; slots: TimeSlotResponse[];
+}
+// in ordersApi:
+getTimeSlots: (brandSlug: string, shopId: string): Promise<AvailableTimeSlotsResponse> =>
+  apiClient.get<AvailableTimeSlotsResponse>(`/brands/${brandSlug}/shops/${shopId}/time-slots`)
+    .then((r) => r.data),
+```
+
+**File (new):** `src/frontend/src/utils/timeSlot.ts`
+- `formatTimeSlot(startIso: string, endIso: string): string` → `"17:10–17:20"` using `Intl.DateTimeFormat('nl-BE', { hour: '2-digit', minute: '2-digit' })` (same convention as `KitchenOrderCard.formatTime`).
+
+### 10. ShopResolver context
+
+**Files:** `src/frontend/src/features/storefront/context/shopContextValue.ts`, `ShopContext.tsx`
+- `ResolvedShop`: add `timeSlotOrdering: TimeSlotOrderingSettings;`; `ShopResolver` copies `shop.timeSlotOrdering` into the context.
+
+### 11. Hook + picker component
+
+**File (new):** `src/frontend/src/features/storefront/hooks/useAvailableTimeSlots.ts`
+```ts
+useQuery({
+  queryKey: ['timeSlots', brandSlug, shopId],
+  queryFn: () => ordersApi.getTimeSlots(brandSlug, shopId),
+  enabled,                 // only when shop.timeSlotOrdering.isEnabled
+  staleTime: 15_000,
+  refetchInterval: 30_000, // slots fill up in real time
+});
+```
+
+**File (new):** `src/frontend/src/features/storefront/components/TimeSlotPicker.tsx`
+- Props: `{ slots: TimeSlotResponse[]; value: string; onChange: (startIso: string) => void; isLoading: boolean; isError: boolean }` where `value === ''` means ASAP.
+- Renders a radio group styled like the existing order-type cards:
+  - First option always **ASAP** (`storefront.checkout.timeSlot.asap`) — AC3.
+  - One option per slot, label from `formatTimeSlot`; when `!isAvailable`: `disabled`, `opacity 0.5`, `cursor: not-allowed`, suffixed badge `storefront.checkout.timeSlot.full` — AC2.
+  - Empty `slots` (e.g. near closing): ASAP option + `storefront.checkout.timeSlot.noneAvailable` notice.
+  - Error state: ASAP option + load-error notice (ordering must still work).
+  - Slot count can be large (a long-open shop at 5-min intervals yields hundreds of slots): render the slot options in a max-height scrollable container (ASAP pinned above it) rather than an unbounded list.
+  - **Stale-slot guard:** the server only generates future slots (start ≥ now + interval), but the fetched list ages between refetches — at render time, filter out slots whose `start` is no longer in the future (`new Date(slot.start) > new Date()`). If the currently selected slot drops out of the filtered list, reset the selection to ASAP. Defense-in-depth: server still rejects past/misaligned slots with 400 on submit.
+
+### 12. CheckoutPage integration
+
+**File:** `src/frontend/src/features/storefront/pages/CheckoutPage.tsx`
+- `CheckoutForm` gets `timeSlotOrdering` prop from `useResolvedShop()`.
+- Form: add `timeSlotStart: string` to `CheckoutFormValues` + zod schema (plain `z.string()`, default `''`); ASAP needs no validation.
+- Render between the order-type fieldset and the VAT notice:
+  - `timeSlotOrdering.isEnabled` → `useAvailableTimeSlots(...)` + `<TimeSlotPicker>` (Controller-wrapped) — AC1.
+  - else → static info banner `storefront.checkout.timeSlot.asapNotice` (reuse the VAT-notice styling) — AC5 MVP fallback.
+- `onSubmit`: `timeSlotStart: values.timeSlotStart || null` in the mutate payload.
+- Error handling: if `createOrder` fails with HTTP 409 (axios `error.response?.status === 409`), show `storefront.checkout.timeSlot.slotFull`, reset `timeSlotStart` to `''`, and `queryClient.invalidateQueries({ queryKey: ['timeSlots', brandSlug, shopId] })`.
+
+### 13. Display surfaces (AC4)
+
+**File:** `src/frontend/src/features/pos/components/KitchenOrderCard.tsx`
+- Replace the `order.timeSlot` condition (line 143) with `order.timeSlotStart != null && order.timeSlotEnd != null`, rendering `t('pos.kitchen.timeSlot', { value: formatTimeSlot(order.timeSlotStart, order.timeSlotEnd) })`. Existing i18n key + `data-testid="kitchen-order-timeslot"` are kept.
+
+**File:** `src/frontend/src/features/pos/utils/printTicket.ts`
+- Same swap: build the meta row from `timeSlotStart`/`timeSlotEnd` via `formatTimeSlot` (the `labels.timeSlot` label param stays).
+
+**File:** `src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx`
+- Add a "Time slot" row when `timeSlotStart` is present (key `storefront.order.timeSlot`), so the customer sees what they picked.
+
+### 14. i18n (NL / FR / DE)
+
+**Files:** `src/frontend/src/i18n/locales/{nl,fr,de}/common.json` — under `storefront.checkout`, new `timeSlot` object; plus one key under `storefront.order`:
+
+| Key | NL | FR | DE |
+|---|---|---|---|
+| `checkout.timeSlot.label` | Tijdslot | Créneau horaire | Zeitfenster |
+| `checkout.timeSlot.asap` | Zo snel mogelijk | Dès que possible | So schnell wie möglich |
+| `checkout.timeSlot.full` | Vol | Complet | Voll |
+| `checkout.timeSlot.noneAvailable` | Geen tijdsloten meer beschikbaar vandaag. Uw bestelling wordt zo snel mogelijk bereid. | Plus de créneaux disponibles aujourd'hui. Votre commande sera préparée dès que possible. | Heute sind keine Zeitfenster mehr verfügbar. Ihre Bestellung wird so schnell wie möglich zubereitet. |
+| `checkout.timeSlot.asapNotice` | Uw bestelling wordt zo snel mogelijk bereid. | Votre commande sera préparée dès que possible. | Ihre Bestellung wird so schnell wie möglich zubereitet. |
+| `checkout.timeSlot.slotFull` | Dit tijdslot is net volgeboekt. Kies een ander tijdslot. | Ce créneau vient d'être complet. Veuillez en choisir un autre. | Dieses Zeitfenster ist soeben ausgebucht. Bitte wählen Sie ein anderes. |
+| `checkout.timeSlot.loadError` | Tijdsloten konden niet geladen worden. U kunt wel "zo snel mogelijk" bestellen. | Impossible de charger les créneaux. Vous pouvez commander "dès que possible". | Zeitfenster konnten nicht geladen werden. Sie können "so schnell wie möglich" bestellen. |
+| `order.timeSlot` | Tijdslot | Créneau horaire | Zeitfenster |
+
+(`pos.kitchen.timeSlot` already exists in all three locales.)
+
+### 15. MSW handlers / fixtures
+
+**File:** `src/frontend/src/test/msw/handlers.ts`
+- Add `timeSlotOrdering` to the active-shops fixture (line ~270 already has it on the admin shop fixture — the storefront one will now need it too).
+- New handler: `GET */brands/:brandSlug/shops/:shopId/time-slots`.
+
+## Tests
+
+### Backend — TUnit (per dotnet-testing skill: `[Test]`, awaited `Assert.That`, `dotnet run -c Release`; **run integration classes individually — parallel SQL containers OOM**)
+
+**Unit — `src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/TimeSlotGeneratorTests.cs`** (new)
+- Disabled settings → empty. No opening hours → empty. Invalid TimeZoneId → empty.
+- Slots anchor at block `OpenTime` and step by interval (11:30 open + 15 min → 11:30, 11:45 …).
+- Slot whose end would exceed `CloseTime` is excluded.
+- Lead time: slots starting before `now + interval` excluded; mid-day "now" yields only remaining slots.
+- Two blocks in one day (lunch + dinner) → both covered, gap excluded.
+- UTC conversion correct for Europe/Brussels (+02:00 in June).
+- 24h-open shop at 5-min interval from start of day → 288 slots (full day, no truncation).
+
+**Unit — `src/backend/TheMillionthFoodOrderApp.Tests.Unit/Orders/OrderTests.cs`** (new or extend)
+- `Order.Create` with start-only / end-only throws; `end <= start` throws; both-null OK; both-set persists.
+
+**Integration — `src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetAvailableTimeSlotsTests.cs`** (new) — `[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]`, seed via HTTP like `PlaceOrderTests` (`PUT shops/{id}` to enable `timeSlotOrdering`, always-open hours helper):
+1. Disabled shop → `{ isEnabled: false, slots: [] }`.
+2. Enabled (10 min, max 2) → slots aligned to interval, all `isAvailable: true`, `remainingCapacity: 2`.
+3. Place 2 orders into one slot → that slot `isAvailable: false`, `remainingCapacity: 0`; neighbours unaffected.
+4. Unknown shop id → 404.
+
+**Integration — `src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTimeSlotTests.cs`** (new)
+1. Valid slot → 201; `timeSlotStart`/`timeSlotEnd` echoed; persisted (fetch tracking endpoint shows them).
+2. No slot (ASAP) with slots enabled → 201, nulls.
+3. Slot supplied while shop has slots disabled → 400.
+4. Misaligned/past slot → 400.
+5. Slot at capacity → **409** with `timeSlotStart` failure.
+6. Kitchen path: `GET orders/active` includes `timeSlotStart`/`timeSlotEnd` (AC4).
+7. In-store endpoint ignores slots entirely (existing `CreateInStoreOrderServiceTests` untouched; add one assertion that in-store orders have null slots).
+
+### Frontend — vitest
+
+- **`src/frontend/src/features/storefront/components/__tests__/TimeSlotPicker.test.tsx`** (new): renders ASAP first; renders formatted slot labels; full slots disabled (AC2); selecting fires `onChange`; empty-slots and error states still offer ASAP; slots with a `start` in the past are not rendered (use fake timers), and a selected slot that ages out resets the selection to ASAP.
+- **`src/frontend/src/features/storefront/pages/__tests__/CheckoutPage.test.tsx`** (extend): picker visible when enabled (AC1); ASAP notice when disabled (AC5); submit payload contains `timeSlotStart` (and `null` for ASAP); 409 → slot-full message shown + slots refetched.
+- **`src/frontend/src/features/pos/components/__tests__/KitchenOrderCard…`** + **`printTicket.test.ts`** (update): time-slot badge/row renders from `timeSlotStart`/`timeSlotEnd`; absent when null.
+- **`src/frontend/src/utils/__tests__/timeSlot.test.ts`** (new): formatting.
+- Update any fixture using the removed `timeSlot` string field.
+
+## Verification
+
+- `dotnet build TheMillionthFoodOrderApp.slnx` in `src/backend/` → 0 errors
+- `dotnet run -c Release` in `TheMillionthFoodOrderApp.Tests.Unit/`
+- `dotnet run -c Release` in `TheMillionthFoodOrderApp.Tests.Integration/` — run the new classes individually (OOM constraint): `--treenode-filter "/*/*/GetAvailableTimeSlotsTests/*"` etc.
+- `pnpm test` and `pnpm build` in `src/frontend/`
+- Manual: enable slots on a seeded shop via admin (US-FP-020 UI), place an online order with a slot, confirm the kitchen display badge and ticket print show it.
+
+## Scope decisions & open questions (explicit)
+
+1. **AC5 / wait time:** US-FP-021 not started → static "as soon as possible" notice; no per-shop configured wait minutes, no place-in-line. Revisit in US-FP-021.
+2. **Capacity counts all statuses:** no cancelled/refused order concept exists; when one lands, the count query must exclude it.
+3. **Overbooking race:** check-then-insert is not transactionally guarded; worst case one extra order in a slot under concurrent submits. Acceptable for MVP; fix later with a slot-counter row + unique constraint if needed.
+4. **Today-only horizon:** no advance-day ordering; aligns with same-day fast-food flow. Special hours/holidays (US-FP-041) not done — slots follow weekly opening hours only, consistent with `IsOpenAt`.
+5. **POS stays ASAP-only**; kitchen display continues to sort by `CreatedAt` (sorting by slot is a possible follow-up, not in the AC).
+6. **Frontend `timeSlot` string field is replaced** by `timeSlotStart`/`timeSlotEnd` — it was speculative and never populated, so this is not a breaking change for real data.
+
+## File summary
+
+**Backend (modified):** `Domain/Orders/Order.cs`, `Domain/Orders/IOrderRepository.cs`, `Infrastructure/Orders/OrderConfiguration.cs`, `Infrastructure/Orders/OrderRepository.cs`, `Application/Orders/OrderDtos.cs`, `Application/Orders/OrderService.cs`, `Application/DependencyInjection.cs`, `Application/Shops/ShopDtos.cs`, `Application/Shops/ShopService.cs`, `Api/Endpoints/Orders/CreateOrderEndpoint.cs`, `Api/Endpoints/Orders/OrderTrackingMapper.cs`
+**Backend (new):** `Domain/Shops/TimeSlotGenerator.cs`, `Application/Orders/ITimeSlotAvailabilityService.cs`, `Application/Orders/TimeSlotAvailabilityService.cs`, `Api/Endpoints/Orders/GetAvailableTimeSlotsEndpoint.cs`, `Infrastructure/Persistence/Migrations/Brand/<ts>_AddOrderTimeSlot.cs`, `Tests.Unit/Shops/TimeSlotGeneratorTests.cs`, `Tests.Unit/Orders/OrderTests.cs`, `Tests.Integration/Orders/GetAvailableTimeSlotsTests.cs`, `Tests.Integration/Orders/PlaceOrderTimeSlotTests.cs`
+**Frontend (modified):** `api/orders.ts`, `api/shops.ts`, `features/storefront/context/shopContextValue.ts`, `features/storefront/context/ShopContext.tsx`, `features/storefront/pages/CheckoutPage.tsx`, `features/storefront/pages/OrderConfirmationPage.tsx`, `features/pos/components/KitchenOrderCard.tsx`, `features/pos/utils/printTicket.ts`, `i18n/locales/{nl,fr,de}/common.json`, `test/msw/handlers.ts`
+**Frontend (new):** `features/storefront/hooks/useAvailableTimeSlots.ts`, `features/storefront/components/TimeSlotPicker.tsx`, `utils/timeSlot.ts`, plus the test files above
+**Docs:** `docs/dependency-tree.md` — mark US-FP-019 ✅ after merge

--- a/docs/dependency-tree.md
+++ b/docs/dependency-tree.md
@@ -1,7 +1,7 @@
 # User Story Dependency Tree & Progress Tracker
 
 > Generated from [frietjes-platform.md](./extract-prd/user-stories/frietjes-platform.md)
-> Last updated: 2026-06-04 (US-FP-066 eat-in toggle + US-FP-020 time-slot config done; US-FP-051 digital receipt done; US-FP-052 print receipt done; US-FP-026 order notifications done; US-FP-023 + US-FP-071 verified done; online-channel cluster unblocked — see "Status Accuracy" below)
+> Last updated: 2026-06-10 (US-FP-019 time-slot picker at checkout done; previously: US-FP-066 eat-in toggle + US-FP-020 time-slot config, US-FP-051 digital receipt, US-FP-052 print receipt, US-FP-026 order notifications, US-FP-023 + US-FP-071 — see "Status Accuracy" below)
 
 ## Progress Legend
 
@@ -18,6 +18,9 @@
 > **Tracking caveat:** GitHub issues are *not* closed when work merges, and this tree had drifted. Statuses below were re-verified by checking each open issue's **acceptance-criteria checklist** against the actual code (backend + frontend). Treat the issue tracker's open/closed state as unreliable on its own — verify against ACs.
 
 **✅ Online-ordering entry point RESOLVED (2026-06-04).** US-FP-071 (shop selection + shop-slug-scoped storefront routes) merged via **PR #128** and was runtime-verified. The storefront now has a real customer journey: `/{brand}/{lang}/shops` chooser → `{shopSlug}/menu` → checkout → payment → order tracking, with the localStorage `shopId` hack removed. This unblocks the cluster that was previously "component-complete but NOT user-reachable" — **US-FP-016 / 017 / 038 / 058 / 063 restored to ✅.** (Historical note: this gap was found 2026-06-03 — `Home.tsx` was a stub and the menu only rendered at a GUID-based route nothing linked to.)
+
+**Changed 2026-06-10:**
+- **US-FP-019** → ✅ done. Customer-facing time-slot picker at checkout, consuming US-FP-020's per-shop config. `Order.TimeSlotStart/End` (`DateTimeOffset?`, null = ASAP) + brand migration `AddOrderTimeSlot` (filtered index for capacity counts). Pure domain `TimeSlotGenerator` (slots anchored per opening-hours block, today-only horizon, lead time = one interval, shop-timezone-aware). New endpoint `GET /brands/{slug}/shops/{shopId}/time-slots` (availability + remaining capacity); server-side enforcement in the shared `OrderService` create-core — full or no-longer-offered slot → typed `TimeSlotUnavailableException` → **409**, which the checkout recovers from (message + reset to ASAP + slot refetch). Storefront `TimeSlotPicker` (ASAP always first, full slots greyed out, scrollable, 30s refetch, stale-slot guard with visible reset notice); kitchen card + ticket print show the slot. POS stays ASAP-only. Scope decisions: today-only slots, capacity counts all statuses (no cancellation concept yet), accepted check-then-insert race (MVP), static "ASAP" notice when slots disabled (configured wait time = US-FP-021).
 
 **Changed 2026-06-04:**
 - **US-FP-066** → ✅ done. Per-shop eat-in toggle + a "require table number" sub-toggle, modelled as an owned `EatInSettings` value object on `Shop` (defaults: eat-in **on**, table **required** — preserves prior behaviour). Admin ShopEdit checkboxes; storefront + POS hide the eat-in order type when disabled and gate the table-number field (required/optional) by the flag; **server-side enforcement** in the shared `OrderService` create-core rejects eat-in when disabled and requires a table number when mandated, so online + in-store are gated identically. Closed US-FP-024's `IsEatInEnabled` gating gap and added **online table-number capture** (the public order path/`CreateOrderRequest` now accepts `tableNumber`). Brand migration `AddShopEatInAndTimeSlotSettings`.
@@ -160,7 +163,7 @@ Once ordering works, these streams are **all independent**.
 | ⬜ | **US-FP-062** | View order history | 016, 037 |
 | 🚧 | **US-FP-024** | Eat-in ordering with table number | 016, 066 |
 | ⬜ | **US-FP-025** | QR code table ordering | 024, 065 |
-| ⬜ | **US-FP-019** | Select time slot at checkout | 016, 020 |
+| ✅ | **US-FP-019** | Select time slot at checkout | 016, 020 |
 | ✅ | **US-FP-064** | Browse menu with allergen/dietary filters | 008 |
 | 🚧 | **US-FP-059** | Place a delivery order (POC) | 016 |
 

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/CreateOrderEndpoint.cs
@@ -20,7 +20,12 @@ public sealed record CreateOrderApiRequest(
     string? CustomerEmail = null,
     string? CustomerPhone = null,
     string? LanguageCode = null,
-    int? TableNumber = null);
+    int? TableNumber = null,
+    /// <summary>
+    /// UTC start of the requested time slot (US-FP-019). Null = "as soon as possible".
+    /// Shape validation only here; authoritative validation (alignment, capacity) is in OrderService.
+    /// </summary>
+    DateTimeOffset? TimeSlotStart = null);
 
 public sealed class CreateOrderRequestValidator : Validator<CreateOrderApiRequest>
 {
@@ -79,6 +84,13 @@ public sealed class CreateOrderRequestValidator : Validator<CreateOrderApiReques
         RuleFor(x => x.TableNumber)
             .GreaterThan(0).WithMessage("TableNumber must be greater than zero.")
             .When(x => x.TableNumber is not null);
+
+        // Time slot shape check only — must be in the future when supplied (US-FP-019).
+        // Authoritative validation (slot alignment, capacity) is done server-side in OrderService.
+        RuleFor(x => x.TimeSlotStart)
+            .Must(v => v!.Value > DateTimeOffset.UtcNow)
+            .WithMessage("TimeSlotStart must be in the future.")
+            .When(x => x.TimeSlotStart is not null);
     }
 }
 
@@ -98,10 +110,12 @@ public sealed class CreateOrderEndpoint(IOrderService orderService)
             s.Description =
                 "Creates a new order for the specified shop. " +
                 "Server resolves current product prices — client-submitted prices are ignored. " +
-                "VAT is applied at 6% for Pickup/Delivery and 21% for EatIn.";
+                "VAT is applied at 6% for Pickup/Delivery and 21% for EatIn. " +
+                "Supply TimeSlotStart (UTC) for a specific slot; omit for 'as soon as possible'.";
             s.Response<OrderResponse>(201, "Order placed successfully.");
             s.Response(400, "Validation error or unknown product/modifier.");
             s.Response(404, "Shop or brand not found.");
+            s.Response(409, "The selected time slot is full; the customer should pick another slot.");
         });
     }
 
@@ -171,7 +185,8 @@ public sealed class CreateOrderEndpoint(IOrderService orderService)
                 email,
                 phone,
                 req.LanguageCode,
-                req.TableNumber);
+                req.TableNumber,
+                req.TimeSlotStart);
 
             var response = await orderService.CreateOrderAsync(appRequest, ct);
 
@@ -186,6 +201,13 @@ public sealed class CreateOrderEndpoint(IOrderService orderService)
         {
             var failures = new List<ValidationFailure> { new("request", ex.Message) };
             await HttpContext.Response.SendErrorsAsync(failures, statusCode: 400, cancellation: ct);
+        }
+        catch (TimeSlotUnavailableException ex)
+        {
+            // The selected slot is full or no longer offered (US-FP-019).
+            // Return 409 so the frontend can refresh the slot list and let the customer pick again.
+            var failures = new List<ValidationFailure> { new("timeSlotStart", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 409, cancellation: ct);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetAvailableTimeSlotsEndpoint.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/GetAvailableTimeSlotsEndpoint.cs
@@ -1,0 +1,53 @@
+using FastEndpoints;
+using FluentValidation.Results;
+using TheMillionthFoodOrderApp.Application.Orders;
+
+namespace TheMillionthFoodOrderApp.Api.Endpoints.Orders;
+
+public sealed record GetAvailableTimeSlotsRequest(
+    [property: RouteParam] string BrandSlug,
+    [property: RouteParam] Guid ShopId);
+
+/// <summary>
+/// Returns the available time slots for a shop's checkout page (US-FP-019).
+/// When time-slot ordering is disabled, the response contains <c>isEnabled: false</c>
+/// and an empty <c>slots</c> array.
+/// </summary>
+public sealed class GetAvailableTimeSlotsEndpoint(ITimeSlotAvailabilityService availabilityService)
+    : Endpoint<GetAvailableTimeSlotsRequest, AvailableTimeSlotsResponse>
+{
+    public const string Route = "/api/brands/{brandSlug}/shops/{shopId}/time-slots";
+
+    public override void Configure()
+    {
+        Get(Route);
+        AllowAnonymous();
+        PreProcessor<BrandScopedPreProcessor<GetAvailableTimeSlotsRequest>>();
+        Summary(s =>
+        {
+            s.Summary = "Get available time slots for a shop";
+            s.Description =
+                "Returns time slots for the remainder of today (shop-local time) based on the " +
+                "shop's configured interval and capacity. Full slots are returned with " +
+                "isAvailable: false and remainingCapacity: 0. " +
+                "When time-slot ordering is disabled, returns { isEnabled: false, slots: [] }. " +
+                "Clients should poll this endpoint every ~30 seconds so they reflect real-time capacity.";
+            s.Response<AvailableTimeSlotsResponse>(200, "Available time slots (may be an empty list near closing).");
+            s.Response(404, "Shop or brand not found.");
+        });
+    }
+
+    public override async Task HandleAsync(GetAvailableTimeSlotsRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var response = await availabilityService.GetAvailableSlotsAsync(req.ShopId, ct);
+            await HttpContext.Response.SendAsync(response, statusCode: 200, cancellation: ct);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            var failures = new List<ValidationFailure> { new("shopId", ex.Message) };
+            await HttpContext.Response.SendErrorsAsync(failures, statusCode: 404, cancellation: ct);
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Api/Endpoints/Orders/OrderTrackingMapper.cs
@@ -57,5 +57,7 @@ internal static class OrderTrackingMapper
             shop?.Address.ToSingleLine(),
             order.CustomerFirstName,
             order.CustomerLastName,
-            order.LanguageCode);
+            order.LanguageCode,
+            order.TimeSlotStart,
+            order.TimeSlotEnd);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/DependencyInjection.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/DependencyInjection.cs
@@ -30,6 +30,7 @@ public static class DependencyInjection
         services.AddScoped<IOrderLifecycleService, OrderLifecycleService>();
         services.AddScoped<ITaxConfigurationService, TaxConfigurationService>();
         services.AddScoped<IOrderService, OrderService>();
+        services.AddScoped<ITimeSlotAvailabilityService, TimeSlotAvailabilityService>();
 
         // Digital-receipt HTML composer (US-FP-051) — pure/stateless.
         services.AddSingleton<IReceiptComposer, ReceiptComposer>();

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/ITimeSlotAvailabilityService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/ITimeSlotAvailabilityService.cs
@@ -1,0 +1,19 @@
+namespace TheMillionthFoodOrderApp.Application.Orders;
+
+/// <summary>
+/// Computes the available time slots for a shop's checkout page (US-FP-019).
+/// </summary>
+public interface ITimeSlotAvailabilityService
+{
+    /// <summary>
+    /// Returns the available time slots for the given shop for the rest of today.
+    /// </summary>
+    /// <param name="shopId">The shop whose slots are computed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// An <see cref="AvailableTimeSlotsResponse"/> whose <c>IsEnabled</c> flag reflects
+    /// whether time-slot ordering is active. When disabled, <c>Slots</c> is empty.
+    /// </returns>
+    /// <exception cref="KeyNotFoundException">Thrown when the shop is not found.</exception>
+    Task<AvailableTimeSlotsResponse> GetAvailableSlotsAsync(Guid shopId, CancellationToken cancellationToken = default);
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderDtos.cs
@@ -26,7 +26,9 @@ public sealed record CreateOrderRequest(
     /// <summary>BCP-47 checkout language (e.g. "nl-BE") for the digital receipt; falls back to the brand default (US-FP-051).</summary>
     string? LanguageCode = null,
     /// <summary>Table number for eat-in orders (US-FP-024/066); null for takeaway/delivery or when not captured.</summary>
-    int? TableNumber = null);
+    int? TableNumber = null,
+    /// <summary>UTC start of the selected time slot (US-FP-019). Null = "as soon as possible".</summary>
+    DateTimeOffset? TimeSlotStart = null);
 
 /// <summary>
 /// Application-layer DTO for placing a new in-store order via counter staff.
@@ -110,7 +112,11 @@ public sealed record OrderResponse(
     /// <summary>Customer last name (US-FP-051).</summary>
     string? CustomerLastName = null,
     /// <summary>BCP-47 checkout language captured for the digital receipt (US-FP-051).</summary>
-    string? LanguageCode = null);
+    string? LanguageCode = null,
+    /// <summary>UTC start of the selected time slot (US-FP-019). Null when "as soon as possible".</summary>
+    DateTimeOffset? TimeSlotStart = null,
+    /// <summary>UTC end of the selected time slot (US-FP-019). Null when "as soon as possible".</summary>
+    DateTimeOffset? TimeSlotEnd = null);
 
 /// <summary>
 /// Combined response DTO returned by the order-tracking endpoints.
@@ -120,3 +126,25 @@ public sealed record OrderResponse(
 public record OrderTrackingResponse(
     OrderResponse Order,
     OrderLifecycleResponse Lifecycle);
+
+// ── Time-slot DTOs (US-FP-019) ───────────────────────────────────────────────
+
+/// <summary>
+/// A single time slot offered to a customer at checkout.
+/// </summary>
+public sealed record TimeSlotDto(
+    DateTimeOffset Start,
+    DateTimeOffset End,
+    bool IsAvailable,
+    int RemainingCapacity);
+
+/// <summary>
+/// Response from <c>GET /api/brands/{brandSlug}/shops/{shopId}/time-slots</c>.
+/// When <see cref="IsEnabled"/> is false, <see cref="Slots"/> is empty and the
+/// interval/capacity fields are null.
+/// </summary>
+public sealed record AvailableTimeSlotsResponse(
+    bool IsEnabled,
+    int? IntervalMinutes,
+    int? MaxOrdersPerInterval,
+    IReadOnlyList<TimeSlotDto> Slots);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/OrderService.cs
@@ -9,6 +9,7 @@ using TheMillionthFoodOrderApp.Domain.Orders;
 using TheMillionthFoodOrderApp.Domain.Products;
 using TheMillionthFoodOrderApp.Domain.Shops;
 using TheMillionthFoodOrderApp.Domain.TaxConfiguration;
+using TimeSlotTuple = (System.DateTimeOffset Start, System.DateTimeOffset End);
 
 namespace TheMillionthFoodOrderApp.Application.Orders;
 
@@ -61,7 +62,8 @@ public sealed class OrderService(
             request.CustomerEmail,
             request.CustomerPhone,
             request.LanguageCode,
-            enforceOpeningHours: true);
+            enforceOpeningHours: true,
+            timeSlotStart: request.TimeSlotStart);
     }
 
     public async Task<OrderResponse> CreateInStoreOrderAsync(
@@ -221,7 +223,8 @@ public sealed class OrderService(
         string? customerEmail = null,
         string? customerPhone = null,
         string? languageCode = null,
-        bool enforceOpeningHours = false)
+        bool enforceOpeningHours = false,
+        DateTimeOffset? timeSlotStart = null)
     {
         // 0. Resolve the receipt language: the customer's checkout language when supplied,
         //    otherwise the brand's primary language (US-FP-051).
@@ -264,6 +267,37 @@ public sealed class OrderService(
         if (enforceOpeningHours && !shop.IsOpenAt(DateTimeOffset.UtcNow))
             throw new InvalidOperationException(
                 "This shop is currently closed and is not accepting online orders.");
+
+        // 3c. Time-slot enforcement (US-FP-019). Only applies to online orders (in-store always ASAP).
+        TimeSlotTuple? resolvedSlot = null;
+        if (timeSlotStart is not null)
+        {
+            if (!shop.TimeSlotOrdering.IsEnabled)
+                throw new ArgumentException("This shop does not accept time-slot orders.");
+
+            // Re-generate valid slots on the server side (alignment + opening hours + lead time).
+            var validSlots = TimeSlotGenerator.GenerateSlotsForToday(shop, DateTimeOffset.UtcNow);
+            TimeSlotTuple? matched = validSlots
+                .Where(s => s.Start == timeSlotStart.Value)
+                .Select(s => (TimeSlotTuple?)s)
+                .FirstOrDefault();
+
+            if (matched is not { } matchedSlot)
+                throw new TimeSlotUnavailableException(
+                    "The requested time slot is no longer available for this shop. It may have " +
+                    "passed, be misaligned with the shop's slot grid, or fall outside opening hours.");
+
+            // Capacity check — count all orders sharing this TimeSlotStart.
+            var counts = await orderRepository.GetTimeSlotOrderCountsAsync(
+                shopId, matchedSlot.Start, matchedSlot.End, cancellationToken);
+            var existing = counts.TryGetValue(matchedSlot.Start, out var c) ? c : 0;
+
+            if (existing >= shop.TimeSlotOrdering.MaxOrdersPerInterval!.Value)
+                throw new TimeSlotUnavailableException(
+                    "The selected time slot is full. Please pick another slot.");
+
+            resolvedSlot = matchedSlot;
+        }
 
         // 4. Load order lifecycle config to determine opening status (lazy-init default if missing)
         var lifecycleConfig = await orderLifecycleConfigRepository.GetByShopIdAsync(shopId, cancellationToken);
@@ -383,7 +417,9 @@ public sealed class OrderService(
                 createdByStaffId,
                 customerEmail,
                 customerPhone,
-                resolvedLanguage);
+                resolvedLanguage,
+                resolvedSlot?.Start,
+                resolvedSlot?.End);
 
             try
             {
@@ -475,5 +511,7 @@ public sealed class OrderService(
             shop?.Address.ToSingleLine(),
             order.CustomerFirstName,
             order.CustomerLastName,
-            order.LanguageCode);
+            order.LanguageCode,
+            order.TimeSlotStart,
+            order.TimeSlotEnd);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/TimeSlotAvailabilityService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/TimeSlotAvailabilityService.cs
@@ -1,0 +1,73 @@
+using TheMillionthFoodOrderApp.Domain.Orders;
+using TheMillionthFoodOrderApp.Domain.Shops;
+
+namespace TheMillionthFoodOrderApp.Application.Orders;
+
+/// <summary>
+/// Computes the available time slots for a shop by combining the domain slot
+/// generator with live order-count data from the repository. US-FP-019.
+/// </summary>
+public sealed class TimeSlotAvailabilityService(
+    IShopRepository shopRepository,
+    IOrderRepository orderRepository) : ITimeSlotAvailabilityService
+{
+    /// <inheritdoc/>
+    public async Task<AvailableTimeSlotsResponse> GetAvailableSlotsAsync(
+        Guid shopId,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Load the shop; 404 if missing.
+        var shop = await shopRepository.GetByIdAsync(shopId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Shop with id '{shopId}' was not found.");
+
+        // 2. When time-slot ordering is disabled, return a disabled response immediately.
+        if (!shop.TimeSlotOrdering.IsEnabled)
+        {
+            return new AvailableTimeSlotsResponse(
+                IsEnabled: false,
+                IntervalMinutes: null,
+                MaxOrdersPerInterval: null,
+                Slots: []);
+        }
+
+        // 3. Generate slots for the rest of today (shop-local time).
+        var now = DateTimeOffset.UtcNow;
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        if (slots.Count == 0)
+        {
+            return new AvailableTimeSlotsResponse(
+                IsEnabled: true,
+                IntervalMinutes: (int?)shop.TimeSlotOrdering.Interval,
+                MaxOrdersPerInterval: shop.TimeSlotOrdering.MaxOrdersPerInterval,
+                Slots: []);
+        }
+
+        // 4. One DB call to count existing orders per slot across the full range.
+        var fromInclusive = slots[0].Start;
+        var toExclusive = slots[^1].End;
+
+        var orderCounts = await orderRepository.GetTimeSlotOrderCountsAsync(
+            shopId, fromInclusive, toExclusive, cancellationToken);
+
+        var maxPerSlot = shop.TimeSlotOrdering.MaxOrdersPerInterval!.Value;
+        var intervalMinutes = (int)shop.TimeSlotOrdering.Interval!.Value;
+
+        // 5. Map each slot to its DTO with remaining capacity.
+        var slotDtos = slots
+            .Select(s =>
+            {
+                var count = orderCounts.TryGetValue(s.Start, out var c) ? c : 0;
+                var remaining = maxPerSlot - count;
+                return new TimeSlotDto(s.Start, s.End, remaining > 0, Math.Max(0, remaining));
+            })
+            .ToList()
+            .AsReadOnly();
+
+        return new AvailableTimeSlotsResponse(
+            IsEnabled: true,
+            IntervalMinutes: intervalMinutes,
+            MaxOrdersPerInterval: maxPerSlot,
+            Slots: slotDtos);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Application/Orders/TimeSlotUnavailableException.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Orders/TimeSlotUnavailableException.cs
@@ -1,0 +1,11 @@
+namespace TheMillionthFoodOrderApp.Application.Orders;
+
+/// <summary>
+/// Thrown when an order requests a time slot that can no longer be fulfilled —
+/// either the slot is at capacity or it is no longer offered (aged past the
+/// lead-time window, misaligned, or outside opening hours). US-FP-019.
+///
+/// Mapped to HTTP 409 by <c>CreateOrderEndpoint</c> so the storefront can
+/// refresh its slot list and ask the customer to pick again.
+/// </summary>
+public sealed class TimeSlotUnavailableException(string message) : Exception(message);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopDtos.cs
@@ -73,4 +73,5 @@ public sealed record StorefrontShopResponse(
     string Slug,
     AddressResponse Address,
     bool IsOpen,
-    EatInSettingsDto EatIn);
+    EatInSettingsDto EatIn,
+    TimeSlotOrderingSettingsDto TimeSlotOrdering);

--- a/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Application/Shops/ShopService.cs
@@ -130,7 +130,11 @@ public sealed class ShopService(IShopRepository shopRepository) : IShopService
                 shop.Address.PostalCode,
                 shop.Address.Country),
             shop.IsOpenAt(now),
-            new EatInSettingsDto(shop.EatIn.IsEnabled, shop.EatIn.RequiresTableNumber));
+            new EatInSettingsDto(shop.EatIn.IsEnabled, shop.EatIn.RequiresTableNumber),
+            new TimeSlotOrderingSettingsDto(
+                shop.TimeSlotOrdering.IsEnabled,
+                (int?)shop.TimeSlotOrdering.Interval,
+                shop.TimeSlotOrdering.MaxOrdersPerInterval));
 
     private static TimeSlotOrderingSettings MapTimeSlotOrdering(TimeSlotOrderingSettingsDto dto) =>
         dto.IsEnabled && dto.IntervalMinutes is int minutes && dto.MaxOrdersPerInterval is int max

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/IOrderRepository.cs
@@ -34,4 +34,16 @@ public interface IOrderRepository
     /// can render line details without a second round-trip.
     /// </summary>
     Task<IReadOnlyList<Order>> GetActiveByShopAsync(Guid shopId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a dictionary mapping each distinct <c>TimeSlotStart</c> value (UTC) to
+    /// the count of orders in that slot for the given shop.
+    /// Only orders whose <c>TimeSlotStart</c> falls within <c>[fromInclusive, toExclusive)</c>
+    /// are counted. Used by <c>TimeSlotAvailabilityService</c> to compute remaining capacity (US-FP-019).
+    /// </summary>
+    Task<IReadOnlyDictionary<DateTimeOffset, int>> GetTimeSlotOrderCountsAsync(
+        Guid shopId,
+        DateTimeOffset fromInclusive,
+        DateTimeOffset toExclusive,
+        CancellationToken cancellationToken = default);
 }

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Orders/Order.cs
@@ -55,6 +55,19 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
     public string LanguageCode { get; private set; } = "nl-BE";
 
     /// <summary>
+    /// UTC start of the selected time slot (US-FP-019). Null means "as soon as possible".
+    /// When set, <see cref="TimeSlotEnd"/> is also set.
+    /// </summary>
+    public DateTimeOffset? TimeSlotStart { get; private set; }
+
+    /// <summary>
+    /// UTC end of the selected time slot (US-FP-019). Null means "as soon as possible".
+    /// Stored to denormalise the slot boundary so future admin config changes
+    /// (interval/capacity) do not corrupt order history.
+    /// </summary>
+    public DateTimeOffset? TimeSlotEnd { get; private set; }
+
+    /// <summary>
     /// True once a digital receipt email has been sent for this order (US-FP-051).
     /// Guards against sending duplicate receipts on repeated terminal transitions.
     /// </summary>
@@ -127,10 +140,18 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
         Guid? createdByStaffId = null,
         string? customerEmail = null,
         string? customerPhone = null,
-        string? languageCode = null)
+        string? languageCode = null,
+        DateTimeOffset? timeSlotStart = null,
+        DateTimeOffset? timeSlotEnd = null)
     {
         if (tableNumber.HasValue && tableNumber.Value <= 0)
             throw new ArgumentException("TableNumber must be greater than zero when provided.", nameof(tableNumber));
+
+        // Time-slot invariants: both-or-neither, and end must be after start (US-FP-019).
+        if (timeSlotStart.HasValue != timeSlotEnd.HasValue)
+            throw new ArgumentException("TimeSlotStart and TimeSlotEnd must both be set or both be null.");
+        if (timeSlotStart.HasValue && timeSlotEnd.HasValue && timeSlotEnd.Value <= timeSlotStart.Value)
+            throw new ArgumentException("TimeSlotEnd must be after TimeSlotStart.");
 
         var itemList = items.ToList();
         if (itemList.Count == 0)
@@ -158,6 +179,8 @@ public sealed class Order : AggregateRoot<Guid>, IAuditable
             LanguageCode = string.IsNullOrWhiteSpace(languageCode) ? "nl-BE" : languageCode.Trim(),
             TableNumber = tableNumber,
             CreatedByStaffId = createdByStaffId,
+            TimeSlotStart = timeSlotStart,
+            TimeSlotEnd = timeSlotEnd,
             VatRatePercent = vatRatePercent,
             SubtotalGross = Math.Round(subtotalGross, 2, MidpointRounding.AwayFromZero),
             TotalVatAmount = Math.Round(totalVatAmount, 2, MidpointRounding.AwayFromZero),

--- a/src/backend/TheMillionthFoodOrderApp.Domain/Shops/TimeSlotGenerator.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Domain/Shops/TimeSlotGenerator.cs
@@ -1,0 +1,119 @@
+namespace TheMillionthFoodOrderApp.Domain.Shops;
+
+/// <summary>
+/// Pure domain service that computes the available time slots for a shop
+/// for the remainder of today (shop-local time). US-FP-019.
+/// </summary>
+public static class TimeSlotGenerator
+{
+    /// <summary>
+    /// Generates all future-facing time slots for today based on the shop's
+    /// opening hours and time-slot ordering configuration.
+    /// </summary>
+    /// <param name="shop">The shop whose configuration and opening hours are used.</param>
+    /// <param name="now">The current instant in UTC.</param>
+    /// <returns>
+    /// Ordered list of (Start, End) UTC <see cref="DateTimeOffset"/> pairs.
+    /// Returns an empty list when time-slot ordering is disabled, no opening hours exist,
+    /// or the time zone identifier is unknown.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The horizon is today only (shop-local calendar day) — no pre-order support.
+    /// Worst-case output: a 24 h shop at 5-minute intervals yields 288 slots.
+    /// </para>
+    /// <para>
+    /// Lead time: the first offered slot starts at or after <c>now + interval</c>
+    /// (rounded up to the grid anchor), giving the kitchen at least one interval of
+    /// prep runway.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyList<(DateTimeOffset Start, DateTimeOffset End)> GenerateSlotsForToday(
+        Shop shop, DateTimeOffset now)
+    {
+        if (!shop.TimeSlotOrdering.IsEnabled
+            || !shop.TimeSlotOrdering.Interval.HasValue
+            || shop.OpeningHours.Count == 0)
+        {
+            return [];
+        }
+
+        TimeZoneInfo tz;
+        try
+        {
+            tz = TimeZoneInfo.FindSystemTimeZoneById(shop.TimeZoneId);
+        }
+        catch (Exception e) when (e is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            return [];
+        }
+
+        var intervalMinutes = (int)shop.TimeSlotOrdering.Interval.Value;
+        var localNow = TimeZoneInfo.ConvertTime(now, tz);
+        var todayDow = localNow.DayOfWeek;
+        var todayDate = localNow.Date;
+
+        // The earliest slot a customer may pick must start at least `interval` minutes from now.
+        var earliestLocalSlotStart = localNow.DateTime.AddMinutes(intervalMinutes);
+
+        var result = new List<(DateTimeOffset Start, DateTimeOffset End)>();
+
+        // Process today's opening-hour blocks only (same-day ordering scope)
+        var todaysBlocks = shop.OpeningHours
+            .Where(b => b.DayOfWeek == todayDow)
+            .OrderBy(b => b.OpenTime);
+
+        foreach (var block in todaysBlocks)
+        {
+            // Anchor slot grid at the block's open time
+            var anchor = todayDate.Add(block.OpenTime.ToTimeSpan());
+            // CloseTime > OpenTime is a domain invariant (no overnight blocks), so the
+            // block end is always on the same calendar day. Compare full DateTimes —
+            // comparing TimeOfDay wraps at midnight and would never terminate the loop.
+            var blockEnd = todayDate.Add(block.CloseTime.ToTimeSpan());
+
+            // Step through the grid, checking that each slot:
+            //   1. ends at or before CloseTime
+            //   2. starts at or after the lead-time threshold
+            var slotStart = anchor;
+
+            while (true)
+            {
+                var slotEnd = slotStart.AddMinutes(intervalMinutes);
+
+                // Slot must fit entirely inside the opening block
+                if (slotEnd > blockEnd)
+                    break;
+
+                // Skip slots that are too close (lead-time guard)
+                if (slotStart >= earliestLocalSlotStart)
+                {
+                    // Convert local boundaries to UTC DateTimeOffset
+                    var utcStart = ConvertLocalToUtc(slotStart, tz);
+                    var utcEnd = ConvertLocalToUtc(slotEnd, tz);
+                    result.Add((utcStart, utcEnd));
+                }
+
+                slotStart = slotEnd; // advance to next slot
+            }
+        }
+
+        return result.AsReadOnly();
+    }
+
+    private static DateTimeOffset ConvertLocalToUtc(DateTime localDateTime, TimeZoneInfo tz)
+    {
+        var attempt = DateTime.SpecifyKind(localDateTime, DateTimeKind.Unspecified);
+
+        // A local time in the DST clock-forward gap is invalid and ConvertTimeToUtc
+        // would throw — step forward to the first valid minute (shifts the slot
+        // boundary by at most the gap length, once a year at most).
+        for (var i = 0; i < 60 && tz.IsInvalidTime(attempt); i++)
+            attempt = attempt.AddMinutes(1);
+
+        // Ambiguous times (clock-back overlap) are interpreted as standard time by
+        // ConvertTimeToUtc — no special handling needed.
+        var utc = TimeZoneInfo.ConvertTimeToUtc(attempt, tz);
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderConfiguration.cs
@@ -92,6 +92,18 @@ public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.Property(o => o.UpdatedAt)
             .IsRequired();
 
+        // Time-slot fields (US-FP-019): null = ASAP; set together when a slot is selected.
+        builder.Property(o => o.TimeSlotStart)
+            .IsRequired(false);
+
+        builder.Property(o => o.TimeSlotEnd)
+            .IsRequired(false);
+
+        // Filtered index for capacity counting — only rows where a slot was selected.
+        builder.HasIndex(o => new { o.ShopId, o.TimeSlotStart })
+            .HasDatabaseName("IX_Orders_ShopId_TimeSlotStart")
+            .HasFilter("[TimeSlotStart] IS NOT NULL");
+
         // Unique order number per shop
         builder.HasIndex(o => new { o.ShopId, o.OrderNumber })
             .IsUnique()

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Orders/OrderRepository.cs
@@ -78,6 +78,25 @@ public sealed class OrderRepository(BrandDbContext dbContext, IMessageBus messag
             .AnyAsync(o => o.ShopId == shopId && o.OrderNumber == orderNumber, cancellationToken);
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<DateTimeOffset, int>> GetTimeSlotOrderCountsAsync(
+        Guid shopId,
+        DateTimeOffset fromInclusive,
+        DateTimeOffset toExclusive,
+        CancellationToken cancellationToken = default)
+    {
+        var counts = await dbContext.Orders
+            .Where(o => o.ShopId == shopId
+                && o.TimeSlotStart != null
+                && o.TimeSlotStart >= fromInclusive
+                && o.TimeSlotStart < toExclusive)
+            .GroupBy(o => o.TimeSlotStart!.Value)
+            .Select(g => new { SlotStart = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        return counts.ToDictionary(x => x.SlotStart, x => x.Count);
+    }
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<Order>> GetActiveByShopAsync(
         Guid shopId,
         CancellationToken cancellationToken = default)

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260610051223_AddOrderTimeSlot.Designer.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260610051223_AddOrderTimeSlot.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TheMillionthFoodOrderApp.Infrastructure.Persistence;
 namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
 {
     [DbContext(typeof(BrandDbContext))]
-    partial class BrandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610051223_AddOrderTimeSlot")]
+    partial class AddOrderTimeSlot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260610051223_AddOrderTimeSlot.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Infrastructure/Persistence/Migrations/Brand/20260610051223_AddOrderTimeSlot.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheMillionthFoodOrderApp.Infrastructure.Persistence.Migrations.Brand
+{
+    /// <inheritdoc />
+    public partial class AddOrderTimeSlot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "TimeSlotEnd",
+                table: "Orders",
+                type: "datetimeoffset",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "TimeSlotStart",
+                table: "Orders",
+                type: "datetimeoffset",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_ShopId_TimeSlotStart",
+                table: "Orders",
+                columns: new[] { "ShopId", "TimeSlotStart" },
+                filter: "[TimeSlotStart] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Orders_ShopId_TimeSlotStart",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "TimeSlotEnd",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "TimeSlotStart",
+                table: "Orders");
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetAvailableTimeSlotsTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/GetAvailableTimeSlotsTests.cs
@@ -1,0 +1,254 @@
+using System.Net;
+using System.Net.Http.Json;
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Orders;
+
+/// <summary>
+/// Integration tests for GET /api/brands/{brandSlug}/shops/{shopId}/time-slots (US-FP-019).
+/// Runs against a real SQL Server via Testcontainers.
+/// Run this class individually to avoid OOM: --treenode-filter "/*/*/GetAvailableTimeSlotsTests/*"
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class GetAvailableTimeSlotsTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string TimeSlotsUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/time-slots";
+
+    private static string ShopsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/shops";
+
+    private static string ProductsUrl(string brandSlug) =>
+        $"/api/brands/{brandSlug}/products";
+
+    private static string OrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders";
+
+    private static string OrderLifecycleUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle";
+
+    // ── Setup helpers ─────────────────────────────────────────────────────────
+
+    private async Task<Guid> CreateShopAsync(HttpClient client, string brandSlug)
+    {
+        var request = new
+        {
+            Name = $"TimeSlot Shop {Guid.NewGuid().ToString("N")[..8]}",
+            Slug = $"ts-{Guid.NewGuid().ToString("N")[..8]}",
+            Address = new { Street = "Frietstraat", Number = "1", City = "Gent", PostalCode = "9000", Country = "BE" },
+            ContactEmail = "ts@frietjes.be",
+            ContactPhone = (string?)null
+        };
+
+        var resp = await client.PostAsJsonAsync(ShopsUrl(brandSlug), request);
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.Created);
+        var shop = await resp.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+
+        // Lazy-init lifecycle
+        await client.GetAsync(OrderLifecycleUrl(brandSlug, shop!.Id));
+        return shop.Id;
+    }
+
+    /// <summary>
+    /// Sets an always-open weekly schedule (00:05–23:55 every day to avoid DST boundary).
+    /// </summary>
+    private async Task SetAlwaysOpenAsync(HttpClient client, string brandSlug, Guid shopId)
+    {
+        var request = new
+        {
+            TimeBlocks = Enumerable.Range(0, 7)
+                .Select(day => new { DayOfWeek = day, OpenTime = "00:05", CloseTime = "23:55" })
+                .ToArray()
+        };
+        await client.PutAsJsonAsync($"/api/brands/{brandSlug}/shops/{shopId}/opening-hours", request);
+    }
+
+    /// <summary>Enables time-slot ordering on a shop.</summary>
+    private async Task EnableTimeSlotsAsync(
+        HttpClient client, string brandSlug, Guid shopId,
+        int intervalMinutes = 10, int maxOrders = 2)
+    {
+        // We must update via the shop's full update endpoint
+        var shopResp = await client.GetAsync($"/api/brands/{brandSlug}/shops/{shopId}");
+        var shop = await shopResp.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+
+        var updateRequest = new
+        {
+            shop!.Name,
+            Address = new
+            {
+                shop.Address.Street,
+                shop.Address.Number,
+                shop.Address.City,
+                shop.Address.PostalCode,
+                shop.Address.Country
+            },
+            shop.ContactEmail,
+            shop.ContactPhone,
+            shop.VatNumber,
+            shop.KitchenDisplayEnabled,
+            shop.TicketPrinterEnabled,
+            shop.PushNotificationEnabled,
+            shop.SoundAlertEnabled,
+            EatIn = new { shop.EatIn.IsEnabled, shop.EatIn.RequiresTableNumber },
+            TimeSlotOrdering = new { IsEnabled = true, IntervalMinutes = intervalMinutes, MaxOrdersPerInterval = maxOrders }
+        };
+
+        var updateResp = await client.PutAsJsonAsync($"/api/brands/{brandSlug}/shops/{shopId}", updateRequest);
+        await Assert.That(updateResp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    private async Task<Guid> CreateProductAsync(HttpClient client, string brandSlug)
+    {
+        var req = new
+        {
+            BasePrice = 3.50m,
+            Translations = new[] { new { LanguageCode = "nl", Name = "Test Friet", Description = (string?)null } }
+        };
+        var resp = await client.PostAsJsonAsync(ProductsUrl(brandSlug), req);
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.Created);
+        var product = await resp.Content.ReadFromJsonAsync<dynamic>();
+        // Extract id from dynamic
+        var json = await resp.Content.ReadAsStringAsync();
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        return parsed.GetProperty("id").GetGuid();
+    }
+
+    private async Task PlaceOrderAtSlotAsync(HttpClient client, string brandSlug, Guid shopId, Guid productId, DateTimeOffset slotStart)
+    {
+        var req = new
+        {
+            OrderType = "Pickup",
+            PaymentMethod = "CashAtPickup",
+            CustomerFirstName = "Jan",
+            CustomerLastName = "Janssen",
+            CustomerEmail = "jan@example.com",
+            CustomerPhone = "+32470000001",
+            TimeSlotStart = slotStart,
+            Items = new[] { new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() } }
+        };
+        var resp = await client.PostAsJsonAsync(OrdersUrl(brandSlug, shopId), req);
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.Created);
+    }
+
+    // ── Test 1: Disabled shop → isEnabled: false, empty slots ────────────────
+
+    [Test]
+    public async Task GetTimeSlots_WhenDisabled_ReturnsEnabledFalseAndEmptySlots()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        await SetAlwaysOpenAsync(client, brand, shopId);
+        // TimeSlotOrdering stays disabled (default)
+
+        var resp = await client.GetAsync(TimeSlotsUrl(brand, shopId));
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadFromJsonAsync<AvailableTimeSlotsResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.IsEnabled).IsFalse();
+        await Assert.That(body.Slots).IsEmpty();
+    }
+
+    // ── Test 2: Enabled → slots aligned, all available ────────────────────────
+
+    [Test]
+    public async Task GetTimeSlots_WhenEnabled_ReturnsSlotsAlignedToInterval()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        await SetAlwaysOpenAsync(client, brand, shopId);
+        await EnableTimeSlotsAsync(client, brand, shopId, intervalMinutes: 10, maxOrders: 2);
+
+        var resp = await client.GetAsync(TimeSlotsUrl(brand, shopId));
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadFromJsonAsync<AvailableTimeSlotsResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.IsEnabled).IsTrue();
+        await Assert.That(body.IntervalMinutes).IsEqualTo(10);
+        await Assert.That(body.MaxOrdersPerInterval).IsEqualTo(2);
+
+        if (body.Slots.Count > 0)
+        {
+            // All slots should be 10 minutes long
+            foreach (var slot in body.Slots)
+            {
+                var duration = (slot.End - slot.Start).TotalMinutes;
+                await Assert.That(duration).IsEqualTo(10);
+                await Assert.That(slot.IsAvailable).IsTrue();
+                await Assert.That(slot.RemainingCapacity).IsEqualTo(2);
+            }
+
+            // Consecutive slots should be contiguous (end of one = start of next)
+            for (var i = 0; i < body.Slots.Count - 1; i++)
+            {
+                await Assert.That(body.Slots[i].End).IsEqualTo(body.Slots[i + 1].Start);
+            }
+        }
+    }
+
+    // ── Test 3: Place 2 orders into a slot → that slot becomes unavailable ────
+
+    [Test]
+    public async Task GetTimeSlots_AfterFillingASlot_SlotIsUnavailable()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        var shopId = await CreateShopAsync(client, brand);
+        await SetAlwaysOpenAsync(client, brand, shopId);
+        await EnableTimeSlotsAsync(client, brand, shopId, intervalMinutes: 10, maxOrders: 2);
+
+        // Get slots to find one to fill
+        var slotsResp = await client.GetAsync(TimeSlotsUrl(brand, shopId));
+        var slotsBody = await slotsResp.Content.ReadFromJsonAsync<AvailableTimeSlotsResponse>();
+        await Assert.That(slotsBody?.Slots).IsNotEmpty();
+
+        var targetSlot = slotsBody!.Slots[0];
+        var productId = await CreateProductAsync(client, brand);
+
+        // Setup tax config first
+        await client.PutAsJsonAsync(
+            $"/api/brands/{brand}/tax-configuration",
+            new { rates = new[] { new { consumptionMode = "Takeaway", ratePercent = 6m }, new { consumptionMode = "EatIn", ratePercent = 21m } } });
+
+        // Place 2 orders into the slot
+        await PlaceOrderAtSlotAsync(client, brand, shopId, productId, targetSlot.Start);
+        await PlaceOrderAtSlotAsync(client, brand, shopId, productId, targetSlot.Start);
+
+        // Re-fetch slots
+        var slotsResp2 = await client.GetAsync(TimeSlotsUrl(brand, shopId));
+        var slotsBody2 = await slotsResp2.Content.ReadFromJsonAsync<AvailableTimeSlotsResponse>();
+
+        var filledSlot = slotsBody2!.Slots.FirstOrDefault(s => s.Start == targetSlot.Start);
+        if (filledSlot != default)
+        {
+            await Assert.That(filledSlot.IsAvailable).IsFalse();
+            await Assert.That(filledSlot.RemainingCapacity).IsEqualTo(0);
+        }
+        // (The slot may have aged out of the list if time passed; test is still valid then)
+    }
+
+    // ── Test 4: Unknown shop → 404 ────────────────────────────────────────────
+
+    [Test]
+    public async Task GetTimeSlots_UnknownShop_Returns404()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var resp = await client.GetAsync(TimeSlotsUrl(brand, Guid.CreateVersion7()));
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTimeSlotTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Integration/Orders/PlaceOrderTimeSlotTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using TheMillionthFoodOrderApp.Application.Orders;
+using TheMillionthFoodOrderApp.Application.Shops;
+using TheMillionthFoodOrderApp.Infrastructure.Multitenancy;
+using TheMillionthFoodOrderApp.Tests.Integration.Fixtures;
+
+namespace TheMillionthFoodOrderApp.Tests.Integration.Orders;
+
+/// <summary>
+/// Integration tests for placing orders with time-slot selection (US-FP-019).
+/// Covers: valid slot, ASAP, disabled shop slot, misaligned slot, full slot (409),
+/// kitchen active-orders view, and in-store null slots.
+/// Run individually: --treenode-filter "/*/*/PlaceOrderTimeSlotTests/*"
+/// </summary>
+[ClassDataSource<IntegrationTestBase>(Shared = SharedType.PerClass)]
+public sealed class PlaceOrderTimeSlotTests(IntegrationTestBase fixture)
+{
+    private HttpClient CreateClient() => fixture.Factory.CreateClient();
+
+    private static string OrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders";
+
+    private static string OrderByIdUrl(string brandSlug, Guid shopId, Guid orderId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders/{orderId}";
+
+    private static string ActiveOrdersUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/orders/active";
+
+    private static string TimeSlotsUrl(string brandSlug, Guid shopId) =>
+        $"/api/brands/{brandSlug}/shops/{shopId}/time-slots";
+
+    // ── Setup helpers ─────────────────────────────────────────────────────────
+
+    private async Task<Guid> SetupShopAsync(
+        HttpClient client, string brandSlug,
+        bool enableTimeSlots = true, int intervalMinutes = 10, int maxOrders = 4)
+    {
+        // Create shop
+        var createResp = await client.PostAsJsonAsync($"/api/brands/{brandSlug}/shops", new
+        {
+            Name = $"TS Shop {Guid.NewGuid().ToString("N")[..6]}",
+            Slug = $"ts-{Guid.NewGuid().ToString("N")[..8]}",
+            Address = new { Street = "Frietstraat", Number = "1", City = "Gent", PostalCode = "9000", Country = "BE" },
+            ContactEmail = "ts@frietjes.be",
+            ContactPhone = (string?)null
+        });
+        await Assert.That(createResp.StatusCode).IsEqualTo(HttpStatusCode.Created);
+        var shop = await createResp.Content.ReadFromJsonAsync<ShopResponse>();
+        await Assert.That(shop).IsNotNull();
+        var shopId = shop!.Id;
+
+        // Lazy-init lifecycle
+        await client.GetAsync($"/api/brands/{brandSlug}/shops/{shopId}/order-lifecycle");
+
+        // Always-open hours (avoid DST midnight)
+        await client.PutAsJsonAsync($"/api/brands/{brandSlug}/shops/{shopId}/opening-hours", new
+        {
+            TimeBlocks = Enumerable.Range(0, 7)
+                .Select(d => new { DayOfWeek = d, OpenTime = "00:05", CloseTime = "23:55" })
+                .ToArray()
+        });
+
+        // Tax config
+        await client.PutAsJsonAsync($"/api/brands/{brandSlug}/tax-configuration", new
+        {
+            rates = new[]
+            {
+                new { consumptionMode = "Takeaway", ratePercent = 6m },
+                new { consumptionMode = "EatIn", ratePercent = 21m }
+            }
+        });
+
+        if (enableTimeSlots)
+        {
+            // Update shop to enable time-slot ordering
+            var shopGetResp = await client.GetAsync($"/api/brands/{brandSlug}/shops/{shopId}");
+            var shopData = await shopGetResp.Content.ReadFromJsonAsync<ShopResponse>();
+            await client.PutAsJsonAsync($"/api/brands/{brandSlug}/shops/{shopId}", new
+            {
+                shopData!.Name,
+                Address = new
+                {
+                    shopData.Address.Street,
+                    shopData.Address.Number,
+                    shopData.Address.City,
+                    shopData.Address.PostalCode,
+                    shopData.Address.Country
+                },
+                shopData.ContactEmail,
+                shopData.ContactPhone,
+                shopData.VatNumber,
+                shopData.KitchenDisplayEnabled,
+                shopData.TicketPrinterEnabled,
+                shopData.PushNotificationEnabled,
+                shopData.SoundAlertEnabled,
+                EatIn = new { shopData.EatIn.IsEnabled, shopData.EatIn.RequiresTableNumber },
+                TimeSlotOrdering = new { IsEnabled = true, IntervalMinutes = intervalMinutes, MaxOrdersPerInterval = maxOrders }
+            });
+        }
+
+        return shopId;
+    }
+
+    private async Task<Guid> CreateProductAsync(HttpClient client, string brandSlug)
+    {
+        var resp = await client.PostAsJsonAsync($"/api/brands/{brandSlug}/products", new
+        {
+            BasePrice = 3.50m,
+            Translations = new[] { new { LanguageCode = "nl", Name = "Frietje TS", Description = (string?)null } }
+        });
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.Created);
+        var json = await resp.Content.ReadAsStringAsync();
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        return parsed.GetProperty("id").GetGuid();
+    }
+
+    private async Task<DateTimeOffset?> GetFirstAvailableSlotAsync(HttpClient client, string brandSlug, Guid shopId)
+    {
+        var resp = await client.GetAsync(TimeSlotsUrl(brandSlug, shopId));
+        var body = await resp.Content.ReadFromJsonAsync<AvailableTimeSlotsResponse>();
+        return body?.Slots.FirstOrDefault(s => s.IsAvailable)?.Start;
+    }
+
+    private object BuildOrderRequest(Guid productId, DateTimeOffset? timeSlotStart = null) => new
+    {
+        OrderType = "Pickup",
+        PaymentMethod = "CashAtPickup",
+        CustomerFirstName = "Jan",
+        CustomerLastName = "Janssen",
+        CustomerEmail = "jan@example.com",
+        CustomerPhone = "+32470000001",
+        TimeSlotStart = timeSlotStart,
+        Items = new[] { new { ProductId = productId, Quantity = 1, SelectedModifierIds = Array.Empty<Guid>() } }
+    };
+
+    // ── Test 1: Valid slot → 201, fields echoed, persisted ────────────────────
+
+    [Test]
+    public async Task PlaceOrder_WithValidSlot_Returns201WithTimeSlotFields()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await SetupShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand);
+        var slotStart = await GetFirstAvailableSlotAsync(client, brand, shopId);
+
+        // It's possible no slots are available (test runs near midnight)
+        if (slotStart is null)
+        {
+            await Assert.That(true).IsTrue(); // Skip — no slots available
+            return;
+        }
+
+        var resp = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), BuildOrderRequest(productId, slotStart));
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await resp.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.TimeSlotStart).IsNotNull();
+        await Assert.That(order.TimeSlotEnd).IsNotNull();
+        await Assert.That(order.TimeSlotStart).IsEqualTo(slotStart);
+
+        // Verify it's persisted — fetch via tracking endpoint
+        var trackResp = await client.GetAsync(OrderByIdUrl(brand, shopId, order.Id));
+        await Assert.That(trackResp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        var trackBody = await trackResp.Content.ReadFromJsonAsync<OrderTrackingResponse>();
+        await Assert.That(trackBody?.Order.TimeSlotStart).IsEqualTo(slotStart);
+    }
+
+    // ── Test 2: ASAP with slots enabled → 201, nulls ──────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_WithSlotsEnabled_ButNoSlotRequested_Returns201WithNullSlots()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        var shopId = await SetupShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand);
+
+        var resp = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), BuildOrderRequest(productId, null));
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        var order = await resp.Content.ReadFromJsonAsync<OrderResponse>();
+        await Assert.That(order).IsNotNull();
+        await Assert.That(order!.TimeSlotStart).IsNull();
+        await Assert.That(order.TimeSlotEnd).IsNull();
+    }
+
+    // ── Test 3: Slot while slots disabled → 400 ───────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_SlotRequestedWhenDisabled_Returns400()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        var shopId = await SetupShopAsync(client, brand, enableTimeSlots: false);
+        var productId = await CreateProductAsync(client, brand);
+
+        var futureSlot = DateTimeOffset.UtcNow.AddHours(2);
+        var resp = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), BuildOrderRequest(productId, futureSlot));
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    // ── Test 4: Misaligned/stale slot → 409 ───────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_MisalignedSlot_Returns409()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await SetupShopAsync(client, brand, intervalMinutes: 15, maxOrders: 4);
+        var productId = await CreateProductAsync(client, brand);
+
+        // Misaligned: some arbitrary time that won't match the slot grid.
+        // 409 (not 400) — the same TimeSlotUnavailableException covers slots that aged
+        // out between fetch and submit, and the storefront recovers by refreshing the list.
+        var misalignedSlot = DateTimeOffset.UtcNow.AddHours(3).AddMinutes(7);
+        var resp = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), BuildOrderRequest(productId, misalignedSlot));
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.Conflict);
+    }
+
+    // ── Test 5: Full slot → 409 ───────────────────────────────────────────────
+
+    [Test]
+    public async Task PlaceOrder_WhenSlotFull_Returns409()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.BetaSlug;
+
+        // maxOrders = 1 so the first order fills it
+        var shopId = await SetupShopAsync(client, brand, intervalMinutes: 10, maxOrders: 1);
+        var productId = await CreateProductAsync(client, brand);
+        var slotStart = await GetFirstAvailableSlotAsync(client, brand, shopId);
+
+        if (slotStart is null)
+        {
+            await Assert.That(true).IsTrue(); // skip near midnight
+            return;
+        }
+
+        // First order fills the slot
+        var first = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), BuildOrderRequest(productId, slotStart));
+        await Assert.That(first.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        // Second order into the same slot → 409
+        var second = await client.PostAsJsonAsync(OrdersUrl(brand, shopId), BuildOrderRequest(productId, slotStart));
+        await Assert.That(second.StatusCode).IsEqualTo(HttpStatusCode.Conflict);
+    }
+
+    // ── Test 6: Kitchen GET active includes time slot fields ──────────────────
+
+    [Test]
+    public async Task GetActiveOrders_IncludesTimeSlotFields()
+    {
+        var client = CreateClient();
+        var brand = IntegrationTestBase.GammaSlug;
+
+        var shopId = await SetupShopAsync(client, brand);
+        var productId = await CreateProductAsync(client, brand);
+        var slotStart = await GetFirstAvailableSlotAsync(client, brand, shopId);
+
+        if (slotStart is null)
+        {
+            await Assert.That(true).IsTrue();
+            return;
+        }
+
+        await client.PostAsJsonAsync(OrdersUrl(brand, shopId), BuildOrderRequest(productId, slotStart));
+
+        var activeResp = await client.GetAsync(ActiveOrdersUrl(brand, shopId));
+        await Assert.That(activeResp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var json = await activeResp.Content.ReadAsStringAsync();
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        var orders = parsed.GetProperty("orders");
+
+        // At least one order should have timeSlotStart populated
+        var hasSlottedOrder = false;
+        foreach (var o in orders.EnumerateArray())
+        {
+            if (o.TryGetProperty("timeSlotStart", out var ts) && ts.ValueKind != System.Text.Json.JsonValueKind.Null)
+            {
+                hasSlottedOrder = true;
+                break;
+            }
+        }
+        await Assert.That(hasSlottedOrder).IsTrue();
+    }
+
+    // ── Test 7: In-store endpoint — slots always null ─────────────────────────
+
+    [Test]
+    public async Task PlaceInStoreOrder_SlotsAlwaysNull()
+    {
+        // The in-store HTTP endpoint requires the CounterStaff role, which the test
+        // app's DevPassThrough auth does not issue — invoke the service layer directly
+        // via DI instead (same pattern as CreateInStoreOrderServiceTests).
+        var client = CreateClient();
+        var brand = IntegrationTestBase.AlphaSlug;
+
+        var shopId = await SetupShopAsync(client, brand); // slots enabled
+        var productId = await CreateProductAsync(client, brand);
+
+        var scope = fixture.Factory.Services.CreateAsyncScope();
+        await using (scope)
+        {
+            scope.ServiceProvider.GetRequiredService<BrandContextAccessor>().BrandSlug = brand;
+            var service = scope.ServiceProvider.GetRequiredService<IOrderService>();
+
+            var request = new CreateInStoreOrderRequest(
+                ShopId: shopId,
+                BrandSlug: brand,
+                OrderType: "Pickup",
+                PaymentMethod: "CashAtPickup",
+                CustomerFirstName: "Counter",
+                CustomerLastName: "Staff",
+                TableNumber: null,
+                Items: [new OrderItemInput(productId, 1, Array.Empty<Guid>().ToList().AsReadOnly())]);
+
+            var order = await service.CreateInStoreOrderAsync(request, Guid.NewGuid());
+
+            await Assert.That(order).IsNotNull();
+            await Assert.That(order.TimeSlotStart).IsNull();
+            await Assert.That(order.TimeSlotEnd).IsNull();
+        }
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Orders/OrderTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Orders/OrderTests.cs
@@ -1,0 +1,119 @@
+using TheMillionthFoodOrderApp.Domain.Orders;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.Orders;
+
+/// <summary>
+/// Unit tests for <see cref="Order.Create"/> time-slot invariants (US-FP-019).
+/// </summary>
+public sealed class OrderTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static OrderItem MakeItem()
+    {
+        var orderId = Guid.CreateVersion7();
+        return OrderItem.Create(orderId, Guid.CreateVersion7(), "Test Product", 1, 3.50m, 3.30m, 0.20m, []);
+    }
+
+    private static Order MakeOrder(
+        DateTimeOffset? timeSlotStart = null,
+        DateTimeOffset? timeSlotEnd = null)
+    {
+        return Order.Create(
+            orderId: Guid.CreateVersion7(),
+            shopId: Guid.CreateVersion7(),
+            brandSlug: "frietjes",
+            orderNumber: "TEST-001",
+            orderType: OrderType.Pickup,
+            paymentMethod: PaymentMethod.CashAtPickup,
+            statusName: "Placed",
+            customerFirstName: "Jan",
+            customerLastName: "Janssen",
+            vatRatePercent: 6m,
+            items: [MakeItem()],
+            timeSlotStart: timeSlotStart,
+            timeSlotEnd: timeSlotEnd);
+    }
+
+    // ── Both null (ASAP) ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Create_WithNullTimeSlots_Succeeds_AndSlotsAreNull()
+    {
+        var order = MakeOrder(null, null);
+
+        await Assert.That(order.TimeSlotStart).IsNull();
+        await Assert.That(order.TimeSlotEnd).IsNull();
+    }
+
+    // ── Both set — valid ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Create_WithValidTimeSlots_Succeeds_AndPersists()
+    {
+        var start = new DateTimeOffset(2026, 6, 10, 15, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2026, 6, 10, 15, 10, 0, TimeSpan.Zero);
+
+        var order = MakeOrder(start, end);
+
+        await Assert.That(order.TimeSlotStart).IsEqualTo(start);
+        await Assert.That(order.TimeSlotEnd).IsEqualTo(end);
+    }
+
+    // ── Start only (end missing) ───────────────────────────────────────────────
+
+    [Test]
+    public async Task Create_WithStartOnlyAndNullEnd_ThrowsArgumentException()
+    {
+        var start = new DateTimeOffset(2026, 6, 10, 15, 0, 0, TimeSpan.Zero);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            _ = MakeOrder(start, null);
+            return Task.CompletedTask;
+        });
+    }
+
+    // ── End only (start missing) ───────────────────────────────────────────────
+
+    [Test]
+    public async Task Create_WithEndOnlyAndNullStart_ThrowsArgumentException()
+    {
+        var end = new DateTimeOffset(2026, 6, 10, 15, 10, 0, TimeSpan.Zero);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            _ = MakeOrder(null, end);
+            return Task.CompletedTask;
+        });
+    }
+
+    // ── End before start ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Create_WithEndBeforeStart_ThrowsArgumentException()
+    {
+        var start = new DateTimeOffset(2026, 6, 10, 15, 10, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2026, 6, 10, 15, 0, 0, TimeSpan.Zero); // end < start
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            _ = MakeOrder(start, end);
+            return Task.CompletedTask;
+        });
+    }
+
+    // ── End equal to start ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Create_WithEndEqualToStart_ThrowsArgumentException()
+    {
+        var instant = new DateTimeOffset(2026, 6, 10, 15, 0, 0, TimeSpan.Zero);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            _ = MakeOrder(instant, instant); // end == start
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/TimeSlotGeneratorTests.cs
+++ b/src/backend/TheMillionthFoodOrderApp.Tests.Unit/Shops/TimeSlotGeneratorTests.cs
@@ -1,0 +1,235 @@
+using TheMillionthFoodOrderApp.Domain.Shops;
+
+namespace TheMillionthFoodOrderApp.Tests.Unit.Shops;
+
+/// <summary>
+/// Unit tests for <see cref="TimeSlotGenerator"/> (US-FP-019).
+/// </summary>
+public sealed class TimeSlotGeneratorTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a minimal Shop with sensible defaults. Opening hours and time-slot
+    /// settings are configured via the Shop domain methods after construction so that
+    /// invariants are respected.
+    /// </summary>
+    private static Shop BuildShop(
+        bool slotEnabled = true,
+        TimeSlotInterval interval = TimeSlotInterval.FifteenMinutes,
+        int maxPerSlot = 4,
+        string timeZoneId = "Europe/Brussels")
+    {
+        // Use the real Shop.Create factory — it validates and assigns a time zone.
+        var shop = Shop.Create(
+            "Test Shop",
+            "test-shop",
+            new Address("Street", "1", "City", "1000", "BE"),
+            "shop@test.be",
+            null);
+
+        // Override the TimeZoneId via the backing field when a non-default TZ is needed for testing.
+        if (timeZoneId != "Europe/Brussels")
+        {
+            // The property has a private setter — access via the compiler-generated backing field.
+            var field = typeof(Shop).GetField("<TimeZoneId>k__BackingField",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            field.SetValue(shop, timeZoneId);
+        }
+
+        if (slotEnabled)
+            shop.SetTimeSlotOrdering(TimeSlotOrderingSettings.Enabled(interval, maxPerSlot));
+
+        return shop;
+    }
+
+    /// <summary>
+    /// Adds a single opening-hours block to the shop.
+    /// <paramref name="open"/> and <paramref name="close"/> use "HH:mm" format.
+    /// </summary>
+    private static void AddHours(Shop shop, DayOfWeek day, string open, string close)
+    {
+        var existing = shop.OpeningHours.ToList();
+        existing.Add(OpeningHoursTimeBlock.Create(shop.Id, day, TimeOnly.Parse(open), TimeOnly.Parse(close)));
+        shop.SetOpeningHours(existing);
+    }
+
+    // ── Disabled / no hours / unknown timezone ────────────────────────────────
+
+    [Test]
+    public async Task GenerateSlotsForToday_WhenDisabled_ReturnsEmpty()
+    {
+        var shop = BuildShop(slotEnabled: false);
+        AddHours(shop, DayOfWeek.Monday, "09:00", "17:00");
+        // "now" = Monday at 10:00 local (CEST +02:00)
+        var now = new DateTimeOffset(2026, 6, 8, 8, 0, 0, TimeSpan.Zero); // 08:00 UTC = 10:00 CEST
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        await Assert.That(slots).IsEmpty();
+    }
+
+    [Test]
+    public async Task GenerateSlotsForToday_WhenNoOpeningHours_ReturnsEmpty()
+    {
+        var shop = BuildShop(); // no hours set
+        var now = new DateTimeOffset(2026, 6, 8, 8, 0, 0, TimeSpan.Zero);
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        await Assert.That(slots).IsEmpty();
+    }
+
+    [Test]
+    public async Task GenerateSlotsForToday_WhenUnknownTimeZone_ReturnsEmpty()
+    {
+        var shop = BuildShop(timeZoneId: "Mars/Olympus_Mons");
+        AddHours(shop, DayOfWeek.Monday, "09:00", "17:00");
+        var now = new DateTimeOffset(2026, 6, 8, 8, 0, 0, TimeSpan.Zero);
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        await Assert.That(slots).IsEmpty();
+    }
+
+    // ── Grid anchoring ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GenerateSlotsForToday_SlotsAnchorAtOpenTime()
+    {
+        // Block 11:30–12:30 (local), 15-min interval, now = 09:00 CEST (07:00 UTC)
+        var shop = BuildShop(interval: TimeSlotInterval.FifteenMinutes, maxPerSlot: 4);
+        AddHours(shop, DayOfWeek.Monday, "11:30", "12:30");
+        var now = new DateTimeOffset(2026, 6, 8, 7, 0, 0, TimeSpan.Zero); // 09:00 CEST
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        // Expected grid (lead time = 15 min; earliest start = 09:15 CEST → well before 11:30)
+        // 11:30–11:45, 11:45–12:00, 12:00–12:15, 12:15–12:30 (4 slots)
+        await Assert.That(slots.Count).IsEqualTo(4);
+        // First slot starts at 11:30 local = 09:30 UTC (CEST is UTC+2)
+        var expectedFirstStart = new DateTimeOffset(2026, 6, 8, 9, 30, 0, TimeSpan.Zero);
+        await Assert.That(slots[0].Start).IsEqualTo(expectedFirstStart);
+    }
+
+    [Test]
+    public async Task GenerateSlotsForToday_SlotExceedingCloseTimeExcluded()
+    {
+        // Block 11:30–11:44, 15-min interval — the single slot would end at 11:45, exceeding close
+        var shop = BuildShop(interval: TimeSlotInterval.FifteenMinutes, maxPerSlot: 4);
+        AddHours(shop, DayOfWeek.Monday, "11:30", "11:44");
+        var now = new DateTimeOffset(2026, 6, 8, 7, 0, 0, TimeSpan.Zero);
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        await Assert.That(slots).IsEmpty();
+    }
+
+    // ── Lead time ─────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GenerateSlotsForToday_SlotsBeforeLeadTimeExcluded()
+    {
+        // Block 12:00–14:00, 15-min, now = 12:30 CEST (10:30 UTC)
+        // Lead threshold = 12:45 CEST → slots 12:00–12:15, 12:15–12:30, 12:30–12:45 excluded
+        // Remaining: 12:45, 13:00, 13:15, 13:30, 13:45
+        var shop = BuildShop(interval: TimeSlotInterval.FifteenMinutes, maxPerSlot: 4);
+        AddHours(shop, DayOfWeek.Monday, "12:00", "14:00");
+        var now = new DateTimeOffset(2026, 6, 8, 10, 30, 0, TimeSpan.Zero); // 12:30 CEST
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        // First available slot should start at 12:45 CEST = 10:45 UTC
+        await Assert.That(slots).IsNotEmpty();
+        var expectedFirstStart = new DateTimeOffset(2026, 6, 8, 10, 45, 0, TimeSpan.Zero);
+        await Assert.That(slots[0].Start).IsEqualTo(expectedFirstStart);
+    }
+
+    // ── Two blocks in one day ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task GenerateSlotsForToday_TwoBlocksBothCovered()
+    {
+        // Lunch 12:00–13:00 and Dinner 18:00–20:00, 30-min interval, now = 09:00 CEST
+        var shop = BuildShop(interval: TimeSlotInterval.FifteenMinutes, maxPerSlot: 4);
+        AddHours(shop, DayOfWeek.Monday, "12:00", "13:00");
+        AddHours(shop, DayOfWeek.Monday, "18:00", "20:00");
+        var now = new DateTimeOffset(2026, 6, 8, 7, 0, 0, TimeSpan.Zero); // 09:00 CEST
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        // Lunch: 12:00, 12:15, 12:30, 12:45 = 4 slots
+        // Dinner: 18:00, 18:15, 18:30, 18:45, 19:00, 19:15, 19:30, 19:45 = 8 slots
+        await Assert.That(slots.Count).IsEqualTo(12);
+
+        // No slot should start in the gap between 13:00 and 18:00
+        var lunchCloseUtc = new DateTimeOffset(2026, 6, 8, 11, 0, 0, TimeSpan.Zero); // 13:00 CEST
+        var dinnerOpenUtc = new DateTimeOffset(2026, 6, 8, 16, 0, 0, TimeSpan.Zero); // 18:00 CEST
+        var gapSlots = slots.Where(s => s.Start >= lunchCloseUtc && s.Start < dinnerOpenUtc).ToList();
+        await Assert.That(gapSlots).IsEmpty();
+    }
+
+    // ── UTC conversion ─────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GenerateSlotsForToday_UtcConversionCorrectForCest()
+    {
+        // June = CEST = UTC+2
+        var shop = BuildShop(interval: TimeSlotInterval.TenMinutes, maxPerSlot: 4);
+        AddHours(shop, DayOfWeek.Tuesday, "10:00", "10:20");
+        var now = new DateTimeOffset(2026, 6, 9, 6, 0, 0, TimeSpan.Zero); // 08:00 CEST on Tuesday
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        // 10:00 CEST = 08:00 UTC, 10:10 CEST = 08:10 UTC, 10:20 is the close time (excluded)
+        await Assert.That(slots.Count).IsEqualTo(2);
+        await Assert.That(slots[0].Start).IsEqualTo(new DateTimeOffset(2026, 6, 9, 8, 0, 0, TimeSpan.Zero));
+        await Assert.That(slots[0].End).IsEqualTo(new DateTimeOffset(2026, 6, 9, 8, 10, 0, TimeSpan.Zero));
+        await Assert.That(slots[1].Start).IsEqualTo(new DateTimeOffset(2026, 6, 9, 8, 10, 0, TimeSpan.Zero));
+        await Assert.That(slots[1].End).IsEqualTo(new DateTimeOffset(2026, 6, 9, 8, 20, 0, TimeSpan.Zero));
+    }
+
+    // ── No artificial cap ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GenerateSlotsForToday_LongOpenShopHasManySlots_NoArtificialCap()
+    {
+        // Verify that no artificial slot cap is applied: a shop open 10:00–22:00 (12 h)
+        // at 5-min intervals yields (12*60)/5 = 144 slots (lead-time may cut some near 10:00).
+        // If there were an artificial cap of e.g. 48 the assert would catch it.
+        var shop = BuildShop(interval: TimeSlotInterval.FiveMinutes, maxPerSlot: 4);
+        // Use a non-DST-transition day and a block that doesn't touch midnight
+        // Wednesday 2026-07-15 (CEST, UTC+2), block 10:00–22:00
+        AddHours(shop, DayOfWeek.Wednesday, "10:00", "22:00");
+
+        // now = 07:00 UTC = 09:00 CEST → lead threshold = 09:05 CEST
+        // First slot at 10:00 CEST (>= 09:05), all 144 slots should appear
+        var now = new DateTimeOffset(2026, 7, 15, 7, 0, 0, TimeSpan.Zero);
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        // 12 h * 60 min / 5 min = 144 slots
+        await Assert.That(slots.Count).IsEqualTo(144);
+    }
+
+    // ── Midnight boundary (regression) ───────────────────────────────────────
+
+    [Test]
+    public async Task GenerateSlotsForToday_BlockEndingNearMidnight_Terminates()
+    {
+        // Regression: the loop exit used to compare slotEnd.TimeOfDay (TimeOnly) against
+        // CloseTime — when the grid reached midnight, TimeOfDay wrapped to 00:00 and the
+        // loop never terminated (DateTime overflow). Block 23:00–23:59, 10-min interval:
+        // slots 23:00, 23:10, 23:20, 23:30, 23:40 (23:50–00:00 crosses midnight → excluded).
+        var shop = BuildShop(interval: TimeSlotInterval.TenMinutes, maxPerSlot: 4);
+        AddHours(shop, DayOfWeek.Monday, "23:00", "23:59");
+        var now = new DateTimeOffset(2026, 6, 8, 18, 0, 0, TimeSpan.Zero); // 20:00 CEST
+
+        var slots = TimeSlotGenerator.GenerateSlotsForToday(shop, now);
+
+        await Assert.That(slots.Count).IsEqualTo(5);
+        // Last slot: 23:40–23:50 CEST = 21:40–21:50 UTC
+        await Assert.That(slots[^1].Start).IsEqualTo(new DateTimeOffset(2026, 6, 8, 21, 40, 0, TimeSpan.Zero));
+        await Assert.That(slots[^1].End).IsEqualTo(new DateTimeOffset(2026, 6, 8, 21, 50, 0, TimeSpan.Zero));
+    }
+}

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -29,6 +29,8 @@ export interface CreateOrderRequest {
   languageCode?: 'nl' | 'fr' | 'de';
   /** Table number for eat-in orders (US-FP-024/066); omitted for takeaway/delivery. */
   tableNumber?: number | null;
+  /** UTC start of the selected time slot (US-FP-019). Null/omitted = "as soon as possible". */
+  timeSlotStart?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -79,8 +81,13 @@ export interface OrderResponse {
   totalGross: number;
   createdAt: string;
   paymentMethod: string;
-  // Forward-compatibility — server only sends timeSlot once that story ships.
-  timeSlot?: string | null;
+  /**
+   * UTC start of the selected time slot (US-FP-019). Null/absent means "as soon as possible".
+   * Previously this was the speculative `timeSlot?: string | null` — replaced by start+end pair.
+   */
+  timeSlotStart?: string | null;
+  /** UTC end of the selected time slot (US-FP-019). Null/absent means "as soon as possible". */
+  timeSlotEnd?: string | null;
   /** Present on in-store EatIn orders. */
   tableNumber?: number;
   /** Staff member who created the order (set by the server from the auth token). */
@@ -122,6 +129,24 @@ export interface CreateInStoreOrderRequest {
 export interface OrderTrackingResponse {
   order: OrderResponse;
   lifecycle: OrderLifecycleResponse;
+}
+
+// ---------------------------------------------------------------------------
+// Time-slot types (US-FP-019)
+// ---------------------------------------------------------------------------
+
+export interface TimeSlotResponse {
+  start: string;
+  end: string;
+  isAvailable: boolean;
+  remainingCapacity: number;
+}
+
+export interface AvailableTimeSlotsResponse {
+  isEnabled: boolean;
+  intervalMinutes: number | null;
+  maxOrdersPerInterval: number | null;
+  slots: TimeSlotResponse[];
 }
 
 // ---------------------------------------------------------------------------
@@ -212,5 +237,17 @@ export const ordersApi = {
         `/brands/${brandSlug}/shops/${shopId}/orders/in-store`,
         data,
       )
+      .then((r) => r.data),
+
+  /**
+   * Fetches available time slots for a shop for the remainder of today (US-FP-019).
+   * Route: GET /brands/{brandSlug}/shops/{shopId}/time-slots
+   */
+  getTimeSlots: (
+    brandSlug: string,
+    shopId: string,
+  ): Promise<AvailableTimeSlotsResponse> =>
+    apiClient
+      .get<AvailableTimeSlotsResponse>(`/brands/${brandSlug}/shops/${shopId}/time-slots`)
       .then((r) => r.data),
 };

--- a/src/frontend/src/api/shops.ts
+++ b/src/frontend/src/api/shops.ts
@@ -17,6 +17,8 @@ export interface StorefrontShop {
   isOpen: boolean;
   /** Eat-in ordering configuration — used to gate the eat-in option at checkout (US-FP-066). */
   eatIn: EatInSettings;
+  /** Time-slot ordering configuration — used to show the slot picker at checkout (US-FP-019). */
+  timeSlotOrdering: TimeSlotOrderingSettings;
 }
 
 export interface CreateShopRequest {

--- a/src/frontend/src/features/admin/forms/AllergenDietaryFields.tsx
+++ b/src/frontend/src/features/admin/forms/AllergenDietaryFields.tsx
@@ -1,0 +1,155 @@
+import type React from 'react';
+import { Controller, type Control } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Allergen, DietaryTag, ALLERGEN_KEYS, DIETARY_TAG_KEYS } from '../../../types/common';
+import type { ProductEditFormValues } from '../pages/schemas/productEditSchema';
+
+// ---------------------------------------------------------------------------
+// AllergenDietaryFields — the allergen + dietary-tag checkbox grids shared by
+// the product editor.
+//
+//  - `mode: 'edit'`     — interactive, Controller-bound (simple products).
+//  - `mode: 'readonly'` — disabled grids that display a computed roll-up
+//                         (combo products inherit their components' values).
+// ---------------------------------------------------------------------------
+
+const sectionStyle: React.CSSProperties = { marginBottom: '1.5rem' };
+const headingStyle: React.CSSProperties = {
+  fontWeight: 600,
+  fontSize: '0.875rem',
+  marginBottom: '0.5rem',
+};
+const gridStyle: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5rem' };
+const hintStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  color: '#6b7280',
+  marginTop: '0.375rem',
+};
+
+interface ToggleItem {
+  value: number;
+  label: string;
+}
+
+interface ToggleGridProps {
+  items: ToggleItem[];
+  selected: number[];
+  /** When omitted the grid is read-only (disabled checkboxes). */
+  onToggle?: (value: number, currentlyChecked: boolean) => void;
+}
+
+function ToggleGrid({ items, selected, onToggle }: ToggleGridProps): React.JSX.Element {
+  const readonly = onToggle === undefined;
+  return (
+    <div style={gridStyle}>
+      {items.map((item) => {
+        const checked = selected.includes(item.value);
+        return (
+          <label
+            key={item.value}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem',
+              fontSize: '0.875rem',
+              cursor: readonly ? 'default' : 'pointer',
+              color: readonly && !checked ? '#9ca3af' : '#374151',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={checked}
+              disabled={readonly}
+              onChange={readonly ? undefined : () => { onToggle(item.value, checked); }}
+            />
+            {item.label}
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+type AllergenDietaryFieldsProps =
+  | { mode: 'edit'; control: Control<ProductEditFormValues> }
+  | { mode: 'readonly'; allergens: number[]; dietaryTags: number[] };
+
+export function AllergenDietaryFields(props: AllergenDietaryFieldsProps): React.JSX.Element {
+  const { t } = useTranslation();
+
+  const allergenItems: ToggleItem[] = ALLERGEN_KEYS.map((key) => ({
+    value: Allergen[key],
+    label: t(`allergens.${key}`),
+  }));
+  const dietaryItems: ToggleItem[] = DIETARY_TAG_KEYS.map((key) => ({
+    value: DietaryTag[key],
+    label: t(`dietaryTags.${key}`),
+  }));
+
+  if (props.mode === 'readonly') {
+    return (
+      <>
+        <div style={sectionStyle}>
+          <p style={headingStyle}>{t('admin.products.allergens')}</p>
+          <ToggleGrid items={allergenItems} selected={props.allergens} />
+          <p style={hintStyle}>
+            Combined from the selected component products (union) — not editable for combos.
+          </p>
+        </div>
+        <div style={sectionStyle}>
+          <p style={headingStyle}>{t('admin.products.dietaryTags')}</p>
+          <ToggleGrid items={dietaryItems} selected={props.dietaryTags} />
+          <p style={hintStyle}>
+            Applies only when every component product shares the tag (intersection).
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  const { control } = props;
+  return (
+    <>
+      <div style={sectionStyle}>
+        <p style={headingStyle}>{t('admin.products.allergens')}</p>
+        <Controller
+          name="allergens"
+          control={control}
+          render={({ field }) => {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- RHF field.value can be undefined before the form resets to fetched values
+            const current = field.value ?? [];
+            return (
+              <ToggleGrid
+                items={allergenItems}
+                selected={current}
+                onToggle={(value, checked) => {
+                  field.onChange(checked ? current.filter((v) => v !== value) : [...current, value]);
+                }}
+              />
+            );
+          }}
+        />
+      </div>
+      <div style={sectionStyle}>
+        <p style={headingStyle}>{t('admin.products.dietaryTags')}</p>
+        <Controller
+          name="dietaryTags"
+          control={control}
+          render={({ field }) => {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- RHF field.value can be undefined before the form resets to fetched values
+            const current = field.value ?? [];
+            return (
+              <ToggleGrid
+                items={dietaryItems}
+                selected={current}
+                onToggle={(value, checked) => {
+                  field.onChange(checked ? current.filter((v) => v !== value) : [...current, value]);
+                }}
+              />
+            );
+          }}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/frontend/src/features/admin/forms/FormActions.tsx
+++ b/src/frontend/src/features/admin/forms/FormActions.tsx
@@ -1,0 +1,39 @@
+import type React from 'react';
+import { primaryButtonStyle, secondaryButtonStyle } from './adminFormStyles';
+
+// ---------------------------------------------------------------------------
+// FormActions — the submit / cancel button pair shared by every admin
+// create/edit form. `isPending` (the mutation state) drives the submit label;
+// `isSubmitting` (react-hook-form) additionally disables the button when a
+// page tracks both.
+// ---------------------------------------------------------------------------
+
+interface FormActionsProps {
+  isPending: boolean;
+  isSubmitting?: boolean;
+  onCancel: () => void;
+  submitLabel: string;
+  pendingLabel: string;
+  cancelLabel?: string;
+}
+
+export function FormActions({
+  isPending,
+  isSubmitting = false,
+  onCancel,
+  submitLabel,
+  pendingLabel,
+  cancelLabel = 'Cancel',
+}: FormActionsProps): React.JSX.Element {
+  const busy = isSubmitting || isPending;
+  return (
+    <div style={{ display: 'flex', gap: '0.75rem' }}>
+      <button type="submit" disabled={busy} style={primaryButtonStyle(busy)}>
+        {isPending ? pendingLabel : submitLabel}
+      </button>
+      <button type="button" onClick={onCancel} style={secondaryButtonStyle}>
+        {cancelLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/frontend/src/features/admin/forms/ModifierGroupAssignments.tsx
+++ b/src/frontend/src/features/admin/forms/ModifierGroupAssignments.tsx
@@ -1,0 +1,285 @@
+import type React from 'react';
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useProductModifierGroups,
+  useModifierGroups,
+  useSetProductModifierGroups,
+} from '../hooks/useModifierGroups';
+import type { ProductModifierGroupResponse } from '../../../types/common';
+
+// ---------------------------------------------------------------------------
+// ModifierGroupAssignments — the modifier-group assignment section shared by
+// ProductEdit and ComboProductEdit. It owns its own data + mutation (modifier
+// assignments are a separate resource from the product form) and the
+// assigned-group ordering UI.
+// ---------------------------------------------------------------------------
+
+const reorderButtonStyle: React.CSSProperties = {
+  padding: '0.125rem 0.4rem',
+  fontSize: '0.75rem',
+  background: '#fff',
+  border: '1px solid #d1d5db',
+  borderRadius: '0.25rem',
+  lineHeight: 1,
+};
+
+interface ModifierGroupAssignmentsProps {
+  brandSlug: string;
+  productId: string;
+}
+
+export function ModifierGroupAssignments({
+  brandSlug,
+  productId,
+}: ModifierGroupAssignmentsProps): React.JSX.Element {
+  const { t } = useTranslation();
+
+  const { data: productModifierGroups } = useProductModifierGroups(brandSlug, productId);
+  const { data: allModifierGroups } = useModifierGroups(brandSlug);
+  const setProductModifierGroups = useSetProductModifierGroups(brandSlug, productId);
+  const [assignedGroups, setAssignedGroups] = useState<ProductModifierGroupResponse[]>([]);
+  const [assignmentsInitialized, setAssignmentsInitialized] = useState(false);
+  const [selectedGroupToAdd, setSelectedGroupToAdd] = useState('');
+
+  // Populate assigned modifier groups when data arrives
+  useEffect(() => {
+    if (productModifierGroups !== undefined && !assignmentsInitialized) {
+      setAssignedGroups(productModifierGroups);
+      setAssignmentsInitialized(true);
+    }
+  }, [productModifierGroups, assignmentsInitialized]);
+
+  function handleAddModifierGroup() {
+    if (!selectedGroupToAdd) return;
+    const alreadyAssigned = assignedGroups.some((g) => g.modifierGroupId === selectedGroupToAdd);
+    if (alreadyAssigned) return;
+
+    const groupInfo = allModifierGroups?.find((g) => g.id === selectedGroupToAdd);
+    if (!groupInfo) return;
+
+    const newGroup: ProductModifierGroupResponse = {
+      modifierGroupId: groupInfo.id,
+      name: groupInfo.name,
+      sortOrder: assignedGroups.length,
+      modifiers: [],
+    };
+    setAssignedGroups((prev) => [...prev, newGroup]);
+    setSelectedGroupToAdd('');
+  }
+
+  function handleRemoveAssignedGroup(modifierGroupId: string) {
+    setAssignedGroups((prev) =>
+      prev
+        .filter((g) => g.modifierGroupId !== modifierGroupId)
+        .map((g, index) => ({ ...g, sortOrder: index })),
+    );
+  }
+
+  function handleMoveGroupUp(index: number) {
+    if (index === 0) return;
+    setAssignedGroups((prev) => {
+      const next = [...prev];
+      const current = next[index];
+      const above = next[index - 1];
+      if (current === undefined || above === undefined) return prev;
+      next[index - 1] = current;
+      next[index] = above;
+      return next.map((g, i) => ({ ...g, sortOrder: i }));
+    });
+  }
+
+  function handleMoveGroupDown(index: number) {
+    setAssignedGroups((prev) => {
+      if (index >= prev.length - 1) return prev;
+      const next = [...prev];
+      const current = next[index];
+      const below = next[index + 1];
+      if (current === undefined || below === undefined) return prev;
+      next[index] = below;
+      next[index + 1] = current;
+      return next.map((g, i) => ({ ...g, sortOrder: i }));
+    });
+  }
+
+  function handleSaveAssignments() {
+    setProductModifierGroups.mutate({
+      assignments: assignedGroups.map((g) => ({
+        modifierGroupId: g.modifierGroupId,
+        sortOrder: g.sortOrder,
+      })),
+    });
+  }
+
+  return (
+    <section
+      style={{
+        marginTop: '2.5rem',
+        borderTop: '2px solid #e5e7eb',
+        paddingTop: '1.5rem',
+      }}
+    >
+      <h2 style={{ fontSize: '1.125rem', fontWeight: 700, marginBottom: '1rem' }}>
+        {t('admin.modifierGroups.title')}
+      </h2>
+
+      {/* Assigned groups list */}
+      {assignedGroups.length === 0 ? (
+        <p style={{ color: '#6b7280', marginBottom: '1rem' }}>
+          {t('admin.modifierGroups.noAssignedGroups')}
+        </p>
+      ) : (
+        <div style={{ marginBottom: '1rem' }}>
+          {assignedGroups.map((group, index) => {
+            // The assignment endpoint returns only { modifierGroupId, sortOrder };
+            // resolve the display name + modifier count from the full group list.
+            const info = allModifierGroups?.find((g) => g.id === group.modifierGroupId);
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- group is API/JSON data; name may be absent at runtime despite the type
+            const groupName = info?.name ?? group.name ?? '';
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- group is API/JSON data; modifiers may be absent at runtime despite the type
+            const modifierCount = info?.modifierCount ?? group.modifiers?.length ?? 0;
+            return (
+            <div
+              key={group.modifierGroupId}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+                padding: '0.625rem 0.75rem',
+                border: '1px solid #e5e7eb',
+                borderRadius: '0.375rem',
+                marginBottom: '0.5rem',
+                background: '#f9fafb',
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <span style={{ fontWeight: 600, fontSize: '0.9rem' }}>{groupName}</span>
+                {modifierCount > 0 && (
+                  <span style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '0.5rem' }}>
+                    {modifierCount} {t('admin.modifierGroups.modifiers').toLowerCase()}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => { handleMoveGroupUp(index); }}
+                disabled={index === 0}
+                style={{
+                  ...reorderButtonStyle,
+                  opacity: index === 0 ? 0.3 : 1,
+                  cursor: index === 0 ? 'not-allowed' : 'pointer',
+                }}
+              >
+                &#9650;
+              </button>
+              <button
+                type="button"
+                onClick={() => { handleMoveGroupDown(index); }}
+                disabled={index === assignedGroups.length - 1}
+                style={{
+                  ...reorderButtonStyle,
+                  opacity: index === assignedGroups.length - 1 ? 0.3 : 1,
+                  cursor: index === assignedGroups.length - 1 ? 'not-allowed' : 'pointer',
+                }}
+              >
+                &#9660;
+              </button>
+              <button
+                type="button"
+                onClick={() => { handleRemoveAssignedGroup(group.modifierGroupId); }}
+                style={{
+                  padding: '0.125rem 0.5rem',
+                  fontSize: '0.75rem',
+                  background: '#fff',
+                  border: '1px solid #fca5a5',
+                  borderRadius: '0.25rem',
+                  color: '#dc2626',
+                  cursor: 'pointer',
+                }}
+              >
+                {t('admin.modifierGroups.removeModifier')}
+              </button>
+            </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Add group dropdown */}
+      {allModifierGroups !== undefined && allModifierGroups.length > 0 && (
+        <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', alignItems: 'center' }}>
+          <select
+            value={selectedGroupToAdd}
+            onChange={(e) => { setSelectedGroupToAdd(e.target.value); }}
+            style={{
+              padding: '0.5rem 0.75rem',
+              border: '1px solid #d1d5db',
+              borderRadius: '0.375rem',
+              fontSize: '0.9rem',
+              flex: 1,
+              maxWidth: '20rem',
+            }}
+          >
+            <option value="">-- Select a modifier group --</option>
+            {allModifierGroups
+              .filter((g) => !assignedGroups.some((a) => a.modifierGroupId === g.id))
+              .map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+          </select>
+          <button
+            type="button"
+            onClick={handleAddModifierGroup}
+            disabled={!selectedGroupToAdd}
+            style={{
+              padding: '0.5rem 1rem',
+              background: '#f9fafb',
+              border: '1px solid #d1d5db',
+              borderRadius: '0.375rem',
+              cursor: selectedGroupToAdd ? 'pointer' : 'not-allowed',
+              opacity: selectedGroupToAdd ? 1 : 0.5,
+              fontSize: '0.875rem',
+            }}
+          >
+            + Add
+          </button>
+        </div>
+      )}
+
+      {/* Save assignments */}
+      {setProductModifierGroups.isError && (
+        <p style={{ color: '#dc2626', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
+          {setProductModifierGroups.error instanceof Error
+            ? setProductModifierGroups.error.message
+            : 'Failed to save assignments. Please try again.'}
+        </p>
+      )}
+
+      {setProductModifierGroups.isSuccess && (
+        <p style={{ color: '#16a34a', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
+          Assignments saved.
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleSaveAssignments}
+        disabled={setProductModifierGroups.isPending}
+        style={{
+          padding: '0.5rem 1.25rem',
+          background: '#111827',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '0.375rem',
+          cursor: setProductModifierGroups.isPending ? 'not-allowed' : 'pointer',
+          fontWeight: 600,
+          opacity: setProductModifierGroups.isPending ? 0.6 : 1,
+        }}
+      >
+        {setProductModifierGroups.isPending ? 'Saving...' : t('admin.modifierGroups.saveAssignments')}
+      </button>
+    </section>
+  );
+}

--- a/src/frontend/src/features/admin/forms/adminFormStyles.tsx
+++ b/src/frontend/src/features/admin/forms/adminFormStyles.tsx
@@ -24,6 +24,19 @@ export const secondaryButtonStyle: React.CSSProperties = {
   cursor: 'pointer',
 };
 
+export function primaryButtonStyle(disabled: boolean): React.CSSProperties {
+  return {
+    padding: '0.5rem 1.25rem',
+    background: '#111827',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '0.375rem',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontWeight: 600,
+    opacity: disabled ? 0.6 : 1,
+  };
+}
+
 export function inputStyle(hasError: boolean): React.CSSProperties {
   return {
     width: '100%',
@@ -43,6 +56,25 @@ export function FieldError({ message }: { message: string }): React.JSX.Element 
   return (
     <p style={{ color: '#dc2626', fontSize: '0.75rem', marginTop: '0.25rem' }}>
       {message}
+    </p>
+  );
+}
+
+/**
+ * Form-level (submission) error banner. Renders nothing when `error` is null/undefined,
+ * the message when it is an Error, or `fallback` otherwise.
+ */
+export function FormError({
+  error,
+  fallback,
+}: {
+  error: unknown;
+  fallback: string;
+}): React.JSX.Element | null {
+  if (error == null) return null;
+  return (
+    <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
+      {error instanceof Error ? error.message : fallback}
     </p>
   );
 }

--- a/src/frontend/src/features/admin/forms/slug.ts
+++ b/src/frontend/src/features/admin/forms/slug.ts
@@ -1,0 +1,12 @@
+/**
+ * Converts a display name into a URL-safe slug: lowercase, trimmed, with
+ * runs of non-alphanumeric characters collapsed to single hyphens and
+ * leading/trailing hyphens stripped. Shared by the brand and shop create pages.
+ */
+export function nameToSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/src/frontend/src/features/admin/pages/BrandCreate.tsx
+++ b/src/frontend/src/features/admin/pages/BrandCreate.tsx
@@ -1,20 +1,13 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useCreateBrand } from '../hooks/useBrands';
-import { labelStyle, inputStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
+import { labelStyle, inputStyle, RequiredMark, FieldError, FormError } from '../forms/adminFormStyles';
+import { FormActions } from '../forms/FormActions';
+import { nameToSlug } from '../forms/slug';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Converts a brand name into a URL-safe slug. */
-function nameToSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -180,46 +173,14 @@ export function BrandCreate() {
         </div>
 
         {/* API error */}
-        {createBrand.isError && (
-          <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
-            {createBrand.error instanceof Error
-              ? createBrand.error.message
-              : 'Failed to create brand. Please try again.'}
-          </p>
-        )}
+        <FormError error={createBrand.error} fallback="Failed to create brand. Please try again." />
 
-        <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button
-            type="submit"
-            disabled={createBrand.isPending}
-            style={{
-              padding: '0.5rem 1.25rem',
-              background: '#111827',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '0.375rem',
-              cursor: createBrand.isPending ? 'not-allowed' : 'pointer',
-              fontWeight: 600,
-              opacity: createBrand.isPending ? 0.6 : 1,
-            }}
-          >
-            {createBrand.isPending ? 'Creating…' : 'Create Brand'}
-          </button>
-          <button
-            type="button"
-            onClick={handleCancel}
-            style={{
-              padding: '0.5rem 1.25rem',
-              background: '#fff',
-              color: '#374151',
-              border: '1px solid #d1d5db',
-              borderRadius: '0.375rem',
-              cursor: 'pointer',
-            }}
-          >
-            Cancel
-          </button>
-        </div>
+        <FormActions
+          isPending={createBrand.isPending}
+          onCancel={handleCancel}
+          submitLabel="Create Brand"
+          pendingLabel="Creating…"
+        />
       </form>
     </main>
   );

--- a/src/frontend/src/features/admin/pages/ComboProductCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ComboProductCreate.tsx
@@ -9,7 +9,8 @@ import type { CreateComboProductRequest } from '@api/products';
 import { comboProductEditSchema, type ComboProductEditFormValues } from './schemas/comboProductEditSchema';
 import { productKeys, useProducts } from '../hooks/useProducts';
 import type { SupportedLocale, ProductListItem } from '../../../types/common';
-import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
+import { labelStyle, inputStyle, RequiredMark, FieldError, FormError } from '../forms/adminFormStyles';
+import { FormActions } from '../forms/FormActions';
 import { ComboTranslationFields } from '../forms/ComboTranslationFields';
 import { SelectedComponentsList } from '../forms/SelectedComponentsList';
 import { ComponentProductPicker } from '../forms/ComponentProductPicker';
@@ -152,11 +153,7 @@ export function ComboProductCreate() {
           onMoveDown={handleMoveDown}
           onToggle={handleToggleComponent}
         />
-        {mutation.error != null && (
-          <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
-            {mutation.error instanceof Error ? mutation.error.message : 'Failed to create combo product. Please try again.'}
-          </p>
-        )}
+        <FormError error={mutation.error} fallback="Failed to create combo product. Please try again." />
         <FormActions
           isPending={mutation.isPending}
           isSubmitting={isSubmitting}
@@ -257,41 +254,6 @@ function LanguageTabBar({ activeTab, onTabChange }: LanguageTabBarProps) {
           {l.code === 'nl' ? ' *' : null}
         </button>
       ))}
-    </div>
-  );
-}
-
-interface FormActionsProps {
-  isPending: boolean;
-  isSubmitting: boolean;
-  onCancel: () => void;
-  submitLabel: string;
-  pendingLabel: string;
-}
-
-function FormActions({ isPending, isSubmitting, onCancel, submitLabel, pendingLabel }: FormActionsProps) {
-  const busy = isSubmitting || isPending;
-  return (
-    <div style={{ display: 'flex', gap: '0.75rem' }}>
-      <button
-        type="submit"
-        disabled={busy}
-        style={{
-          padding: '0.5rem 1.25rem',
-          background: '#111827',
-          color: '#fff',
-          border: 'none',
-          borderRadius: '0.375rem',
-          cursor: busy ? 'not-allowed' : 'pointer',
-          fontWeight: 600,
-          opacity: busy ? 0.6 : 1,
-        }}
-      >
-        {isPending ? pendingLabel : submitLabel}
-      </button>
-      <button type="button" onClick={onCancel} style={secondaryButtonStyle}>
-        Cancel
-      </button>
     </div>
   );
 }

--- a/src/frontend/src/features/admin/pages/ComboProductEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ComboProductEdit.tsx
@@ -1,13 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Controller } from 'react-hook-form';
 import { useProducts, useDeleteProduct } from '../hooks/useProducts';
-import {
-  useProductModifierGroups,
-  useModifierGroups,
-  useSetProductModifierGroups,
-} from '../hooks/useModifierGroups';
 import { useResourceForm } from '../forms/useResourceForm';
 import { productKeys } from '../hooks/useProducts';
 import { productsApi } from '../../../api/products';
@@ -15,12 +10,14 @@ import { comboProductEditSchema, type ComboProductEditFormValues } from './schem
 import type {
   SupportedLocale,
   ProductListItem,
-  ProductModifierGroupResponse,
   Product,
 } from '../../../types/common';
+import { Allergen, DietaryTag, ALLERGEN_KEYS, DIETARY_TAG_KEYS } from '../../../types/common';
 import type { UpdateComboProductRequest } from '../../../api/products';
 import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
 import { ComboTranslationFields } from '../forms/ComboTranslationFields';
+import { ModifierGroupAssignments } from '../forms/ModifierGroupAssignments';
+import { AllergenDietaryFields } from '../forms/AllergenDietaryFields';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -71,22 +68,6 @@ export function ComboProductEdit() {
 
   const { data: allProducts } = useProducts(resolvedBrandSlug);
   const deleteProduct = useDeleteProduct(resolvedBrandSlug);
-
-  // Modifier groups (kept imperative — separate resource / mutation)
-  const { data: productModifierGroups } = useProductModifierGroups(resolvedBrandSlug, resolvedProductId);
-  const { data: allModifierGroups } = useModifierGroups(resolvedBrandSlug);
-  const setProductModifierGroups = useSetProductModifierGroups(resolvedBrandSlug, resolvedProductId);
-  const [assignedGroups, setAssignedGroups] = useState<ProductModifierGroupResponse[]>([]);
-  const [assignmentsInitialized, setAssignmentsInitialized] = useState(false);
-  const [selectedGroupToAdd, setSelectedGroupToAdd] = useState('');
-
-  // Populate assigned modifier groups when data arrives
-  useEffect(() => {
-    if (productModifierGroups !== undefined && !assignmentsInitialized) {
-      setAssignedGroups(productModifierGroups);
-      setAssignmentsInitialized(true);
-    }
-  }, [productModifierGroups, assignmentsInitialized]);
 
   // Active translation tab (UI-only state — not part of the form schema)
   const [activeTab, setActiveTab] = useState<SupportedLocale>('nl');
@@ -194,65 +175,6 @@ export function ComboProductEdit() {
   }
 
   // ---------------------------------------------------------------------------
-  // Modifier group assignment handlers (imperative — separate resource)
-  // ---------------------------------------------------------------------------
-
-  function handleAddModifierGroup() {
-    if (!selectedGroupToAdd) return;
-    const alreadyAssigned = assignedGroups.some((g) => g.modifierGroupId === selectedGroupToAdd);
-    if (alreadyAssigned) return;
-
-    const groupInfo = allModifierGroups?.find((g) => g.id === selectedGroupToAdd);
-    if (!groupInfo) return;
-
-    const newGroup: ProductModifierGroupResponse = {
-      modifierGroupId: groupInfo.id,
-      name: groupInfo.name,
-      sortOrder: assignedGroups.length,
-      modifiers: [],
-    };
-    setAssignedGroups((prev) => [...prev, newGroup]);
-    setSelectedGroupToAdd('');
-  }
-
-  function handleRemoveAssignedGroup(modifierGroupId: string) {
-    setAssignedGroups((prev) =>
-      prev
-        .filter((g) => g.modifierGroupId !== modifierGroupId)
-        .map((g, index) => ({ ...g, sortOrder: index })),
-    );
-  }
-
-  function handleMoveGroupUp(index: number) {
-    if (index === 0) return;
-    setAssignedGroups((prev) => {
-      const next = [...prev];
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index is in-bounds (index > 0) and next is a copy of prev
-      [next[index - 1], next[index]] = [next[index]!, next[index - 1]!];
-      return next.map((g, i) => ({ ...g, sortOrder: i }));
-    });
-  }
-
-  function handleMoveGroupDown(index: number) {
-    setAssignedGroups((prev) => {
-      if (index >= prev.length - 1) return prev;
-      const next = [...prev];
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index and index+1 are in-bounds (index < length-1) and next is a copy of prev
-      [next[index], next[index + 1]] = [next[index + 1]!, next[index]!];
-      return next.map((g, i) => ({ ...g, sortOrder: i }));
-    });
-  }
-
-  function handleSaveAssignments() {
-    setProductModifierGroups.mutate({
-      assignments: assignedGroups.map((g) => ({
-        modifierGroupId: g.modifierGroupId,
-        sortOrder: g.sortOrder,
-      })),
-    });
-  }
-
-  // ---------------------------------------------------------------------------
   // Loading / error states
   // ---------------------------------------------------------------------------
 
@@ -292,6 +214,21 @@ export function ComboProductEdit() {
   // Pre-compute error messages to avoid complex type inference inside JSX
   const nlNameError = (errors.translations?.nl?.name as { message?: string } | undefined)?.message;
   const componentIdsError = (errors.componentProductIds as { message?: string } | undefined)?.message;
+
+  // Allergens/dietary tags are derived (read-only) for combos: a combo carries
+  // the union of its components' allergens and the intersection of their dietary tags.
+  const selectedComponents = watch('componentProductIds')
+    .map((id) => allProducts?.find((p) => p.id === id))
+    .filter((p): p is ProductListItem => p !== undefined);
+  const comboAllergens = ALLERGEN_KEYS.map((key) => Allergen[key]).filter((value) =>
+    selectedComponents.some((p) => p.allergens.includes(value)),
+  );
+  const comboDietaryTags =
+    selectedComponents.length === 0
+      ? []
+      : DIETARY_TAG_KEYS.map((key) => DietaryTag[key]).filter((value) =>
+          selectedComponents.every((p) => p.dietaryTags.includes(value)),
+        );
 
   return (
     <main style={{ padding: '1.5rem', maxWidth: '40rem' }}>
@@ -542,6 +479,13 @@ export function ComboProductEdit() {
           />
         </section>
 
+        {/* Allergens & dietary tags — derived (read-only) from the selected components */}
+        <AllergenDietaryFields
+          mode="readonly"
+          allergens={comboAllergens}
+          dietaryTags={comboDietaryTags}
+        />
+
         {/* API error */}
         {submitError != null && (
           <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
@@ -591,167 +535,8 @@ export function ComboProductEdit() {
         </div>
       </form>
 
-      {/* Modifier Groups Section */}
-      <section
-        style={{
-          marginTop: '2.5rem',
-          borderTop: '2px solid #e5e7eb',
-          paddingTop: '1.5rem',
-        }}
-      >
-        <h2 style={{ fontSize: '1.125rem', fontWeight: 700, marginBottom: '1rem' }}>
-          {t('admin.modifierGroups.title')}
-        </h2>
-
-        {/* Assigned groups list */}
-        {assignedGroups.length === 0 ? (
-          <p style={{ color: '#6b7280', marginBottom: '1rem' }}>
-            {t('admin.modifierGroups.noAssignedGroups')}
-          </p>
-        ) : (
-          <div style={{ marginBottom: '1rem' }}>
-            {assignedGroups.map((group, index) => (
-              <div
-                key={group.modifierGroupId}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem',
-                  padding: '0.625rem 0.75rem',
-                  border: '1px solid #e5e7eb',
-                  borderRadius: '0.375rem',
-                  marginBottom: '0.5rem',
-                  background: '#f9fafb',
-                }}
-              >
-                <div style={{ flex: 1 }}>
-                  <span style={{ fontWeight: 600, fontSize: '0.9rem' }}>{group.name}</span>
-                  {group.modifiers.length > 0 && (
-                    <span style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '0.5rem' }}>
-                      {group.modifiers.length} {t('admin.modifierGroups.modifiers').toLowerCase()}
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => { handleMoveGroupUp(index); }}
-                  disabled={index === 0}
-                  style={{
-                    ...reorderButtonStyle,
-                    opacity: index === 0 ? 0.3 : 1,
-                    cursor: index === 0 ? 'not-allowed' : 'pointer',
-                  }}
-                >
-                  &#9650;
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { handleMoveGroupDown(index); }}
-                  disabled={index === assignedGroups.length - 1}
-                  style={{
-                    ...reorderButtonStyle,
-                    opacity: index === assignedGroups.length - 1 ? 0.3 : 1,
-                    cursor: index === assignedGroups.length - 1 ? 'not-allowed' : 'pointer',
-                  }}
-                >
-                  &#9660;
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { handleRemoveAssignedGroup(group.modifierGroupId); }}
-                  style={{
-                    padding: '0.125rem 0.5rem',
-                    fontSize: '0.75rem',
-                    background: '#fff',
-                    border: '1px solid #fca5a5',
-                    borderRadius: '0.25rem',
-                    color: '#dc2626',
-                    cursor: 'pointer',
-                  }}
-                >
-                  {t('admin.modifierGroups.removeModifier')}
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Add group dropdown */}
-        {allModifierGroups !== undefined && allModifierGroups.length > 0 && (
-          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', alignItems: 'center' }}>
-            <select
-              value={selectedGroupToAdd}
-              onChange={(e) => { setSelectedGroupToAdd(e.target.value); }}
-              style={{
-                padding: '0.5rem 0.75rem',
-                border: '1px solid #d1d5db',
-                borderRadius: '0.375rem',
-                fontSize: '0.9rem',
-                flex: 1,
-                maxWidth: '20rem',
-              }}
-            >
-              <option value="">{t('admin.comboProducts.selectModifierGroup')}</option>
-              {allModifierGroups
-                .filter((g) => !assignedGroups.some((a) => a.modifierGroupId === g.id))
-                .map((g) => (
-                  <option key={g.id} value={g.id}>
-                    {g.name}
-                  </option>
-                ))}
-            </select>
-            <button
-              type="button"
-              onClick={handleAddModifierGroup}
-              disabled={!selectedGroupToAdd}
-              style={{
-                padding: '0.5rem 1rem',
-                background: '#f9fafb',
-                border: '1px solid #d1d5db',
-                borderRadius: '0.375rem',
-                cursor: selectedGroupToAdd ? 'pointer' : 'not-allowed',
-                opacity: selectedGroupToAdd ? 1 : 0.5,
-                fontSize: '0.875rem',
-              }}
-            >
-              + Add
-            </button>
-          </div>
-        )}
-
-        {/* Save assignments */}
-        {setProductModifierGroups.isError && (
-          <p style={{ color: '#dc2626', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
-            {setProductModifierGroups.error instanceof Error
-              ? setProductModifierGroups.error.message
-              : 'Failed to save assignments. Please try again.'}
-          </p>
-        )}
-
-        {setProductModifierGroups.isSuccess && (
-          <p style={{ color: '#16a34a', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
-            Assignments saved.
-          </p>
-        )}
-
-        <button
-          type="button"
-          onClick={handleSaveAssignments}
-          disabled={setProductModifierGroups.isPending}
-          style={{
-            padding: '0.5rem 1.25rem',
-            background: '#111827',
-            color: '#fff',
-            border: 'none',
-            borderRadius: '0.375rem',
-            cursor: setProductModifierGroups.isPending ? 'not-allowed' : 'pointer',
-            fontWeight: 600,
-            opacity: setProductModifierGroups.isPending ? 0.6 : 1,
-          }}
-        >
-          {setProductModifierGroups.isPending ? 'Saving...' : t('admin.modifierGroups.saveAssignments')}
-        </button>
-      </section>
+      {/* Modifier Groups */}
+      <ModifierGroupAssignments brandSlug={resolvedBrandSlug} productId={resolvedProductId} />
     </main>
   );
 }

--- a/src/frontend/src/features/admin/pages/MenuCategoryCreate.tsx
+++ b/src/frontend/src/features/admin/pages/MenuCategoryCreate.tsx
@@ -4,7 +4,8 @@ import { useCreateMenuCategory } from '../hooks/useMenuCategories';
 import { useBrandSettings } from '../hooks/useBrandSettings';
 import { extractPrimaryLocale } from '../../../types/common';
 import type { SupportedLocale } from '../../../types/common';
-import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
+import { labelStyle, inputStyle, RequiredMark, FieldError, FormError } from '../forms/adminFormStyles';
+import { FormActions } from '../forms/FormActions';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -222,35 +223,14 @@ export function MenuCategoryCreate() {
         </div>
 
         {/* API error */}
-        {createCategory.isError && (
-          <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
-            {createCategory.error instanceof Error
-              ? createCategory.error.message
-              : 'Failed to create menu category. Please try again.'}
-          </p>
-        )}
+        <FormError error={createCategory.error} fallback="Failed to create menu category. Please try again." />
 
-        <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button
-            type="submit"
-            disabled={createCategory.isPending}
-            style={{
-              padding: '0.5rem 1.25rem',
-              background: '#111827',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '0.375rem',
-              cursor: createCategory.isPending ? 'not-allowed' : 'pointer',
-              fontWeight: 600,
-              opacity: createCategory.isPending ? 0.6 : 1,
-            }}
-          >
-            {createCategory.isPending ? 'Creating...' : 'Create Category'}
-          </button>
-          <button type="button" onClick={handleCancel} style={secondaryButtonStyle}>
-            Cancel
-          </button>
-        </div>
+        <FormActions
+          isPending={createCategory.isPending}
+          onCancel={handleCancel}
+          submitLabel="Create Category"
+          pendingLabel="Creating..."
+        />
       </form>
     </main>
   );

--- a/src/frontend/src/features/admin/pages/ModifierGroupCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ModifierGroupCreate.tsx
@@ -5,7 +5,8 @@ import { useCreateModifierGroup } from '../hooks/useModifierGroups';
 import { useBrandSettings } from '../hooks/useBrandSettings';
 import { extractPrimaryLocale } from '../../../types/common';
 import type { SupportedLocale } from '../../../types/common';
-import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
+import { labelStyle, inputStyle, RequiredMark, FieldError, FormError } from '../forms/adminFormStyles';
+import { FormActions } from '../forms/FormActions';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -241,35 +242,14 @@ export function ModifierGroupCreate() {
         </div>
 
         {/* API error */}
-        {createModifierGroup.isError && (
-          <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
-            {createModifierGroup.error instanceof Error
-              ? createModifierGroup.error.message
-              : 'Failed to create modifier group. Please try again.'}
-          </p>
-        )}
+        <FormError error={createModifierGroup.error} fallback="Failed to create modifier group. Please try again." />
 
-        <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button
-            type="submit"
-            disabled={createModifierGroup.isPending}
-            style={{
-              padding: '0.5rem 1.25rem',
-              background: '#111827',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '0.375rem',
-              cursor: createModifierGroup.isPending ? 'not-allowed' : 'pointer',
-              fontWeight: 600,
-              opacity: createModifierGroup.isPending ? 0.6 : 1,
-            }}
-          >
-            {createModifierGroup.isPending ? 'Creating...' : t('admin.modifierGroups.create')}
-          </button>
-          <button type="button" onClick={handleCancel} style={secondaryButtonStyle}>
-            Cancel
-          </button>
-        </div>
+        <FormActions
+          isPending={createModifierGroup.isPending}
+          onCancel={handleCancel}
+          submitLabel={t('admin.modifierGroups.create')}
+          pendingLabel="Creating..."
+        />
       </form>
     </main>
   );

--- a/src/frontend/src/features/admin/pages/ProductCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ProductCreate.tsx
@@ -15,7 +15,8 @@ import {
   DIETARY_TAG_KEYS,
 } from '../../../types/common';
 import type { SupportedLocale } from '../../../types/common';
-import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
+import { labelStyle, inputStyle, RequiredMark, FieldError, FormError } from '../forms/adminFormStyles';
+import { FormActions } from '../forms/FormActions';
 import { ProductTranslationFields } from '../forms/ProductTranslationFields';
 
 // ---------------------------------------------------------------------------
@@ -294,35 +295,16 @@ export function ProductCreate() {
         />
 
         {/* API error */}
-        {mutation.error != null && (
-          <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
-            {mutation.error instanceof Error
-              ? mutation.error.message
-              : t('admin.products.createError')}
-          </p>
-        )}
+        <FormError error={mutation.error} fallback={t('admin.products.createError')} />
 
-        <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button
-            type="submit"
-            disabled={isSubmitting || mutation.isPending}
-            style={{
-              padding: '0.5rem 1.25rem',
-              background: '#111827',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '0.375rem',
-              cursor: isSubmitting || mutation.isPending ? 'not-allowed' : 'pointer',
-              fontWeight: 600,
-              opacity: isSubmitting || mutation.isPending ? 0.6 : 1,
-            }}
-          >
-            {mutation.isPending ? t('admin.products.creating') : t('admin.products.create')}
-          </button>
-          <button type="button" onClick={handleCancel} style={secondaryButtonStyle}>
-            {t('admin.products.cancel')}
-          </button>
-        </div>
+        <FormActions
+          isPending={mutation.isPending}
+          isSubmitting={isSubmitting}
+          onCancel={handleCancel}
+          submitLabel={t('admin.products.create')}
+          pendingLabel={t('admin.products.creating')}
+          cancelLabel={t('admin.products.cancel')}
+        />
       </form>
     </main>
   );

--- a/src/frontend/src/features/admin/pages/ProductEdit.tsx
+++ b/src/frontend/src/features/admin/pages/ProductEdit.tsx
@@ -1,27 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Controller } from 'react-hook-form';
 import { useDeleteProduct, productKeys } from '../hooks/useProducts';
-import {
-  useProductModifierGroups,
-  useModifierGroups,
-  useSetProductModifierGroups,
-} from '../hooks/useModifierGroups';
 import { useResourceForm } from '../forms/useResourceForm';
 import { productsApi } from '../../../api/products';
 import type { UpdateProductRequest } from '../../../api/products';
 import { productEditSchema, type ProductEditFormValues } from './schemas/productEditSchema';
-import {
-  Allergen,
-  DietaryTag,
-  ALLERGEN_KEYS,
-  DIETARY_TAG_KEYS,
-} from '../../../types/common';
-import type { SupportedLocale, ProductModifierGroupResponse, Product } from '../../../types/common';
+import type { SupportedLocale, Product } from '../../../types/common';
 import { labelStyle, inputStyle, secondaryButtonStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
 import { ResourceFormShell } from '../forms/ResourceFormShell';
 import { ProductTranslationFields } from '../forms/ProductTranslationFields';
+import { ModifierGroupAssignments } from '../forms/ModifierGroupAssignments';
+import { AllergenDietaryFields } from '../forms/AllergenDietaryFields';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -71,22 +61,6 @@ export function ProductEdit() {
   const resolvedProductId = productId ?? '';
 
   const deleteProduct = useDeleteProduct(resolvedBrandSlug);
-
-  // Modifier groups (kept imperative — separate resource / mutation)
-  const { data: productModifierGroups } = useProductModifierGroups(resolvedBrandSlug, resolvedProductId);
-  const { data: allModifierGroups } = useModifierGroups(resolvedBrandSlug);
-  const setProductModifierGroups = useSetProductModifierGroups(resolvedBrandSlug, resolvedProductId);
-  const [assignedGroups, setAssignedGroups] = useState<ProductModifierGroupResponse[]>([]);
-  const [assignmentsInitialized, setAssignmentsInitialized] = useState(false);
-  const [selectedGroupToAdd, setSelectedGroupToAdd] = useState('');
-
-  // Populate assigned modifier groups when data arrives
-  useEffect(() => {
-    if (productModifierGroups !== undefined && !assignmentsInitialized) {
-      setAssignedGroups(productModifierGroups);
-      setAssignmentsInitialized(true);
-    }
-  }, [productModifierGroups, assignmentsInitialized]);
 
   // Active translation tab (UI-only state — not part of the form schema)
   const [activeTab, setActiveTab] = useState<SupportedLocale>('nl');
@@ -165,71 +139,6 @@ export function ProductEdit() {
   }
 
   // ---------------------------------------------------------------------------
-  // Modifier group assignment handlers (imperative — separate resource)
-  // ---------------------------------------------------------------------------
-
-  function handleAddModifierGroup() {
-    if (!selectedGroupToAdd) return;
-    const alreadyAssigned = assignedGroups.some((g) => g.modifierGroupId === selectedGroupToAdd);
-    if (alreadyAssigned) return;
-
-    const groupInfo = allModifierGroups?.find((g) => g.id === selectedGroupToAdd);
-    if (!groupInfo) return;
-
-    const newGroup: ProductModifierGroupResponse = {
-      modifierGroupId: groupInfo.id,
-      name: groupInfo.name,
-      sortOrder: assignedGroups.length,
-      modifiers: [],
-    };
-    setAssignedGroups((prev) => [...prev, newGroup]);
-    setSelectedGroupToAdd('');
-  }
-
-  function handleRemoveAssignedGroup(modifierGroupId: string) {
-    setAssignedGroups((prev) =>
-      prev
-        .filter((g) => g.modifierGroupId !== modifierGroupId)
-        .map((g, index) => ({ ...g, sortOrder: index })),
-    );
-  }
-
-  function handleMoveGroupUp(index: number) {
-    if (index === 0) return;
-    setAssignedGroups((prev) => {
-      const next = [...prev];
-      const current = next[index];
-      const above = next[index - 1];
-      if (current === undefined || above === undefined) return prev;
-      next[index - 1] = current;
-      next[index] = above;
-      return next.map((g, i) => ({ ...g, sortOrder: i }));
-    });
-  }
-
-  function handleMoveGroupDown(index: number) {
-    setAssignedGroups((prev) => {
-      if (index >= prev.length - 1) return prev;
-      const next = [...prev];
-      const current = next[index];
-      const below = next[index + 1];
-      if (current === undefined || below === undefined) return prev;
-      next[index] = below;
-      next[index + 1] = current;
-      return next.map((g, i) => ({ ...g, sortOrder: i }));
-    });
-  }
-
-  function handleSaveAssignments() {
-    setProductModifierGroups.mutate({
-      assignments: assignedGroups.map((g) => ({
-        modifierGroupId: g.modifierGroupId,
-        sortOrder: g.sortOrder,
-      })),
-    });
-  }
-
-  // ---------------------------------------------------------------------------
   // Form render
   // ---------------------------------------------------------------------------
 
@@ -305,99 +214,7 @@ export function ProductEdit() {
           ) : null}
         </div>
 
-        {/* Allergens */}
-        <div style={{ marginBottom: '1.5rem' }}>
-          <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.5rem' }}>
-            {t('admin.products.allergens')}
-          </p>
-          <Controller
-            name="allergens"
-            control={control}
-            render={({ field }) => (
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-                {ALLERGEN_KEYS.map((key) => {
-                  const val = Allergen[key];
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
-                  const checked = (field.value ?? []).includes(val);
-                  return (
-                    <label
-                      key={key}
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.25rem',
-                        fontSize: '0.875rem',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => {
-                          if (checked) {
-                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
-                            field.onChange((field.value ?? []).filter((v) => v !== val));
-                          } else {
-                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
-                            field.onChange([...(field.value ?? []), val]);
-                          }
-                        }}
-                      />
-                      {t(`allergens.${key}`)}
-                    </label>
-                  );
-                })}
-              </div>
-            )}
-          />
-        </div>
-
-        {/* Dietary Tags */}
-        <div style={{ marginBottom: '1.5rem' }}>
-          <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.5rem' }}>
-            {t('admin.products.dietaryTags')}
-          </p>
-          <Controller
-            name="dietaryTags"
-            control={control}
-            render={({ field }) => (
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-                {DIETARY_TAG_KEYS.map((key) => {
-                  const val = DietaryTag[key];
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
-                  const checked = (field.value ?? []).includes(val);
-                  return (
-                    <label
-                      key={key}
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.25rem',
-                        fontSize: '0.875rem',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => {
-                          if (checked) {
-                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
-                            field.onChange((field.value ?? []).filter((v) => v !== val));
-                          } else {
-                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- field.value is react-hook-form Controller state that can be undefined before defaults apply
-                            field.onChange([...(field.value ?? []), val]);
-                          }
-                        }}
-                      />
-                      {t(`dietaryTags.${key}`)}
-                    </label>
-                  );
-                })}
-              </div>
-            )}
-          />
-        </div>
+        <AllergenDietaryFields mode="edit" control={control} />
 
         {/* Translation Tabs */}
         <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.5rem' }}>
@@ -489,191 +306,10 @@ export function ProductEdit() {
         </div>
       </form>
 
-      {/* Modifier Groups Section */}
-      <section
-        style={{
-          marginTop: '2.5rem',
-          borderTop: '2px solid #e5e7eb',
-          paddingTop: '1.5rem',
-        }}
-      >
-        <h2 style={{ fontSize: '1.125rem', fontWeight: 700, marginBottom: '1rem' }}>
-          {t('admin.modifierGroups.title')}
-        </h2>
-
-        {/* Assigned groups list */}
-        {assignedGroups.length === 0 ? (
-          <p style={{ color: '#6b7280', marginBottom: '1rem' }}>
-            {t('admin.modifierGroups.noAssignedGroups')}
-          </p>
-        ) : (
-          <div style={{ marginBottom: '1rem' }}>
-            {assignedGroups.map((group, index) => {
-              // The assignment endpoint returns only { modifierGroupId, sortOrder };
-              // resolve the display name + modifier count from the full group list.
-              const info = allModifierGroups?.find((g) => g.id === group.modifierGroupId);
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- group is API/JSON data; name may be absent at runtime despite the type
-              const groupName = info?.name ?? group.name ?? '';
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- group is API/JSON data; modifiers may be absent at runtime despite the type
-              const modifierCount = info?.modifierCount ?? group.modifiers?.length ?? 0;
-              return (
-              <div
-                key={group.modifierGroupId}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem',
-                  padding: '0.625rem 0.75rem',
-                  border: '1px solid #e5e7eb',
-                  borderRadius: '0.375rem',
-                  marginBottom: '0.5rem',
-                  background: '#f9fafb',
-                }}
-              >
-                <div style={{ flex: 1 }}>
-                  <span style={{ fontWeight: 600, fontSize: '0.9rem' }}>{groupName}</span>
-                  {modifierCount > 0 && (
-                    <span style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '0.5rem' }}>
-                      {modifierCount} {t('admin.modifierGroups.modifiers').toLowerCase()}
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => { handleMoveGroupUp(index); }}
-                  disabled={index === 0}
-                  style={{
-                    ...reorderButtonStyle,
-                    opacity: index === 0 ? 0.3 : 1,
-                    cursor: index === 0 ? 'not-allowed' : 'pointer',
-                  }}
-                >
-                  &#9650;
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { handleMoveGroupDown(index); }}
-                  disabled={index === assignedGroups.length - 1}
-                  style={{
-                    ...reorderButtonStyle,
-                    opacity: index === assignedGroups.length - 1 ? 0.3 : 1,
-                    cursor: index === assignedGroups.length - 1 ? 'not-allowed' : 'pointer',
-                  }}
-                >
-                  &#9660;
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { handleRemoveAssignedGroup(group.modifierGroupId); }}
-                  style={{
-                    padding: '0.125rem 0.5rem',
-                    fontSize: '0.75rem',
-                    background: '#fff',
-                    border: '1px solid #fca5a5',
-                    borderRadius: '0.25rem',
-                    color: '#dc2626',
-                    cursor: 'pointer',
-                  }}
-                >
-                  {t('admin.modifierGroups.removeModifier')}
-                </button>
-              </div>
-              );
-            })}
-          </div>
-        )}
-
-        {/* Add group dropdown */}
-        {allModifierGroups !== undefined && allModifierGroups.length > 0 && (
-          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', alignItems: 'center' }}>
-            <select
-              value={selectedGroupToAdd}
-              onChange={(e) => { setSelectedGroupToAdd(e.target.value); }}
-              style={{
-                padding: '0.5rem 0.75rem',
-                border: '1px solid #d1d5db',
-                borderRadius: '0.375rem',
-                fontSize: '0.9rem',
-                flex: 1,
-                maxWidth: '20rem',
-              }}
-            >
-              <option value="">-- Select a modifier group --</option>
-              {allModifierGroups
-                .filter((g) => !assignedGroups.some((a) => a.modifierGroupId === g.id))
-                .map((g) => (
-                  <option key={g.id} value={g.id}>
-                    {g.name}
-                  </option>
-                ))}
-            </select>
-            <button
-              type="button"
-              onClick={handleAddModifierGroup}
-              disabled={!selectedGroupToAdd}
-              style={{
-                padding: '0.5rem 1rem',
-                background: '#f9fafb',
-                border: '1px solid #d1d5db',
-                borderRadius: '0.375rem',
-                cursor: selectedGroupToAdd ? 'pointer' : 'not-allowed',
-                opacity: selectedGroupToAdd ? 1 : 0.5,
-                fontSize: '0.875rem',
-              }}
-            >
-              + Add
-            </button>
-          </div>
-        )}
-
-        {/* Save assignments */}
-        {setProductModifierGroups.isError && (
-          <p style={{ color: '#dc2626', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
-            {setProductModifierGroups.error instanceof Error
-              ? setProductModifierGroups.error.message
-              : 'Failed to save assignments. Please try again.'}
-          </p>
-        )}
-
-        {setProductModifierGroups.isSuccess && (
-          <p style={{ color: '#16a34a', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
-            Assignments saved.
-          </p>
-        )}
-
-        <button
-          type="button"
-          onClick={handleSaveAssignments}
-          disabled={setProductModifierGroups.isPending}
-          style={{
-            padding: '0.5rem 1.25rem',
-            background: '#111827',
-            color: '#fff',
-            border: 'none',
-            borderRadius: '0.375rem',
-            cursor: setProductModifierGroups.isPending ? 'not-allowed' : 'pointer',
-            fontWeight: 600,
-            opacity: setProductModifierGroups.isPending ? 0.6 : 1,
-          }}
-        >
-          {setProductModifierGroups.isPending ? 'Saving...' : t('admin.modifierGroups.saveAssignments')}
-        </button>
-      </section>
+      {/* Modifier Groups */}
+      <ModifierGroupAssignments brandSlug={resolvedBrandSlug} productId={resolvedProductId} />
     </main>
     </ResourceFormShell>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Local style helpers (reorderButtonStyle is unique to this page)
-// ---------------------------------------------------------------------------
-
-const reorderButtonStyle: React.CSSProperties = {
-  padding: '0.125rem 0.4rem',
-  fontSize: '0.75rem',
-  background: '#fff',
-  border: '1px solid #d1d5db',
-  borderRadius: '0.25rem',
-  lineHeight: 1,
-};
 

--- a/src/frontend/src/features/admin/pages/ShopCreate.tsx
+++ b/src/frontend/src/features/admin/pages/ShopCreate.tsx
@@ -7,20 +7,13 @@ import { shopsApi } from '@api/shops';
 import type { CreateShopRequest } from '@api/shops';
 import { shopCreateSchema, type ShopCreateFormValues } from './schemas/shopCreateSchema';
 import { shopKeys } from '../hooks/useShops';
-import { labelStyle, inputStyle, RequiredMark, FieldError } from '../forms/adminFormStyles';
+import { labelStyle, inputStyle, RequiredMark, FieldError, FormError } from '../forms/adminFormStyles';
+import { FormActions } from '../forms/FormActions';
+import { nameToSlug } from '../forms/slug';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Converts a shop name into a URL-safe slug. */
-function nameToSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
 
 function toCreatePayload(values: ShopCreateFormValues): CreateShopRequest {
   return {
@@ -267,46 +260,15 @@ export function ShopCreate() {
         </div>
 
         {/* API error */}
-        {mutation.error != null && (
-          <p style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
-            {mutation.error instanceof Error
-              ? mutation.error.message
-              : 'Failed to create shop. Please try again.'}
-          </p>
-        )}
+        <FormError error={mutation.error} fallback="Failed to create shop. Please try again." />
 
-        <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button
-            type="submit"
-            disabled={isSubmitting || mutation.isPending}
-            style={{
-              padding: '0.5rem 1.25rem',
-              background: '#111827',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '0.375rem',
-              cursor: isSubmitting || mutation.isPending ? 'not-allowed' : 'pointer',
-              fontWeight: 600,
-              opacity: isSubmitting || mutation.isPending ? 0.6 : 1,
-            }}
-          >
-            {mutation.isPending ? 'Creating…' : 'Create Shop'}
-          </button>
-          <button
-            type="button"
-            onClick={handleCancel}
-            style={{
-              padding: '0.5rem 1.25rem',
-              background: '#fff',
-              color: '#374151',
-              border: '1px solid #d1d5db',
-              borderRadius: '0.375rem',
-              cursor: 'pointer',
-            }}
-          >
-            Cancel
-          </button>
-        </div>
+        <FormActions
+          isPending={mutation.isPending}
+          isSubmitting={isSubmitting}
+          onCancel={handleCancel}
+          submitLabel="Create Shop"
+          pendingLabel="Creating…"
+        />
       </form>
     </main>
   );

--- a/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
+++ b/src/frontend/src/features/pos/components/KitchenOrderCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import type { OrderResponse, OrderType } from '@api/orders';
 import type { OrderStatusResponse } from '@/types/common';
+import { formatTime, formatTimeSlot } from '../../../utils/timeSlot';
 
 interface KitchenOrderCardProps {
   order: OrderResponse;
@@ -23,11 +24,6 @@ const orderTypeColor: Record<OrderType, string> = {
   EatIn: '#9333ea',
   Delivery: '#059669',
 };
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return new Intl.DateTimeFormat('nl-BE', { hour: '2-digit', minute: '2-digit' }).format(d);
-}
 
 function formatRelative(iso: string, now: number): string {
   const elapsedMs = now - new Date(iso).getTime();
@@ -140,7 +136,7 @@ export function KitchenOrderCard({
             {t('pos.kitchen.table', { number: order.tableNumber })}
           </span>
         )}
-        {order.timeSlot != null && order.timeSlot.length > 0 && (
+        {order.timeSlotStart != null && order.timeSlotEnd != null && (
           <span
             data-testid="kitchen-order-timeslot"
             style={{
@@ -152,7 +148,7 @@ export function KitchenOrderCard({
               fontWeight: 700,
             }}
           >
-            {t('pos.kitchen.timeSlot', { value: order.timeSlot })}
+            {t('pos.kitchen.timeSlot', { value: formatTimeSlot(order.timeSlotStart, order.timeSlotEnd) })}
           </span>
         )}
         {order.customerName != null && order.customerName.length > 0 && (

--- a/src/frontend/src/features/pos/utils/__tests__/printTicket.test.ts
+++ b/src/frontend/src/features/pos/utils/__tests__/printTicket.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildTicketHtml, type TicketLabels } from '../printTicket';
+import { formatTimeSlot } from '../../../../utils/timeSlot';
 import type { OrderResponse } from '@api/orders';
 
 const labels: TicketLabels = {
@@ -66,9 +67,19 @@ describe('buildTicketHtml', () => {
     expect(buildTicketHtml(makeOrder(), labels)).not.toContain('Table:');
   });
 
-  it('renders the time slot only when present', () => {
-    expect(buildTicketHtml(makeOrder({ timeSlot: '18:30' }), labels)).toContain('Time slot: 18:30');
-    expect(buildTicketHtml(makeOrder({ timeSlot: null }), labels)).not.toContain('Time slot:');
+  it('renders the time slot only when both timeSlotStart and timeSlotEnd are present', () => {
+    // Exact local-time text depends on the host timezone, so assert against the same
+    // formatter the ticket uses — this still catches swapped args or a wrong source field.
+    const start = '2026-06-10T17:30:00Z';
+    const end = '2026-06-10T17:40:00Z';
+    const withSlot = buildTicketHtml(
+      makeOrder({ timeSlotStart: start, timeSlotEnd: end }),
+      labels,
+    );
+    expect(withSlot).toContain(`Time slot: ${formatTimeSlot(start, end)}`);
+
+    // When both are null, the row must be absent.
+    expect(buildTicketHtml(makeOrder(), labels)).not.toContain('Time slot:');
   });
 
   it('renders the customer name when present', () => {

--- a/src/frontend/src/features/pos/utils/printReceipt.ts
+++ b/src/frontend/src/features/pos/utils/printReceipt.ts
@@ -1,5 +1,6 @@
 import type { OrderResponse } from '@api/orders';
 import { printHtmlDocument } from './printDocument';
+import { formatTimeSlot } from '../../../utils/timeSlot';
 
 /**
  * Localised, pre-resolved labels for the printed customer receipt. Kept caller-supplied
@@ -87,9 +88,9 @@ export function buildReceiptHtml(order: OrderResponse, labels: ReceiptLabels): s
       `<div class="meta">${escapeHtml(labels.table)}: ${escapeHtml(String(order.tableNumber))}</div>`,
     );
   }
-  if (order.timeSlot != null && order.timeSlot.length > 0) {
+  if (order.timeSlotStart != null && order.timeSlotEnd != null) {
     metaRows.push(
-      `<div class="meta">${escapeHtml(labels.timeSlot)}: ${escapeHtml(order.timeSlot)}</div>`,
+      `<div class="meta">${escapeHtml(labels.timeSlot)}: ${escapeHtml(formatTimeSlot(order.timeSlotStart, order.timeSlotEnd))}</div>`,
     );
   }
   if (order.customerName != null && order.customerName.length > 0) {

--- a/src/frontend/src/features/pos/utils/printTicket.ts
+++ b/src/frontend/src/features/pos/utils/printTicket.ts
@@ -1,5 +1,6 @@
 import type { OrderResponse } from '@api/orders';
 import { printHtmlDocument } from './printDocument';
+import { formatTimeSlot } from '../../../utils/timeSlot';
 
 /**
  * Localised, pre-resolved labels for the printed ticket. Kept caller-supplied so
@@ -56,9 +57,9 @@ export function buildTicketHtml(order: OrderResponse, labels: TicketLabels): str
       `<div class="meta">${escapeHtml(labels.table)}: ${escapeHtml(String(order.tableNumber))}</div>`,
     );
   }
-  if (order.timeSlot != null && order.timeSlot.length > 0) {
+  if (order.timeSlotStart != null && order.timeSlotEnd != null) {
     metaRows.push(
-      `<div class="meta">${escapeHtml(labels.timeSlot)}: ${escapeHtml(order.timeSlot)}</div>`,
+      `<div class="meta">${escapeHtml(labels.timeSlot)}: ${escapeHtml(formatTimeSlot(order.timeSlotStart, order.timeSlotEnd))}</div>`,
     );
   }
   if (order.customerName != null && order.customerName.length > 0) {

--- a/src/frontend/src/features/storefront/__tests__/ShopChooserPage.test.tsx
+++ b/src/frontend/src/features/storefront/__tests__/ShopChooserPage.test.tsx
@@ -50,6 +50,7 @@ function makeShop(overrides: Partial<StorefrontShop> = {}): StorefrontShop {
     },
     isOpen: true,
     eatIn: { isEnabled: true, requiresTableNumber: true },
+    timeSlotOrdering: { isEnabled: false, intervalMinutes: null, maxOrdersPerInterval: null },
     ...overrides,
   };
 }

--- a/src/frontend/src/features/storefront/__tests__/ShopResolver.test.tsx
+++ b/src/frontend/src/features/storefront/__tests__/ShopResolver.test.tsx
@@ -66,6 +66,7 @@ function makeShop(overrides: Partial<StorefrontShop> = {}): StorefrontShop {
     },
     isOpen: true,
     eatIn: { isEnabled: true, requiresTableNumber: true },
+    timeSlotOrdering: { isEnabled: false, intervalMinutes: null, maxOrdersPerInterval: null },
     ...overrides,
   };
 }

--- a/src/frontend/src/features/storefront/components/TimeSlotPicker.tsx
+++ b/src/frontend/src/features/storefront/components/TimeSlotPicker.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TimeSlotResponse } from '@api/orders';
+import { formatTimeSlot } from '../../../utils/timeSlot';
+
+// ---------------------------------------------------------------------------
+// TimeSlotPicker — radio group for selecting an available time slot (US-FP-019)
+// ---------------------------------------------------------------------------
+
+interface TimeSlotPickerProps {
+  /** Available slots from the server. May be empty near closing time. */
+  slots: TimeSlotResponse[];
+  /**
+   * Currently selected slot start (ISO string), or empty string meaning "ASAP".
+   * Empty string is the initial/reset value.
+   */
+  value: string;
+  /** Called when the customer selects a slot. `''` means "ASAP". */
+  onChange: (startIso: string) => void;
+  /** True while the slot list is being fetched. */
+  isLoading: boolean;
+  /** True when the slot-list fetch failed. */
+  isError: boolean;
+}
+
+/**
+ * Renders a radio group for time-slot selection.
+ *
+ * - ASAP is always the first option (AC3).
+ * - Full slots are shown but disabled (AC2).
+ * - Slots whose `start` is no longer in the future are filtered out at render
+ *   time (stale-slot guard).  If the currently selected slot ages out, the
+ *   selection is reset to ASAP.
+ * - Empty state and error state both still offer ASAP so checkout stays usable.
+ */
+export function TimeSlotPicker({
+  slots,
+  value,
+  onChange,
+  isLoading,
+  isError,
+}: TimeSlotPickerProps) {
+  const { t } = useTranslation('common');
+  const now = Date.now();
+
+  // Filter out slots that are no longer in the future at render time.
+  const freshSlots = slots.filter((s) => new Date(s.start).getTime() > now);
+
+  // Reset to ASAP if the previously selected slot has aged out of the list,
+  // and tell the customer — silently downgrading their slot to ASAP would let
+  // them submit believing the slot is still booked.
+  const [showResetNotice, setShowResetNotice] = useState(false);
+  const selectionAgedOut = value !== '' && !freshSlots.some((s) => s.start === value);
+  useEffect(() => {
+    if (selectionAgedOut) {
+      setShowResetNotice(true);
+      onChange('');
+    }
+  }, [selectionAgedOut, onChange]);
+
+  function handleSelect(radioValue: string) {
+    setShowResetNotice(false);
+    onChange(radioValue);
+  }
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <div style={{ marginBottom: '1.5rem' }}>
+        <p style={{ fontSize: '0.9375rem', color: '#6b7280' }}>
+          {t('loading')}
+        </p>
+      </div>
+    );
+  }
+
+  // ── Shared radio option renderer ───────────────────────────────────────────
+
+  function renderOption(
+    key: string,
+    radioValue: string,
+    label: string,
+    disabled = false,
+    badge?: string,
+  ) {
+    const isSelected = value === radioValue;
+    return (
+      <label
+        key={key}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          padding: '0.875rem 1rem',
+          borderRadius: '0.5rem',
+          border: `2px solid ${isSelected ? 'var(--brand-color-primary, #111827)' : '#e5e7eb'}`,
+          background: isSelected ? '#f9fafb' : '#fff',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          fontSize: '0.9375rem',
+          fontWeight: isSelected ? 600 : 400,
+          color: '#111827',
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        <input
+          type="radio"
+          name="timeSlotPicker"
+          value={radioValue}
+          checked={isSelected}
+          disabled={disabled}
+          onChange={() => { handleSelect(radioValue); }}
+          style={{ width: '1.125rem', height: '1.125rem', cursor: disabled ? 'not-allowed' : 'pointer' }}
+          aria-disabled={disabled}
+        />
+        <span style={{ flex: 1 }}>{label}</span>
+        {badge && (
+          <span
+            style={{
+              display: 'inline-block',
+              padding: '0.125rem 0.5rem',
+              borderRadius: '999px',
+              background: '#f3f4f6',
+              color: '#6b7280',
+              fontSize: '0.75rem',
+              fontWeight: 700,
+            }}
+          >
+            {badge}
+          </span>
+        )}
+      </label>
+    );
+  }
+
+  const asapOption = renderOption('asap', '', t('storefront.checkout.timeSlot.asap'));
+
+  return (
+    <fieldset style={{ border: 'none', padding: 0, margin: '0 0 1.5rem' }}>
+      <legend
+        style={{
+          fontSize: '1rem',
+          fontWeight: 700,
+          color: '#111827',
+          marginBottom: '0.75rem',
+        }}
+      >
+        {t('storefront.checkout.timeSlot.label')}
+      </legend>
+
+      {/* Notice when the previously selected slot aged out and was reset to ASAP */}
+      {showResetNotice && (
+        <p
+          role="status"
+          style={{
+            color: '#991b1b',
+            background: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: '0.5rem',
+            padding: '0.625rem 0.875rem',
+            fontSize: '0.875rem',
+            margin: '0 0 0.5rem',
+          }}
+        >
+          {t('storefront.checkout.timeSlot.slotFull')}
+        </p>
+      )}
+
+      {/* ASAP is always pinned above the scrollable slot list */}
+      <div style={{ marginBottom: '0.5rem' }}>
+        {asapOption}
+      </div>
+
+      {/* Error state — ASAP still available above */}
+      {isError && (
+        <p style={{ color: '#6b7280', fontSize: '0.875rem', marginTop: '0.5rem' }}>
+          {t('storefront.checkout.timeSlot.loadError')}
+        </p>
+      )}
+
+      {/* Empty state (no future slots) — ASAP still available above */}
+      {!isError && freshSlots.length === 0 && (
+        <p style={{ color: '#6b7280', fontSize: '0.875rem', marginTop: '0.5rem' }}>
+          {t('storefront.checkout.timeSlot.noneAvailable')}
+        </p>
+      )}
+
+      {/* Slot list in a scrollable container so hundreds of slots don't break the page */}
+      {!isError && freshSlots.length > 0 && (
+        <div
+          style={{
+            maxHeight: '16rem',
+            overflowY: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.5rem',
+            paddingRight: '0.25rem',
+          }}
+        >
+          {freshSlots.map((slot) =>
+            renderOption(
+              slot.start,
+              slot.start,
+              formatTimeSlot(slot.start, slot.end),
+              !slot.isAvailable,
+              !slot.isAvailable ? t('storefront.checkout.timeSlot.full') : undefined,
+            ),
+          )}
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/src/frontend/src/features/storefront/components/__tests__/TimeSlotPicker.test.tsx
+++ b/src/frontend/src/features/storefront/components/__tests__/TimeSlotPicker.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Tests for TimeSlotPicker (US-FP-019):
+ * - ASAP option always rendered first
+ * - Slot labels display formatted times
+ * - Full slots are disabled
+ * - onChange fires with selected slot ISO start
+ * - Empty slots and error states still offer ASAP
+ * - Slots with a start in the past are not rendered (fake timers)
+ * - A selected slot that ages out resets to ASAP via onChange
+ */
+import { beforeAll, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import i18next from 'i18next';
+import '../../../../i18n/config';
+import type { TimeSlotResponse } from '@api/orders';
+import { TimeSlotPicker } from '../TimeSlotPicker';
+
+beforeAll(async () => {
+  await i18next.changeLanguage('nl');
+});
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** A slot starting at the given UTC timestamp, 10 minutes long. */
+function makeSlot(startIso: string, overrides: Partial<TimeSlotResponse> = {}): TimeSlotResponse {
+  const start = new Date(startIso);
+  const end = new Date(start.getTime() + 10 * 60_000);
+  return {
+    start: startIso,
+    end: end.toISOString(),
+    isAvailable: true,
+    remainingCapacity: 2,
+    ...overrides,
+  };
+}
+
+// Future slots (10 min from now + some offset)
+const futureFarIso = new Date(Date.now() + 60 * 60_000).toISOString(); // +1h
+const futureNearIso = new Date(Date.now() + 20 * 60_000).toISOString(); // +20min
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+interface PickerProps {
+  slots?: TimeSlotResponse[];
+  value?: string;
+  onChange?: (v: string) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+}
+
+function renderPicker(props: PickerProps = {}) {
+  const {
+    slots = [],
+    value = '',
+    onChange = vi.fn(),
+    isLoading = false,
+    isError = false,
+  } = props;
+
+  return render(
+    <TimeSlotPicker
+      slots={slots}
+      value={value}
+      onChange={onChange}
+      isLoading={isLoading}
+      isError={isError}
+    />,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('TimeSlotPicker', () => {
+  it('always renders the ASAP option', () => {
+    renderPicker();
+    expect(screen.getByRole('radio', { name: /zo snel mogelijk/i })).toBeInTheDocument();
+  });
+
+  it('ASAP option is checked by default (value === empty string)', () => {
+    renderPicker({ value: '' });
+    expect(screen.getByRole('radio', { name: /zo snel mogelijk/i })).toBeChecked();
+  });
+
+  it('renders a radio for each future slot', () => {
+    const slots = [makeSlot(futureFarIso), makeSlot(futureNearIso)];
+    renderPicker({ slots });
+    // 1 ASAP + 2 slots = 3 radios
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('fires onChange with the slot start ISO when a slot is selected', () => {
+    const onChange = vi.fn();
+    const slots = [makeSlot(futureFarIso)];
+    renderPicker({ slots, onChange });
+
+    const radios = screen.getAllByRole('radio');
+    // radios[0] = ASAP, radios[1] = first slot
+    const slotRadio = radios[1];
+    if (!slotRadio) throw new Error('Expected slot radio to exist');
+    fireEvent.click(slotRadio);
+    expect(onChange).toHaveBeenCalledWith(futureFarIso);
+  });
+
+  it('fires onChange with empty string when ASAP is selected', () => {
+    const onChange = vi.fn();
+    const slots = [makeSlot(futureFarIso)];
+    renderPicker({ slots, value: futureFarIso, onChange });
+
+    fireEvent.click(screen.getByRole('radio', { name: /zo snel mogelijk/i }));
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('marks full slots as disabled and shows the "Vol" badge', () => {
+    const slots = [makeSlot(futureFarIso, { isAvailable: false, remainingCapacity: 0 })];
+    renderPicker({ slots });
+
+    // The slot radio has value equal to its start ISO string (non-empty).
+    const allRadios = screen.getAllByRole('radio') as HTMLInputElement[];
+    const slotRadios = allRadios.filter((r) => r.value !== '');
+    expect(slotRadios[0]).toBeDisabled();
+    expect(screen.getByText(/vol/i)).toBeInTheDocument();
+  });
+
+  it('shows noneAvailable notice and still offers ASAP when slots array is empty', () => {
+    renderPicker({ slots: [] });
+    expect(screen.getByRole('radio', { name: /zo snel mogelijk/i })).toBeInTheDocument();
+    expect(screen.getByText(/geen tijdsloten meer beschikbaar/i)).toBeInTheDocument();
+  });
+
+  it('shows loadError notice and still offers ASAP when isError is true', () => {
+    renderPicker({ isError: true });
+    expect(screen.getByRole('radio', { name: /zo snel mogelijk/i })).toBeInTheDocument();
+    expect(screen.getByText(/tijdsloten konden niet geladen worden/i)).toBeInTheDocument();
+  });
+
+  it('shows loading text when isLoading is true', () => {
+    renderPicker({ isLoading: true });
+    expect(screen.getByText(/laden/i)).toBeInTheDocument();
+  });
+
+  it('filters out slots whose start is in the past', () => {
+    const pastIso = new Date(Date.now() - 5 * 60_000).toISOString();
+    const slots = [makeSlot(pastIso), makeSlot(futureFarIso)];
+    renderPicker({ slots });
+    // Past slot radio should not be present — only ASAP + 1 future slot = 2 radios
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('resets selection to ASAP when the selected slot ages out', () => {
+    const onChange = vi.fn();
+    // A slot that is in the future right now
+    const slots = [makeSlot(futureFarIso)];
+
+    // Render with the slot selected
+    const { rerender } = render(
+      <TimeSlotPicker
+        slots={slots}
+        value={futureFarIso}
+        onChange={onChange}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    // Now pretend time advanced past the slot (slots prop becomes empty / slot is gone)
+    rerender(
+      <TimeSlotPicker
+        slots={[]}
+        value={futureFarIso}
+        onChange={onChange}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    // useEffect fires: since futureFarIso is not in freshSlots, onChange('') is called
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+});

--- a/src/frontend/src/features/storefront/context/ShopContext.tsx
+++ b/src/frontend/src/features/storefront/context/ShopContext.tsx
@@ -56,6 +56,7 @@ export function ShopResolver() {
     slug: shop.slug,
     isOpen: shop.isOpen,
     eatIn: shop.eatIn,
+    timeSlotOrdering: shop.timeSlotOrdering,
   };
 
   return (

--- a/src/frontend/src/features/storefront/context/shopContextValue.ts
+++ b/src/frontend/src/features/storefront/context/shopContextValue.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { EatInSettings } from '../../../types/common';
+import type { EatInSettings, TimeSlotOrderingSettings } from '../../../types/common';
 
 // ---------------------------------------------------------------------------
 // ResolvedShop type and context
@@ -16,6 +16,8 @@ export interface ResolvedShop {
   isOpen: boolean;
   /** Eat-in ordering configuration — gates the eat-in option at checkout (US-FP-066). */
   eatIn: EatInSettings;
+  /** Time-slot ordering configuration — drives the slot picker at checkout (US-FP-019). */
+  timeSlotOrdering: TimeSlotOrderingSettings;
 }
 
 /**

--- a/src/frontend/src/features/storefront/hooks/useAvailableTimeSlots.ts
+++ b/src/frontend/src/features/storefront/hooks/useAvailableTimeSlots.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { ordersApi } from '../../../api/orders';
+import type { AvailableTimeSlotsResponse } from '../../../api/orders';
+
+/** Query-key factory — also used by CheckoutPage to invalidate after a 409. */
+export const timeSlotKeys = {
+  list: (brandSlug: string, shopId: string) => ['timeSlots', brandSlug, shopId] as const,
+};
+
+/**
+ * Fetches available time slots for a shop for the remainder of today (US-FP-019).
+ * Refreshes every 30 seconds so the picker stays in sync with orders being placed
+ * concurrently by other customers.
+ *
+ * @param brandSlug - The brand slug from the URL.
+ * @param shopId    - The shop id resolved by ShopResolver.
+ * @param enabled   - Pass `false` to skip the query when time-slot ordering is disabled.
+ */
+export function useAvailableTimeSlots(
+  brandSlug: string,
+  shopId: string,
+  enabled = true,
+) {
+  return useQuery<AvailableTimeSlotsResponse>({
+    queryKey: timeSlotKeys.list(brandSlug, shopId),
+    queryFn: () => ordersApi.getTimeSlots(brandSlug, shopId),
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    enabled,
+  });
+}

--- a/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
+++ b/src/frontend/src/features/storefront/pages/CheckoutPage.tsx
@@ -4,13 +4,17 @@ import { useTranslation } from 'react-i18next';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 import { useAuth } from '@/auth/useAuth';
 import { CartProvider, useCart } from '../context/CartContext';
 import { useResolvedShop } from '../hooks/useResolvedShop';
 import { useCreateOrder } from '../hooks/useCreateOrder';
+import { timeSlotKeys, useAvailableTimeSlots } from '../hooks/useAvailableTimeSlots';
 import { MockPaymentScreen } from '../components/MockPaymentScreen';
+import { TimeSlotPicker } from '../components/TimeSlotPicker';
 import type { OrderType } from '@api/orders';
-import type { SupportedLocale, EatInSettings } from '@/types/common';
+import type { SupportedLocale, EatInSettings, TimeSlotOrderingSettings } from '@/types/common';
 
 // ---------------------------------------------------------------------------
 // Language normalisation helper
@@ -76,6 +80,8 @@ function makeCheckoutSchema(
       ...contactFields,
       tableNumber: z.string(),
       paymentMethod: z.enum(['CashAtPickup', 'CreditCard', 'Bancontact']),
+      // Empty string = ASAP (always valid); non-empty = selected slot ISO string (US-FP-019)
+      timeSlotStart: z.string(),
     })
     // Eat-in is only an allowed order type when the shop accepts it (US-FP-066).
     .refine((v) => eatIn.isEnabled || v.orderType !== 'EatIn', {
@@ -106,6 +112,8 @@ interface CheckoutFormValues {
   customerPhone: string;
   tableNumber: string;
   paymentMethod: 'CashAtPickup' | 'CreditCard' | 'Bancontact';
+  /** ISO string of the selected time slot start, or empty string for ASAP (US-FP-019). */
+  timeSlotStart: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,18 +126,28 @@ interface CheckoutFormProps {
   shopSlug: string;
   shopIsOpen: boolean;
   eatIn: EatInSettings;
+  timeSlotOrdering: TimeSlotOrderingSettings;
 }
 
-function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: CheckoutFormProps) {
+function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn, timeSlotOrdering }: CheckoutFormProps) {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
   const { brandSlug: paramSlug, lang } = useParams<{ brandSlug: string; lang: string }>();
   const { user, isAuthenticated } = useAuth();
   const { state, clearCart } = useCart();
   const createOrder = useCreateOrder(brandSlug, shopId);
+  const queryClient = useQueryClient();
+
+  // Separate 409 (slot unavailable/full) error message from the generic submit error.
+  const [slotFullError, setSlotFullError] = useState(false);
 
   const [showMockPayment, setShowMockPayment] = useState(false);
   const [pendingOrderId, setPendingOrderId] = useState<string | null>(null);
+
+  // Time slot availability — only fetched when time-slot ordering is enabled, and
+  // polling stops while the mock payment screen replaces the form (US-FP-019).
+  const { data: timeSlotsData, isLoading: isSlotsLoading, isError: isSlotsError } =
+    useAvailableTimeSlots(brandSlug, shopId, timeSlotOrdering.isEnabled && !showMockPayment);
 
   // Redirect to menu if cart is empty
   useEffect(() => {
@@ -152,6 +170,7 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
     customerPhone: user?.phoneNumber ?? '',
     tableNumber: '',
     paymentMethod: 'CashAtPickup',
+    timeSlotStart: '',
   };
 
   const {
@@ -159,6 +178,7 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
     handleSubmit,
     watch,
     control,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm<CheckoutFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -189,35 +209,52 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
     // Guard: a closed shop does not accept online orders (mirrors the backend check).
     if (!shopIsOpen) return;
 
+    // Clear any previous slot-full error.
+    setSlotFullError(false);
+
     const orderItems = state.items.map((item) => ({
       productId: item.productId,
       quantity: item.quantity,
       selectedModifierIds: item.selectedModifiers.map((m) => m.modifierId),
     }));
 
-    const result = await createOrder.mutateAsync({
-      orderType: values.orderType as OrderType,
-      customerFirstName: values.customerFirstName || null,
-      customerLastName: values.customerLastName || null,
-      customerEmail: values.customerEmail || null,
-      customerPhone: values.customerPhone || null,
-      items: orderItems,
-      paymentMethod: values.paymentMethod,
-      languageCode: normalizeLang(lang),
-      tableNumber:
-        values.orderType === 'EatIn' && values.tableNumber.trim().length > 0
-          ? Number(values.tableNumber)
-          : null,
-    });
+    try {
+      const result = await createOrder.mutateAsync({
+        orderType: values.orderType as OrderType,
+        customerFirstName: values.customerFirstName || null,
+        customerLastName: values.customerLastName || null,
+        customerEmail: values.customerEmail || null,
+        customerPhone: values.customerPhone || null,
+        items: orderItems,
+        paymentMethod: values.paymentMethod,
+        languageCode: normalizeLang(lang),
+        tableNumber:
+          values.orderType === 'EatIn' && values.tableNumber.trim().length > 0
+            ? Number(values.tableNumber)
+            : null,
+        // Empty string → null (ASAP); non-empty → selected slot ISO string (US-FP-019).
+        timeSlotStart: values.timeSlotStart || null,
+      });
 
-    clearCart();
+      clearCart();
 
-    if (values.paymentMethod === 'CashAtPickup') {
-      navigate(`/${String(paramSlug)}/${String(lang)}/${shopSlug}/order/${result.id}`);
-    } else {
-      // Online payment methods: show mock processing screen first
-      setPendingOrderId(result.id);
-      setShowMockPayment(true);
+      if (values.paymentMethod === 'CashAtPickup') {
+        navigate(`/${String(paramSlug)}/${String(lang)}/${shopSlug}/order/${result.id}`);
+      } else {
+        // Online payment methods: show mock processing screen first
+        setPendingOrderId(result.id);
+        setShowMockPayment(true);
+      }
+    } catch (err) {
+      // 409 = selected slot just filled up — show targeted message, reset to ASAP,
+      // and invalidate the slot query so the picker refreshes (US-FP-019, AC4).
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
+        setSlotFullError(true);
+        setValue('timeSlotStart', '');
+        void queryClient.invalidateQueries({ queryKey: timeSlotKeys.list(brandSlug, shopId) });
+      }
+      // Re-throw so react-hook-form marks the submission as failed (sets isSubmitting=false).
+      throw err;
     }
   }
 
@@ -322,6 +359,38 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
             )}
           />
         </fieldset>
+
+        {/* Time slot section (US-FP-019) */}
+        {timeSlotOrdering.isEnabled ? (
+          <Controller
+            name="timeSlotStart"
+            control={control}
+            render={({ field }) => (
+              <TimeSlotPicker
+                slots={timeSlotsData?.slots ?? []}
+                value={field.value}
+                onChange={field.onChange}
+                isLoading={isSlotsLoading}
+                isError={isSlotsError}
+              />
+            )}
+          />
+        ) : (
+          /* AC5: static ASAP notice when time-slot ordering is disabled (US-FP-021 not done) */
+          <div
+            style={{
+              padding: '0.75rem 1rem',
+              borderRadius: '0.375rem',
+              background: '#eff6ff',
+              border: '1px solid #bfdbfe',
+              color: '#1e40af',
+              fontSize: '0.875rem',
+              marginBottom: '1.5rem',
+            }}
+          >
+            {t('storefront.checkout.timeSlot.asapNotice')}
+          </div>
+        )}
 
         {/* VAT notice */}
         {vatNotice && (
@@ -681,8 +750,26 @@ function CheckoutForm({ brandSlug, shopId, shopSlug, shopIsOpen, eatIn }: Checko
           />
         </fieldset>
 
-        {/* Error */}
-        {createOrder.isError && (
+        {/* 409 slot-full error — shown instead of the generic error */}
+        {slotFullError && (
+          <div
+            role="alert"
+            style={{
+              padding: '0.75rem 1rem',
+              borderRadius: '0.375rem',
+              background: '#fef2f2',
+              border: '1px solid #fecaca',
+              color: '#991b1b',
+              fontSize: '0.875rem',
+              marginBottom: '1rem',
+            }}
+          >
+            {t('storefront.checkout.timeSlot.slotFull')}
+          </div>
+        )}
+
+        {/* Generic submit error (not 409) */}
+        {createOrder.isError && !slotFullError && (
           <div
             style={{
               padding: '0.75rem 1rem',
@@ -754,6 +841,7 @@ export function CheckoutPage() {
         shopSlug={shop.slug}
         shopIsOpen={shop.isOpen}
         eatIn={shop.eatIn}
+        timeSlotOrdering={shop.timeSlotOrdering}
       />
     </CartProvider>
   );

--- a/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
+++ b/src/frontend/src/features/storefront/pages/OrderConfirmationPage.tsx
@@ -6,6 +6,7 @@ import { ordersApi } from '@api/orders';
 import type { OrderResponse } from '@api/orders';
 import { useOrderUpdates } from '@api/useOrderUpdates';
 import { useResolvedShop } from '../hooks/useResolvedShop';
+import { formatTimeSlot } from '../../../utils/timeSlot';
 
 // ---------------------------------------------------------------------------
 // Query
@@ -151,6 +152,12 @@ export function OrderConfirmationPage() {
               : t('storefront.checkout.payment.statusPayAtPickup')
           }
         />
+        {order.timeSlotStart != null && order.timeSlotEnd != null && (
+          <InfoCard
+            label={t('storefront.order.timeSlot')}
+            value={formatTimeSlot(order.timeSlotStart, order.timeSlotEnd)}
+          />
+        )}
       </div>
 
       {/* Items */}

--- a/src/frontend/src/features/storefront/pages/__tests__/CheckoutPage.test.tsx
+++ b/src/frontend/src/features/storefront/pages/__tests__/CheckoutPage.test.tsx
@@ -52,6 +52,7 @@ const defaultShop: ResolvedShop = {
   slug: 'gent-centrum',
   isOpen: true,
   eatIn: { isEnabled: true, requiresTableNumber: true },
+  timeSlotOrdering: { isEnabled: false, intervalMinutes: null, maxOrdersPerInterval: null },
 };
 
 /** Unauthenticated context (guest). */

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -93,7 +93,16 @@
       "placing": "Wird aufgegeben…",
       "submitError": "Bestellung fehlgeschlagen. Bitte erneut versuchen.",
       "cartEmpty": "Ihr Warenkorb ist leer.",
-      "shopClosed": "Dieser Shop ist derzeit geschlossen und nimmt keine Online-Bestellungen an."
+      "shopClosed": "Dieser Shop ist derzeit geschlossen und nimmt keine Online-Bestellungen an.",
+      "timeSlot": {
+        "label": "Zeitfenster",
+        "asap": "So schnell wie möglich",
+        "full": "Voll",
+        "noneAvailable": "Heute sind keine Zeitfenster mehr verfügbar. Ihre Bestellung wird so schnell wie möglich zubereitet.",
+        "asapNotice": "Ihre Bestellung wird so schnell wie möglich zubereitet.",
+        "slotFull": "Dieses Zeitfenster ist nicht mehr verfügbar. Bitte wählen Sie ein anderes.",
+        "loadError": "Zeitfenster konnten nicht geladen werden. Sie können \"so schnell wie möglich\" bestellen."
+      }
     },
     "order": {
       "confirmed": "Bestellung bestätigt!",
@@ -101,6 +110,7 @@
       "orderNumber": "Bestellnummer",
       "orderType": "Bestellart",
       "customerName": "Name",
+      "timeSlot": "Zeitfenster",
       "status": "Status",
       "items": "Artikel",
       "each": "je",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -93,7 +93,16 @@
       "placing": "En cours…",
       "submitError": "Échec de la commande. Veuillez réessayer.",
       "cartEmpty": "Votre panier est vide.",
-      "shopClosed": "Ce magasin est actuellement fermé et n'accepte pas de commandes en ligne."
+      "shopClosed": "Ce magasin est actuellement fermé et n'accepte pas de commandes en ligne.",
+      "timeSlot": {
+        "label": "Créneau horaire",
+        "asap": "Dès que possible",
+        "full": "Complet",
+        "noneAvailable": "Plus de créneaux disponibles aujourd'hui. Votre commande sera préparée dès que possible.",
+        "asapNotice": "Votre commande sera préparée dès que possible.",
+        "slotFull": "Ce créneau n'est plus disponible. Veuillez en choisir un autre.",
+        "loadError": "Impossible de charger les créneaux. Vous pouvez commander \"dès que possible\"."
+      }
     },
     "order": {
       "confirmed": "Commande confirmée !",
@@ -101,6 +110,7 @@
       "orderNumber": "Numéro de commande",
       "orderType": "Type de commande",
       "customerName": "Nom",
+      "timeSlot": "Créneau horaire",
       "status": "Statut",
       "items": "Articles",
       "each": "chacun",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -93,7 +93,16 @@
       "placing": "Bezig met plaatsen…",
       "submitError": "Bestelling plaatsen mislukt. Probeer opnieuw.",
       "cartEmpty": "Uw winkelwagen is leeg.",
-      "shopClosed": "Deze winkel is momenteel gesloten en accepteert geen online bestellingen."
+      "shopClosed": "Deze winkel is momenteel gesloten en accepteert geen online bestellingen.",
+      "timeSlot": {
+        "label": "Tijdslot",
+        "asap": "Zo snel mogelijk",
+        "full": "Vol",
+        "noneAvailable": "Geen tijdsloten meer beschikbaar vandaag. Uw bestelling wordt zo snel mogelijk bereid.",
+        "asapNotice": "Uw bestelling wordt zo snel mogelijk bereid.",
+        "slotFull": "Dit tijdslot is niet meer beschikbaar. Kies een ander tijdslot.",
+        "loadError": "Tijdsloten konden niet geladen worden. U kunt wel \"zo snel mogelijk\" bestellen."
+      }
     },
     "order": {
       "confirmed": "Bestelling bevestigd!",
@@ -101,6 +110,7 @@
       "orderNumber": "Bestelnummer",
       "orderType": "Besteltype",
       "customerName": "Naam",
+      "timeSlot": "Tijdslot",
       "status": "Status",
       "items": "Artikelen",
       "each": "elk",

--- a/src/frontend/src/test/msw/handlers.ts
+++ b/src/frontend/src/test/msw/handlers.ts
@@ -247,8 +247,20 @@ export const handlers = [
         },
         isOpen: true,
         eatIn: { isEnabled: true, requiresTableNumber: true },
+        timeSlotOrdering: { isEnabled: false, intervalMinutes: null, maxOrdersPerInterval: null },
       },
     ]),
+  ),
+
+  // Time slots for the storefront checkout (US-FP-019).
+  // Must precede /orders handlers to avoid route ambiguity.
+  http.get('/api/brands/:brandSlug/shops/:shopId/time-slots', () =>
+    HttpResponse.json({
+      isEnabled: false,
+      intervalMinutes: null,
+      maxOrdersPerInterval: null,
+      slots: [],
+    }),
   ),
 
   http.get('/api/brands/:slug/shops/:shopId', ({ params }) =>

--- a/src/frontend/src/utils/__tests__/timeSlot.test.ts
+++ b/src/frontend/src/utils/__tests__/timeSlot.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { formatTimeSlot } from '../timeSlot';
+
+describe('formatTimeSlot', () => {
+  it('formats a start/end UTC ISO pair as a time range in nl-BE format', () => {
+    // 2026-07-10 is in CEST (+02:00), so 15:30 UTC = 17:30 local, 15:40 UTC = 17:40 local
+    const result = formatTimeSlot('2026-07-10T15:30:00Z', '2026-07-10T15:40:00Z');
+    // The exact output depends on the system timezone, but it must contain the separator.
+    expect(result).toContain('–');
+    // Should contain two colon-separated time parts (HH:mm format).
+    const parts = result.split('–');
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toMatch(/^\d{2}:\d{2}$/);
+    expect(parts[1]).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it('produces different start and end times when the slot spans multiple minutes', () => {
+    const result = formatTimeSlot('2026-07-10T10:00:00Z', '2026-07-10T10:15:00Z');
+    const parts = result.split('–');
+    expect(parts[0]).not.toBe(parts[1]);
+  });
+
+  it('produces the same time for both ends when the slot has zero duration', () => {
+    const result = formatTimeSlot('2026-07-10T12:00:00Z', '2026-07-10T12:00:00Z');
+    const parts = result.split('–');
+    expect(parts[0]).toBe(parts[1]);
+  });
+});

--- a/src/frontend/src/utils/timeSlot.ts
+++ b/src/frontend/src/utils/timeSlot.ts
@@ -1,0 +1,25 @@
+/**
+ * Time formatting utilities (US-FP-019).
+ */
+
+// Hoisted: Intl.DateTimeFormat construction is expensive and the picker formats
+// hundreds of slots per render. nl-BE gives the 24-hour HH:mm clock used across
+// the Belgian NL/FR/DE markets.
+const timeFormat = new Intl.DateTimeFormat('nl-BE', { hour: '2-digit', minute: '2-digit' });
+
+/**
+ * Formats a UTC ISO timestamp as a wall-clock time (HH:mm) in the client's
+ * local timezone — devices and customers share the shop's Belgian timezone.
+ */
+export function formatTime(iso: string): string {
+  return timeFormat.format(new Date(iso));
+}
+
+/**
+ * Formats a UTC ISO time-slot start/end pair as a human-readable time range.
+ *
+ * @example formatTimeSlot('2026-06-10T11:30:00Z', '2026-06-10T11:40:00Z') → "13:30–13:40"
+ */
+export function formatTimeSlot(startIso: string, endIso: string): string {
+  return `${formatTime(startIso)}–${formatTime(endIso)}`;
+}


### PR DESCRIPTION
## Summary

Implements **US-FP-019 — Select time slot at checkout**, the customer-facing counterpart to US-FP-020's per-shop time-slot configuration.

### Backend
- `Order.TimeSlotStart` / `TimeSlotEnd` (`DateTimeOffset?`, null = ASAP) + brand migration `AddOrderTimeSlot` with a filtered index for capacity counting
- New pure domain service `TimeSlotGenerator`: slots anchored at each opening-hours block's open time, stepping by the configured interval (5/10/15 min), today-only horizon, first slot ≥ now + one interval, shop-timezone-aware (DST-gap safe)
- New endpoint `GET /api/brands/{brandSlug}/shops/{shopId}/time-slots` returning slots with `isAvailable` + `remainingCapacity`
- Server-side enforcement in the shared `OrderService` create-core (same pattern as eat-in gating): a full or no-longer-offered slot throws a typed `TimeSlotUnavailableException` → **409**, so the storefront can recover; POS path never passes a slot
- `StorefrontShopResponse` now carries `timeSlotOrdering` so checkout knows whether to show the picker

### Frontend
- `TimeSlotPicker` radio group: ASAP always first (AC3), full slots greyed out (AC2), scrollable list, 30s refetch, stale-slot render-time guard with a visible notice when a selection ages out and resets to ASAP
- Checkout 409 recovery: targeted message, reset to ASAP, slot-list invalidation
- Kitchen card, printed ticket, and order confirmation show the slot via the real `timeSlotStart`/`timeSlotEnd` (replacing the speculative never-populated `timeSlot` field) (AC4)
- When slots are disabled: static "prepared as soon as possible" notice (AC5 MVP fallback — configured wait times are US-FP-021)
- i18n NL/FR/DE

### Scope decisions (documented in `.agents/plans/us-fp-019-time-slot-checkout.md`)
- Today-only slot horizon (no pre-ordering)
- Capacity counts all order statuses — no cancellation concept exists yet
- Known MVP check-then-insert race: concurrent submits can overbook a slot by one (documented; fix would need a transactional counter)
- POS stays ASAP-only
- Follow-ups noted from review: checkout radio-card markup is tripled (order type / payment / slot) and the capacity check is computed in both the availability service and order create — candidates for a later cleanup pass

### Also included
Two pre-existing frontend cleanup commits from the branch point (`chore/frontend-create-page-dedup`): shared FormActions/FormError/nameToSlug + extracted ModifierGroupAssignments/AllergenDietaryFields.

## Test plan
- Backend: 347 unit tests (incl. `TimeSlotGenerator` grid/lead-time/DST/midnight-regression cases), new integration classes `GetAvailableTimeSlotsTests` (4) + `PlaceOrderTimeSlotTests` (7) covering 201/400/409 paths and the kitchen active-orders view
- Frontend: 357 vitest tests (picker states, checkout integration, ticket/kitchen rendering), `pnpm build` + type-check clean

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)